### PR TITLE
varlink: Return a promise from varlink.connect()

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -81,11 +81,11 @@ class Application extends React.Component {
                     this.updateImagesAfterEvent();
                     this.updateContainersAfterEvent();
                 })
-                .catch(ex => {
-                    if (ex.problem === 'not-found')
+                .catch(error => {
+                    if (error.name === "ConnectionClosed")
                         this.setState({ serviceAvailable: false });
                     else
-                        console.error("Failed to do GetVersion call:", JSON.stringify(ex));
+                        console.error("Failed to call GetVersion():", error);
                 });
     }
 


### PR DESCRIPTION
Return a promise from `varlink.connect()` that resolves when the channel
signals that it is ready. This is not technically needed, because
cockpit allows sending messages to channels before they're ready. It is
a bit cleaner though, because clients can be sure that connections have
been established before starting to send messages.

This was already expected in `varlink.call()`, which is also the only
consumer of this call.