### PR TITLE
Fix and validate AppStream metainfo

### DIFF
--- a/cockpit-podman.spec.in
+++ b/cockpit-podman.spec.in
@@ -6,6 +6,7 @@ License: LGPLv2+
 
 Source: cockpit-podman-%{version}.tar.gz
 BuildArch: noarch
+BuildRequires:  libappstream-glib
 
 Requires: cockpit-bridge >= 138
 Requires: cockpit-shell >= 138
@@ -21,6 +22,7 @@ The Cockpit user interface for Podman containers.
 
 %install
 %make_install
+appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/*
 
 %files
 %{_datadir}/cockpit/*

--- a/org.cockpit-project.podman.metainfo.xml
+++ b/org.cockpit-project.podman.metainfo.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
   <id>org.cockpit-project.podman</id>
   <metadata_license>CC0-1.0</metadata_license>


### PR DESCRIPTION
 - Add missing XML header
 - Validate format as per documentation:
   https://docs.fedoraproject.org/en-US/packaging-guidelines/AppData/#_app_data_validate_usage