### PR TITLE
Adjust image configuration JSON structure

### DIFF
--- a/src/ImageDetails.jsx
+++ b/src/ImageDetails.jsx
@@ -15,10 +15,10 @@ const ImageDetails = (props) => {
     let command = '';
     let ports = [];
 
-    if (image.ContainerConfig) {
-        entrypoint = image.ContainerConfig.Entrypoint;
-        command = image.ContainerConfig.Cmd;
-        ports = Object.keys(image.ContainerConfig.ExposedPorts || {});
+    if (image.Config) {
+        entrypoint = image.Config.Entrypoint;
+        command = image.Config.Cmd;
+        ports = Object.keys(image.Config.ExposedPorts || {});
     }
 
     return (


### PR DESCRIPTION
Images now have their entrypoint, command, and port configuration in the
`Config` instead of the `ContainerConfig` sub-dictionary.

---

This gets spotted by the [current test failure](https://fedorapeople.org/groups/cockpit/logs/pull-11019-20190121-104747-2a99e462-cockpit-project-cockpit-podman-cockpit-fedora-29/log).