### PR TITLE
Move commit modal handler code into the CommitModalComponent and enhance error messages

### DIFF
--- a/src/Notification.jsx
+++ b/src/Notification.jsx
@@ -23,9 +23,9 @@ import cockpit from 'cockpit';
 
 const _ = cockpit.gettext;
 
-export const ErrorNotification = ({ errorMessage, errorDetail }) => {
+export const ErrorNotification = ({ errorMessage, errorDetail, onDismiss }) => {
     return (
-        <Alert>
+        <Alert onDismiss={onDismiss}>
             <strong>
                 {errorMessage}
             </strong>


### PR DESCRIPTION
Container.jsx file is home to much code that should be split into different files. This makes this file a total mess.

By moving all the code related to ContainerCommit to the ContainerCommitModal we can get rid of all these useless handlers that we need to pass around the react components otherwise.

Also error messages previously were printed like JSON.stringify(ex) which is definitely not a user friendly way to tell 'you container commit failed'. So I changed a bit the presentation of error messages as well.