### PR TITLE
spec: Align property values

### DIFF
--- a/cockpit-podman.spec.in
+++ b/cockpit-podman.spec.in
@@ -1,17 +1,17 @@
-Name: cockpit-podman
-Version: @VERSION@
-Release: 1%{?dist}
-Summary: Cockpit component for Podman containers
-License: LGPLv2+
-URL: https://github.com/cockpit-project/cockpit-podman
+Name:           cockpit-podman
+Version:        @VERSION@
+Release:        1%{?dist}
+Summary:        Cockpit component for Podman containers
+License:        LGPLv2+
+URL:            https://github.com/cockpit-project/cockpit-podman
 
-Source0: https://github.com/cockpit-project/cockpit-podman/releases/download/%{version}/cockpit-podman-%{version}.tar.gz
-BuildArch: noarch
+Source0:        https://github.com/cockpit-project/cockpit-podman/releases/download/%{version}/cockpit-podman-%{version}.tar.gz
+BuildArch:      noarch
 BuildRequires:  libappstream-glib
 
-Requires: cockpit-bridge >= 138
-Requires: cockpit-shell >= 138
-Requires: podman
+Requires:       cockpit-bridge >= 138
+Requires:       cockpit-shell >= 138
+Requires:       podman
 
 %description
 The Cockpit user interface for Podman containers.


### PR DESCRIPTION
Use the same 17-column row for the property keys and aligned values as
in cockpit and composer. This will provide a consistent result from
cockpituous' release-srpm when it adds/modifies Version: and Release:.