### PR TITLE
Update to the new create type

### DIFF
--- a/cockpit-podman.spec.in
+++ b/cockpit-podman.spec.in
@@ -11,7 +11,7 @@ BuildRequires:  libappstream-glib
 
 Requires:       cockpit-bridge >= 138
 Requires:       cockpit-shell >= 138
-Requires:       podman >= 1:1.2.0
+Requires:       podman >= 2:1.3.0
 
 %description
 The Cockpit user interface for Podman containers.

--- a/cockpit-podman.spec.in
+++ b/cockpit-podman.spec.in
@@ -11,7 +11,7 @@ BuildRequires:  libappstream-glib
 
 Requires:       cockpit-bridge >= 138
 Requires:       cockpit-shell >= 138
-Requires:       podman >= 2:1.3.0
+Requires:       podman >= 1:1.2.0
 
 %description
 The Cockpit user interface for Podman containers.

--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -219,12 +219,12 @@ export class ImageRunModal extends React.Component {
     getCreateConfig() {
         let createConfig = {};
 
-        createConfig.image = this.state.image.repoTags ? this.state.image.repoTags[0] : "";
+        createConfig.args = this.state.image.repoTags ? [this.state.image.repoTags[0]] : [""];
         createConfig.resources = {};
         if (this.state.containerName)
             createConfig.name = this.state.containerName;
         if (this.state.command)
-            createConfig.command = utils.unquote_cmdline(this.state.command);
+            createConfig.args = createConfig.args.concat(utils.unquote_cmdline(this.state.command));
         if (this.state.memoryConfigure && this.state.memory)
             createConfig.resources.memory = this.state.memory * (1024 ** units[this.state.memoryUnit].base1024Exponent);
         if (this.state.hasTTY)
@@ -234,12 +234,10 @@ export class ImageRunModal extends React.Component {
                     .filter(port => port.hostPort && port.containerPort)
                     .map(port => port.hostPort + ':' + port.containerPort + '/' + port.protocol);
         if (this.state.env) {
-            createConfig.env = {};
-            for (let item of this.state.env)
-                createConfig.env[item.envKey] = item.envValue;
+            createConfig.env = this.state.env.map(item => item.envKey + "=" + item.envValue);
         }
         if (this.state.volumes) {
-            createConfig.volumes = this.state.volumes
+            createConfig.volume = this.state.volumes
                     .filter(volume => volume.hostPath && volume.containerPath)
                     .map(volume => {
                         if (volume.mode)

--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -218,13 +218,22 @@ export class ImageRunModal extends React.Component {
 
     getCreateConfig() {
         let createConfig = {};
+        // HACK: checking version is because API got broken from 1.2 -> 1.3
+        // Once we support only 1.3 podman, commit which introduces these changes can be reverted
 
-        createConfig.args = this.state.image.repoTags ? [this.state.image.repoTags[0]] : [""];
+        if (this.props.version < "1.3.0")
+            createConfig.image = this.state.image.repoTags ? this.state.image.repoTags[0] : "";
+        else
+            createConfig.args = this.state.image.repoTags ? [this.state.image.repoTags[0]] : [""];
         createConfig.resources = {};
         if (this.state.containerName)
             createConfig.name = this.state.containerName;
-        if (this.state.command)
-            createConfig.args = createConfig.args.concat(utils.unquote_cmdline(this.state.command));
+        if (this.state.command) {
+            if (this.props.version < "1.3.0")
+                createConfig.command = utils.unquote_cmdline(this.state.command);
+            else
+                createConfig.args = createConfig.args.concat(utils.unquote_cmdline(this.state.command));
+        }
         if (this.state.memoryConfigure && this.state.memory)
             createConfig.resources.memory = this.state.memory * (1024 ** units[this.state.memoryUnit].base1024Exponent);
         if (this.state.hasTTY)
@@ -234,16 +243,25 @@ export class ImageRunModal extends React.Component {
                     .filter(port => port.hostPort && port.containerPort)
                     .map(port => port.hostPort + ':' + port.containerPort + '/' + port.protocol);
         if (this.state.env) {
-            createConfig.env = this.state.env.map(item => item.envKey + "=" + item.envValue);
+            if (this.props.version < "1.3.0") {
+                createConfig.env = {};
+                for (let item of this.state.env)
+                    createConfig.env[item.envKey] = item.envValue;
+            } else
+                createConfig.env = this.state.env.map(item => item.envKey + "=" + item.envValue);
         }
         if (this.state.volumes) {
-            createConfig.volume = this.state.volumes
+            let volume = this.state.volumes
                     .filter(volume => volume.hostPath && volume.containerPath)
                     .map(volume => {
                         if (volume.mode)
                             return volume.hostPath + ':' + volume.containerPath + ':' + volume.mode;
                         return volume.hostPath + ':' + volume.containerPath;
                     });
+            if (this.props.version < "1.3.0")
+                createConfig.volumes = volume;
+            else
+                createConfig.volume = volume;
         }
 
         return createConfig;

--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -240,7 +240,8 @@ class Images extends React.Component {
                 {this.state.showRunImageModal &&
                 <ImageRunModal
                     close={() => this.setState({ showRunImageModal: undefined })}
-                    image={this.state.showRunImageModal} /> }
+                    image={this.state.showRunImageModal}
+                    version={this.props.version} /> }
                 {this.state.showSearchImageModal &&
                 <ImageSearchModal
                     close={() => this.setState({ showSearchImageModal: false })}

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -41,6 +41,7 @@ class Application extends React.Component {
             onlyShowRunning: true,
             dropDownValue: 'Everything',
             notifications: [],
+            version: '1.2.0'
         };
         this.onAddNotification = this.onAddNotification.bind(this);
         this.onDismissNotification = this.onDismissNotification.bind(this);
@@ -173,7 +174,7 @@ class Application extends React.Component {
     init() {
         varlink.call(utils.PODMAN_ADDRESS, "io.podman.GetVersion")
                 .then(reply => {
-                    this.setState({ serviceAvailable: true });
+                    this.setState({ serviceAvailable: true, version: reply.version });
                     this.updateImagesAfterEvent();
                     this.updateContainersAfterEvent();
 
@@ -261,6 +262,7 @@ class Application extends React.Component {
             <Images
                 key={_("imageList")}
                 images={this.state.images}
+                version={this.state.version}
                 onAddNotification={this.onAddNotification}
             />;
         containerList =


### PR DESCRIPTION
Since version 1.3.0 (with epoch 2) there has been some changes in API,
cockpit-podman has been affected with the create type.

There were four changes, which needed to be addressed:
1) env is not map but array of 'key=value'
2) image is passed in array `args`
3) command is passed in array `args`
4) `volumes` option has been renamed to `volume`

These changes were introduced to better match commandline options from
podman itself.

Note about tests:
f30 - this image has this new version and naughty, since it was failing. Expected result is that all tests pass without the naughty being used.