### PR TITLE
Add empty state pattern for non-running service, and some bug fixes

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -31,7 +31,6 @@ class Application extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            version: { version: "unknown" },
             images: {}, /* images[Id]: detail info of image with Id from InspectImage */
             containers: {}, /* containers[Id] detail info of container with Id from InspectContainer */
             containersStats:{}, /* containersStats[Id] memory usage of running container with Id */
@@ -74,12 +73,10 @@ class Application extends React.Component {
     componentDidMount() {
         varlink.call(utils.PODMAN_ADDRESS, "io.podman.GetVersion")
                 .then(reply => {
-                    this.setState({ version: reply.version });
+                    this.updateImagesAfterEvent();
+                    this.updateContainersAfterEvent();
                 })
                 .catch(ex => console.error("Failed to do GetVersion call:", JSON.stringify(ex)));
-
-        this.updateImagesAfterEvent();
-        this.updateContainersAfterEvent();
     }
 
     render() {

--- a/src/varlink.js
+++ b/src/varlink.js
@@ -57,6 +57,8 @@ function connect(address) {
     });
 
     channel.addEventListener("close", (event, options) => {
+        pending.forEach(p => p.reject({ error: "ConnectionClosed", problem: options.problem }));
+        pending = [];
         if (connection.onclosed)
             connection.onclosed(options.problem);
     });
@@ -74,6 +76,7 @@ function connect(address) {
 
     connection.close = function () {
         pending.forEach(p => p.reject({ error: "ConnectionClosed" }));
+        pending = [];
         channel.close();
     };
 

--- a/test/check-application
+++ b/test/check-application
@@ -211,6 +211,48 @@ class TestApplication(testlib.MachineCase):
 
         self.check_container('swamped-crate', ['swamped-crate', 'busybox:latest', 'sh', 'stopped'])
 
+    def testNotRunning(self):
+        b = self.browser
+        m = self.machine
+
+        m.execute("systemctl disable --now io.podman.socket")
+
+        self.login_and_go("/podman")
+        b.wait_present("#app .blank-slate-pf")
+
+        # Troubleshoot action
+        b.wait_present("#app .blank-slate-pf button.btn-default")
+        b.click("#app .blank-slate-pf button.btn-default")
+        b.enter_page("/system/services")
+        b.wait_present("#service-unit")
+        b.wait_in_text("#service-unit", "io.podman.socket")
+
+        # Start action, with enabling (by default)
+        b.go("/podman")
+        b.enter_page("/podman")
+        b.wait_present("#app .blank-slate-pf button.btn-primary")
+        b.click("#app .blank-slate-pf button.btn-primary")
+
+        b.wait_present("#containers-containers")
+
+        self.assertEqual(m.execute("systemctl is-enabled io.podman.socket").strip(), "enabled")
+        self.assertEqual(m.execute("systemctl is-active io.podman.socket").strip(), "active")
+
+        # Start action, without enabling
+        m.execute("systemctl disable --now io.podman.socket")
+        b.reload()
+        b.enter_page("/podman")
+        b.wait_present("#app .blank-slate-pf input[type=checkbox]")
+        b.click("#app .blank-slate-pf input[type=checkbox]")
+        b.wait_present("#app .blank-slate-pf button.btn-primary")
+        b.click("#app .blank-slate-pf button.btn-primary")
+
+        b.wait_present("#containers-containers")
+        self.assertEqual(m.execute("! systemctl is-enabled io.podman.socket").strip(), "disabled")
+        self.assertEqual(m.execute("systemctl is-active io.podman.socket").strip(), "active")
+
+        self.allow_journal_messages("/run/podman/io.podman: couldn't connect.*")
+
     def check_container(self, row_name, expected_strings):
         """Check the container with row_name has the expected_string shown in the row"""
         b = self.browser


### PR DESCRIPTION
See individual commits. Now, if the socket isn't running, the page looks like this

![notrunning](https://user-images.githubusercontent.com/200109/52305873-8f72a800-2996-11e9-9f12-21b0db9a6b3c.png)

Which is much more useful than the previous confusing state where the lists were shown, but empty.

This isn't perfect yet, e. g. the page does not *watch* for the socket to go up and down (we might copy cockpit's services.js for that?). But it should hopefully cover the most common problem scenario.