### PR TITLE
Pass podman's time format into moment() calls

### DIFF
--- a/src/ContainerDetails.jsx
+++ b/src/ContainerDetails.jsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import cockpit from 'cockpit';
+import * as util from './util.js';
 
 const moment = require('moment');
 const _ = cockpit.gettext;
 
 const render_container_state = (container) => {
     if (container.status === "running") {
-        const momentDate = moment(container.createdat);
-        return cockpit.format(_("Up since $0"), momentDate.isValid()
-            ? momentDate.calendar() : container.createdat);
+        return cockpit.format(_("Up since $0"), moment(container.createdat, util.GOLANG_TIME_FORMAT).calendar());
     }
     return cockpit.format(_("Exited"));
 };
@@ -19,7 +18,7 @@ const ContainerDetails = ({container}) => (
             <dt>{_("ID")}</dt>
             <dd>{container.id}</dd>
             <dt>{_("Created")}</dt>
-            <dd>{moment(container.createdat).isValid() ? moment(container.createdat).calendar() : container.createdat}</dd>
+            <dd>{moment(container.createdat, util.GOLANG_TIME_FORMAT).calendar()}</dd>
             <dt>{_("Image")}</dt>
             <dd>{container.image}</dd>
             <dt>{_("Command")}</dt>

--- a/src/ImageDetails.jsx
+++ b/src/ImageDetails.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import cockpit from 'cockpit';
+import * as util from './util.js';
 
 const moment = require('moment');
 const _ = cockpit.gettext;
@@ -24,7 +25,7 @@ const ImageDetails = (props) => {
                 <dt>{_("Command")}</dt>
                 <dd>{image.command ? image.command.join(" ") : "" }</dd>
                 <dt>{_("Created")}</dt>
-                <dd title={created.toLocaleString()}>{moment(created).isValid() ? moment(created).calendar() : created}</dd>
+                <dd title={created.toLocaleString()}>{moment(created, util.GOLANG_TIME_FORMAT).calendar()}</dd>
                 <dt>{_("Author")}</dt>
                 <dd>{image.author}</dd>
                 <dt>{_("Ports")}</dt>

--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -130,7 +130,7 @@ class Images extends React.Component {
         let columns = [
             {name: image.repoTags ? image.repoTags[0] : "", header: true},
             vulnerabilityColumn,
-            moment(image.created).isValid() ? moment(image.created).calendar() : image.created,
+            moment(image.created, utils.GOLANG_TIME_FORMAT).calendar(),
             cockpit.format_bytes(image.size),
             {
                 element: element,

--- a/src/util.js
+++ b/src/util.js
@@ -5,6 +5,16 @@ const _ = cockpit.gettext;
 
 export const PODMAN_ADDRESS = "unix:/run/podman/io.podman";
 
+/*
+ * Podman returns dates in the format that golang's time.String() exports. Use
+ * this format specifier for converting that to moment.js time, e.g.:
+ *
+ *     moment(date, util.GOLANG_TIME_FORMAT)
+ *
+ * https://github.com/containers/libpod/issues/2260
+ */
+export const GOLANG_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss.S Z';
+
 export function truncate_id(id) {
     if (!id) {
         return _("");


### PR DESCRIPTION
Podman uses the format of golang's `time.String()` to output times in
the varlink API. That doesn't output time in a standard format that
moment.js recognizes.

This makes all times show up as readable times again and gets rid of a
warning by moment.js on the console.

Fix this by explicitly passing a format string. Also filed upstream:

https://github.com/containers/libpod/issues/2260

Depends on:
- [x] https://github.com/cockpit-project/cockpit-podman/pull/44