### PR TITLE
Revert "package.json: Pin down terser 3.14.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "sass-loader": "^7.0.3",
     "sizzle": "^2.3.3",
     "stdio": "^0.2.7",
-    "terser": "3.14.1",
     "webpack": "^4.17.1",
     "webpack-cli": "^3.1.0"
   },


### PR DESCRIPTION
This reverts commit 5d3aebcf962264dd08e0beef80fcaf73dab14640.

terser 3.16.1 got released which fixes the regression.