### PR TITLE
Fix `make rpm` for unreleased code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # extract name from package.json
 PACKAGE_NAME := $(shell awk '/"name":/ {gsub(/[",]/, "", $$2); print $$2}' package.json)
 RPM_NAME := cockpit-$(PACKAGE_NAME)
-VERSION := $(shell git describe 2>/dev/null || echo 1)
+VERSION := $(shell T=$$(git describe 2>/dev/null) || T=1; echo $$T | tr '-' '.')
 ifeq ($(TEST_OS),)
 TEST_OS = fedora-28
 endif


### PR DESCRIPTION
When the topmost commit isn't tagged, rpmbuild otherwise fails with

    error: line 2: Illegal char '-' (0x2d) in: Version: 176-1-g9101a30a

Replace the dashes from `git describe` with periods, to get a valid RPM
upstream version number.