### PR TITLE
Cmd with arguments

### DIFF
--- a/src/ContainerCommitModal.jsx
+++ b/src/ContainerCommitModal.jsx
@@ -18,7 +18,7 @@ class ContainerCommitModal extends React.Component {
             tag: "",
             author:"",
             message: "",
-            command: props.container.command ? props.container.command.join(" ") : "",
+            command: props.container.command ? utils.quote_cmdline(props.container.command) : "",
             pause: true,
             setonbuild: false,
             onbuild: [""],

--- a/src/ContainerDetails.jsx
+++ b/src/ContainerDetails.jsx
@@ -34,7 +34,7 @@ const ContainerDetails = ({ container }) => (
             <dt>{_("Image")}</dt>
             <dd>{container.image}</dd>
             <dt>{_("Command")}</dt>
-            <dd>{container.command ? container.command.join(" ") : ""}</dd>
+            <dd>{container.command ? util.quote_cmdline(container.command) : ""}</dd>
             <dt>{_("State")}</dt>
             <dd>{render_container_state(container)}</dd>
             <dt>{_("Ports")}</dt>

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -86,7 +86,7 @@ class Containers extends React.Component {
         let columns = [
             { name: container.names, header: true },
             image,
-            container.command.join(" "),
+            utils.quote_cmdline(container.command),
             isRunning ? utils.format_cpu_percent(containerStats.cpu * 100) : "",
             containerStats ? utils.format_memory_and_limit(containerStats.mem_usage, containerStats.mem_limit) : "",
             container.status /* TODO: i18n */,

--- a/src/ImageDetails.jsx
+++ b/src/ImageDetails.jsx
@@ -23,7 +23,7 @@ const ImageDetails = (props) => {
                 <dt>{_("Entrypoint")}</dt>
                 <dd>{image.entrypoint ? image.entrypoint.join(" ") : ""}</dd>
                 <dt>{_("Command")}</dt>
-                <dd>{image.command ? image.command.join(" ") : "" }</dd>
+                <dd>{image.command ? util.quote_cmdline(image.command) : "" }</dd>
                 <dt>{_("Created")}</dt>
                 <dd title={created.toLocaleString()}>{moment(created, util.GOLANG_TIME_FORMAT).calendar()}</dd>
                 <dt>{_("Author")}</dt>

--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -199,7 +199,7 @@ export class ImageRunModal extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            command: 'sh',
+            command: this.props.image.command ? utils.unquote_cmdline(this.props.image.command) : "sh",
             containerName: dockerNames.getRandomName(),
             env: [],
             hasTTY: true,

--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -224,7 +224,7 @@ export class ImageRunModal extends React.Component {
         if (this.state.containerName)
             createConfig.name = this.state.containerName;
         if (this.state.command)
-            createConfig.command = [this.state.command];
+            createConfig.command = utils.unquote_cmdline(this.state.command);
         if (this.state.memoryConfigure && this.state.memory)
             createConfig.resources.memory = this.state.memory * (1024 ** units[this.state.memoryUnit].base1024Exponent);
         if (this.state.hasTTY)

--- a/src/util.js
+++ b/src/util.js
@@ -134,3 +134,95 @@ export function getCommitArr(arr, cmd) {
     }
     return ret;
 }
+
+/*
+ * The functions quote_cmdline and unquote_cmdline implement
+ * a simple shell-like quoting syntax.  They are used when letting the
+ * user edit a sequence of words as a single string.
+ *
+ * When parsing, words are separated by whitespace.  Single and double
+ * quotes can be used to protect a sequence of characters that
+ * contains whitespace or the other quote character.  A backslash can
+ * be used to protect any character.  Quotes can appear in the middle
+ * of a word.
+ *
+ * This comes from cockpit-project/cockpit docker package. Changes should be
+ * made there and then backported here.
+ */
+
+export function quote_cmdline(words) {
+    words = words || [];
+
+    function is_whitespace(c) {
+        return c == ' ';
+    }
+
+    function quote(word) {
+        var text = "";
+        var quote_char = "";
+        var i;
+        for (i = 0; i < word.length; i++) {
+            if (word[i] == '\\' || word[i] == quote_char)
+                text += '\\';
+            else if (quote_char === "") {
+                if (word[i] == "'" || is_whitespace(word[i]))
+                    quote_char = '"';
+                else if (word[i] == '"')
+                    quote_char = "'";
+            }
+            text += word[i];
+        }
+
+        return quote_char + text + quote_char;
+    }
+
+    return words.map(quote).join(' ');
+}
+
+export function unquote_cmdline(text) {
+    var words = [ ];
+    var next;
+
+    function is_whitespace(c) {
+        return c == ' ';
+    }
+
+    function skip_whitespace() {
+        while (next < text.length && is_whitespace(text[next]))
+            next++;
+    }
+
+    function parse_word() {
+        var word = "";
+        var quote_char = null;
+
+        while (next < text.length) {
+            if (text[next] == '\\') {
+                next++;
+                if (next < text.length) {
+                    word += text[next];
+                }
+            } else if (text[next] == quote_char) {
+                quote_char = null;
+            } else if (quote_char) {
+                word += text[next];
+            } else if (text[next] == '"' || text[next] == "'") {
+                quote_char = text[next];
+            } else if (is_whitespace(text[next])) {
+                break;
+            } else
+                word += text[next];
+            next++;
+        }
+        return word;
+    }
+
+    next = 0;
+    skip_whitespace();
+    while (next < text.length) {
+        words.push(parse_word());
+        skip_whitespace();
+    }
+
+    return words;
+}

--- a/test/check-application
+++ b/test/check-application
@@ -365,6 +365,9 @@ class TestApplication(testlib.MachineCase):
         # Enable tty
         b.set_checked("#run-image-dialog-tty", True)
 
+        # Set up command line
+        b.set_input_text('#run-image-dialog-command', 'sh -c "while echo Hello World; do sleep 1; done"')
+
         # Configure published ports
         b.set_input_text('.publish-port-form[data-key="0"] input:first-child', '5000')
         b.set_input_text('.publish-port-form[data-key="0"] input:nth-child(2)', '6000')
@@ -413,10 +416,11 @@ class TestApplication(testlib.MachineCase):
         b.click('div.modal-footer button:contains("Run")')
         b.wait_not_present("div.modal-dialog")
         b.wait_present('#containers-containers tr:contains("busybox:latest")')
-        self.check_container('busybox-with-tty', ['busybox-with-tty', 'busybox:latest', 'sh', 'running'])
+        self.check_container('busybox-with-tty', ['busybox-with-tty', 'busybox:latest', 'sh -c "while echo Hello World; do sleep 1; done"', 'running'])
 
         hasTTY = m.execute("podman inspect --format '{{.Config.Tty}}' busybox-with-tty").strip()
         self.assertEqual(hasTTY, 'true')
+        b.wait(lambda: "Hello World" in m.execute("podman logs busybox-with-tty"))
 
         b.click('#containers-containers tbody tr:contains("busybox:latest") td.listing-ct-toggle')
         b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Ports") + dd', '0.0.0.0:6000 \u2192 5000/tcp')

--- a/test/check-application
+++ b/test/check-application
@@ -38,6 +38,7 @@ class TestApplication(testlib.MachineCase):
         b.wait_present('#containers-images tr:contains("busybox:latest")')
         b.click('#containers-images tbody tr:contains("busybox:latest") td.listing-ct-toggle')
         b.wait_present('#containers-images tbody tr:contains("busybox:latest") + tr button.btn-delete')
+        b.wait_in_text('#containers-images tbody tr .listing-ct-body:first-child:contains("busybox:latest")', "Commandsh")
 
         # make sure no running containers shown
         self.filter_containers('running')
@@ -138,6 +139,7 @@ class TestApplication(testlib.MachineCase):
         # delete image alpine that has been used by a container
         b.wait_present('#containers-images tr:contains("alpine:latest")')
         b.click('#containers-images tbody tr:contains("alpine:latest") td.listing-ct-toggle')
+        b.wait_in_text('#containers-images tbody tr .listing-ct-body:first-child:contains("alpine:latest")', "Command/bin/sh")
         b.click('#containers-images tbody tr:contains("alpine:latest") + tr button.btn-delete')
         b.click(".modal-dialog div #btn-img-delete")
         b.wait_not_present("modal-dialog div #btn-img-delete")
@@ -339,6 +341,14 @@ class TestApplication(testlib.MachineCase):
 
         self.login_and_go("/podman")
         b.wait_in_text("#containers-images", "busybox:latest")
+        b.wait_in_text("#containers-images", "alpine:latest")
+
+        # Check command in alpine
+        b.wait_present('#containers-images tr:contains("alpine:latest")')
+        b.click('#containers-images tbody tr:contains("alpine:latest") td.listing-ct-actions button')
+        b.wait_present('div.modal-dialog div.modal-header h4.modal-title:contains("Run Image")')
+        b.wait_present("#run-image-dialog-command[value='/bin/sh']")
+        b.click(".btn-cancel")
 
         # Open run image dialog
         b.wait_present('#containers-images tr:contains("busybox:latest")')


### PR DESCRIPTION
Using command like `sh -c "while date; do sleep 2; done"` to create new
container would fail with executable not found as it took the whole line as an executable.

This commit makes it possible to use arguments in the command.

Also show as default command image cmd.