### PR TITLE
package.json: Pin dependencies to exact versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,20 +45,20 @@
     "webpack-cli": "^3.1.0"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.0.0",
-    "bootstrap": "^4.1.1",
-    "bootstrap-less": "^3.3.8",
-    "docker-names": "^1.1.1",
-    "moment": "^2.22.2",
-    "node-sass": "^4.9.0",
-    "patternfly": "^3.54.1",
-    "patternfly-react": "^1.19.1",
-    "prop-types": "^15.6.1",
-    "react": "^16.7.0",
-    "react-addons-css-transition-group": "^15.6.2",
-    "react-addons-transition-group": "^15.6.2",
-    "react-dom": "^16.7.0",
-    "strict-loader": "^1.2.0",
-    "throttle-debounce": "^2.1.0"
+    "@babel/polyfill": "7.4.3",
+    "bootstrap": "4.3.1",
+    "bootstrap-less": "3.3.8",
+    "docker-names": "1.1.1",
+    "moment": "2.24.0",
+    "node-sass": "4.11.0",
+    "patternfly": "3.59.1",
+    "patternfly-react": "1.19.1",
+    "prop-types": "15.7.2",
+    "react": "16.8.6",
+    "react-addons-css-transition-group": "15.6.2",
+    "react-addons-transition-group": "15.6.2",
+    "react-dom": "16.7.0",
+    "strict-loader": "1.2.0",
+    "throttle-debounce": "2.1.0"
   }
 }


### PR DESCRIPTION
We now let the Cockpit npm-update bot update these in a controlled
manner.