### PR TITLE
Drop non-existing fade property from Modal

### DIFF
--- a/src/ContainerRemoveErrorModal.jsx
+++ b/src/ContainerRemoveErrorModal.jsx
@@ -8,7 +8,7 @@ const ContainerRemoveErrorModal = (props) => {
     const name = props.containerWillDelete ? _(props.containerWillDelete.Name) : _("");
     return (
         <div>
-            <Modal show={props.setContainerRemoveErrorModal} fade={false} >
+            <Modal show={props.setContainerRemoveErrorModal} >
                 <Modal.Header>
                     <Modal.Title>{cockpit.format(_("Please confirm forced deletion of $0"), name)}</Modal.Title>
                 </Modal.Header>


### PR DESCRIPTION
Fixes this React warning:

```
error: Warning: Received `false` for non-boolean attribute `fade`. If this is expected, cast the value to a string.
    in div (created by CustomModalDialog)
    in CustomModalDialog (created by Modal)
    in Transition (created by Fade)
    in Fade (created by DialogTransition)
    in DialogTransition (created by Modal)
    in RefHolder (created by Modal)
    in div (created by Modal)
    in Portal (created by Modal)
    in Modal (created by Modal)
    in Modal (created by ContainerRemoveErrorModal)
```