### PR TITLE
test: Properly clean up test VM on image preparation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,8 @@ rpm: dist-gzip $(RPM_NAME).spec
 
 # build a VM with locally built rpm installed
 $(VM_IMAGE): rpm bots
-	bots/image-customize -v -r 'rpm -e $(RPM_NAME) || true' -i cockpit-ws -i `pwd`/$(RPM_NAME)-*.noarch.rpm -s $(CURDIR)/test/vm.install $(TEST_OS)
+	rm -f $(VM_IMAGE) $(VM_IMAGE).qcow2
+	bots/image-customize -v -i cockpit-ws -i `pwd`/$(RPM_NAME)-*.noarch.rpm -s $(CURDIR)/test/vm.install $(TEST_OS)
 
 # convenience target for the above
 vm: $(VM_IMAGE)


### PR DESCRIPTION
Remove the entire previous overlay instead of just removing the built
package. This ensures that there are no leftovers from previous
interactive debugging sessions.

This has already shown to lead to confusion in practice in
cockpit-podman.

Cherry-picked from starter-kit commit 6e05f5b4837a4

 - [x] Fix crash on varlink errors (PR #13)