### PR TITLE
Fix crashes on error reporting

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -54,7 +54,7 @@ function varlinkCallChannel(channel, method, parameters) {
 function varlinkCallError(error) {
     let str = "";
     error.error ? str += error.error.toString() : str;
-    error.parameters.reason ? str += " " + error.parameters.reason.toString() : str;
+    (error.parameters && error.parameters.reason) ? str += " " + error.parameters.reason.toString() : str;
     return str;
 }
 


### PR DESCRIPTION
If the error returned by varlink did not have a `.parameters` field, the
page oopsed with

    RuntimeError: TypeError: Cannot read property 'reason' of undefined

This also gets picked up by the test cases often and makes them fail.