### PR TITLE
Introduce terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-addons-transition-group": "15.6.2",
     "react-dom": "16.8.6",
     "strict-loader": "1.2.0",
-    "throttle-debounce": "2.1.0"
+    "throttle-debounce": "2.1.0",
+    "xterm": "3.13.1"
   }
 }

--- a/src/ContainerDetails.jsx
+++ b/src/ContainerDetails.jsx
@@ -25,7 +25,7 @@ const render_container_published_ports = ({ ports }) => {
 };
 
 const ContainerDetails = ({ container }) => (
-    <div className='listing-ct-body'>
+    <div className='listing-ct-body container-details'>
         <dl>
             <dt>{_("ID")}</dt>
             <dd>{container.id}</dd>

--- a/src/ContainerTerminal.css
+++ b/src/ContainerTerminal.css
@@ -1,0 +1,17 @@
+@import "~xterm/lib/xterm.css";
+
+.terminal {
+    /* 5px all around and on right +11 since the scrollbar is 11px wide */
+    padding: 5px 16px 5px 5px;
+}
+
+.empty-state {
+    padding-top: 50px;
+    padding-bottom: 50px;
+    text-align: center;
+}
+
+.empty-message {
+    font-size: 175%;
+    font-weight: 100;
+}

--- a/src/ContainerTerminal.jsx
+++ b/src/ContainerTerminal.jsx
@@ -1,0 +1,184 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import cockpit from 'cockpit';
+import { Terminal } from "xterm";
+
+import * as utils from './util.js';
+import varlink from './varlink.js';
+
+import "./ContainerTerminal.css";
+
+const _ = cockpit.gettext;
+
+class ContainerTerminal extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.onChannelClose = this.onChannelClose.bind(this);
+        this.onChannelMessage = this.onChannelMessage.bind(this);
+        this.disconnectChannel = this.disconnectChannel.bind(this);
+        this.connectChannel = this.connectChannel.bind(this);
+        this.resize = this.resize.bind(this);
+
+        let term = new Terminal({
+            cols: 80,
+            rows: 24,
+            screenKeys: true,
+            cursorBlink: true,
+            fontSize: 12,
+            fontFamily: 'Menlo, Monaco, Consolas, monospace',
+            screenReaderMode: true
+        });
+
+        this.state = {
+            term: term,
+            container: props.containerId,
+            channel: null,
+            control_channel: null,
+            opened: false,
+            errorMessage: "",
+            cols: 80,
+        };
+    }
+
+    componentDidMount() {
+        this.connectChannel();
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        if (!this.state.channel && this.props.containerStatus === "running" && prevProps.containerStatus !== "running")
+            this.connectChannel();
+        if (prevProps.width !== this.props.width) {
+            this.resize(this.props.width);
+        }
+    }
+
+    resize(width) {
+        var padding = 11 + 5 + 50;
+        var realWidth = this.state.term._core.renderer.dimensions.actualCellWidth;
+        var cols = Math.floor((width - padding) / realWidth);
+        this.state.term.resize(cols, 24);
+        cockpit.spawn(["sh", "-c", "echo '1 24 " + cols.toString() + "'>" + this.state.control_channel], { superuser: true });
+        this.setState({ cols: cols });
+    }
+
+    connectChannel() {
+        let self = this;
+        if (self.state.channel)
+            return;
+
+        if (self.props.containerStatus !== "running") {
+            let message = _("Container is not running");
+            this.setState({ errorMessage: message });
+            return;
+        }
+
+        varlink.call(utils.PODMAN_ADDRESS, "io.podman.GetAttachSockets", { name: this.state.container })
+                .then(out => {
+                    let opts = {
+                        payload: "packet",
+                        unix: out.sockets.io_socket,
+                        superuser: "require",
+                        binary: false
+                    };
+
+                    let channel = cockpit.channel(opts);
+                    channel.wait()
+                            .then(() => {
+                                // Show the terminal. Once it was shown, do not show it again but reuse the previous one
+                                if (!this.state.opened) {
+                                    this.state.term.open(this.refs.terminal);
+                                    this.setState({ opened: true });
+
+                                    self.state.term.on('data', function(data) {
+                                        if (self.state.channel)
+                                            self.state.channel.send(data);
+                                    });
+                                }
+
+                                channel.addEventListener("message", this.onChannelMessage);
+                                channel.addEventListener('close', this.onChannelClose);
+
+                                channel.send(String.fromCharCode(12)); // Send SIGWINCH to show prompt on attaching
+                                this.setState({ channel: channel, control_channel: out.sockets.control_socket, errorMessage: "" });
+                                this.resize(this.props.width);
+                            })
+                            .catch(e => {
+                                let message = cockpit.format(_("Could not open channel: $0"), e.problem);
+                                if (e.problem === "not-supported")
+                                    message = _("This version of the Web Console does not support a terminal.");
+                                this.setState({ errorMessage: message });
+                            });
+                })
+                .catch(e => this.setState({ errorMessage: cockpit.format(_("Could not attach to this container: $0"), e.problem) }));
+    }
+
+    componentWillUnmount() {
+        this.disconnectChannel();
+        if (this.state.channel)
+            this.state.channel.close();
+        this.state.term.destroy();
+    }
+
+    onChannelMessage(event, data) {
+        this.state.term.write(data.substring(1)); // Drop first character which is marking stdin/stdout/stderr
+    }
+
+    onChannelClose(event, options) {
+        var term = this.state.term;
+        term.write('\x1b[31m disconnected \x1b[m\r\n');
+        this.disconnectChannel();
+        this.setState({ channel: null });
+        term.cursorHidden = true;
+    }
+
+    disconnectChannel() {
+        if (this.state.channel) {
+            this.state.channel.removeEventListener('message', this.onChannelMessage);
+            this.state.channel.removeEventListener('close', this.onChannelClose);
+        }
+    }
+
+    render() {
+        let element = <div ref="terminal" />;
+        if (this.state.errorMessage)
+            element = (<div ref="terminal" className="empty-state">
+                <span className="empty-message">
+                    { this.state.errorMessage }
+                </span>
+            </div>
+            );
+
+        return (
+            <React.Fragment>
+                { element }
+            </React.Fragment>
+        );
+    }
+}
+
+ContainerTerminal.propTypes = {
+    containerId: PropTypes.string.isRequired,
+    containerStatus: PropTypes.string.isRequired
+};
+
+export default ContainerTerminal;

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import ReactDOM from "react-dom";
 import { Alert } from 'patternfly-react';
 
 import cockpit from 'cockpit';
 import * as Listing from '../lib/cockpit-components-listing.jsx';
 import ContainerDetails from './ContainerDetails.jsx';
+import ContainerTerminal from './ContainerTerminal.jsx';
 import Dropdown from './Dropdown.jsx';
 import ContainerDeleteModal from './ContainerDeleteModal.jsx';
 import ContainerRemoveErrorModal from './ContainerRemoveErrorModal.jsx';
@@ -20,8 +22,10 @@ class Containers extends React.Component {
             selectContainerDeleteModal: false,
             setContainerRemoveErrorModal: false,
             containerWillDelete: {},
+            width: 0,
         };
         this.renderRow = this.renderRow.bind(this);
+        this.onWindowResize = this.onWindowResize.bind(this);
         this.restartContainer = this.restartContainer.bind(this);
         this.startContainer = this.startContainer.bind(this);
         this.stopContainer = this.stopContainer.bind(this);
@@ -30,6 +34,16 @@ class Containers extends React.Component {
         this.handleRemoveContainer = this.handleRemoveContainer.bind(this);
         this.handleCancelRemoveError = this.handleCancelRemoveError.bind(this);
         this.handleForceRemoveContainer = this.handleForceRemoveContainer.bind(this);
+
+        window.addEventListener('resize', this.onWindowResize);
+    }
+
+    componentDidMount() {
+        this.onWindowResize();
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('resize', this.onWindowResize);
     }
 
     deleteContainer(container, event) {
@@ -96,6 +110,10 @@ class Containers extends React.Component {
             name: _("Details"),
             renderer: ContainerDetails,
             data: { container: container }
+        }, {
+            name: _("Console"),
+            renderer: ContainerTerminal,
+            data: { containerId: container.id, containerStatus: container.status, width:this.state.width }
         }];
 
         var actions = [
@@ -172,6 +190,12 @@ class Containers extends React.Component {
                     });
                 })
                 .catch(ex => console.error("Failed to do RemoveContainerForce call:", JSON.stringify(ex)));
+    }
+
+    onWindowResize() {
+        this.setState({
+            width: ReactDOM.findDOMNode(this).clientWidth
+        });
     }
 
     render() {

--- a/test/check-application
+++ b/test/check-application
@@ -5,7 +5,6 @@
 
 import os
 import sys
-import time
 from distutils.version import StrictVersion
 import unittest
 
@@ -474,13 +473,27 @@ class TestApplication(testlib.MachineCase):
         self.assertIn('rw', rwmnt)
         self.assertIn(rwdir[4:], rwmnt)
 
+        b.click("a:contains('Console')")
+        if m.image != "fedora-29":
+            b.wait_in_text(".xterm-accessibility-tree > div:nth-child(2)", "Hello World")
+        else:
+            b.wait_text("span.empty-message", "This version of the Web Console does not support a terminal.")
+
+        # HACK: Stop this container because of https://github.com/containers/libpod/issues/3454
+        b.click('#containers-containers tbody tr:contains("busybox-with-tty") + tr button:contains(Stop)')
+        b.click("div.dropdown.open ul li:nth-child(1) a")
+
         # Create another instance without port publishing
         b.wait_present('#containers-images tr:contains("busybox:latest")')
+        b.click('#containers-containers tbody tr:contains("busybox:latest") td.listing-ct-toggle')
         b.click('#containers-images tbody tr:contains("busybox:latest") td.listing-ct-actions button')
         b.wait_present('div.modal-dialog div.modal-header h4.modal-title:contains("Run Image")')
 
         b.wait_in_text("#run-image-dialog-image", "busybox:latest")
         b.set_input_text("#run-image-dialog-name", "busybox-without-publish")
+
+        # Set up command line
+        b.set_input_text('#run-image-dialog-command', '/bin/sh')
 
         b.click('div.modal-footer button:contains("Run")')
         b.wait_not_present("div.modal-dialog")
@@ -488,6 +501,28 @@ class TestApplication(testlib.MachineCase):
         b.click('#containers-containers tbody tr:contains("busybox-without-publish") td.listing-ct-toggle')
         b.wait_present('#containers-containers tbody tr:contains("busybox-without-publish") + tr dt:contains("Ports")')
         b.wait_text('#containers-containers tr:contains("busybox-without-publish") + tr dt:contains("Ports") + dd', "")
+
+        b.set_val("#containers-containers-filter", "all")
+
+        if m.image != "fedora-29":
+            b.click("a:contains('Console')")
+            b.wait_text(".xterm-accessibility-tree > div:nth-child(1)", "/ # ")
+            b.focus('.terminal')
+            b.key_press('echo hello\r')
+            b.wait_text(".xterm-accessibility-tree > div:nth-child(2)", "hello")
+            b.wait_text(".xterm-accessibility-tree > div:nth-child(3)", "/ # ")
+            b.wait_text(".xterm-accessibility-tree > div:nth-child(1)", "/ # echo hello")
+            b.click('#containers-containers tbody tr:contains("busybox-without-publish") + tr button:contains(Stop)')
+            b.click("div.dropdown.open ul li:nth-child(1) a")
+            b.wait_text(".xterm-accessibility-tree > div:nth-child(3)", "/ #  disconnected ")
+            self.check_container('busybox-without-publish', ['busybox-without-publish', 'busybox:latest', '/bin/sh', 'exited'])
+            b.click('#containers-containers tbody tr:contains("busybox-without-publish") + tr button:contains(Start)')
+            self.check_container('busybox-without-publish', ['busybox-without-publish', 'busybox:latest', '/bin/sh', 'running'])
+            b.wait_text(".xterm-accessibility-tree > div:nth-child(1)", "/ # ")
+            b.click('#containers-containers tbody tr:contains("busybox-without-publish") + tr button:contains(Stop)')
+            b.click("div.dropdown.open ul li:nth-child(1) a")
+            self.check_container('busybox-without-publish', ['busybox-without-publish', 'busybox:latest', '/bin/sh', 'exited'])
+            b.click('#containers-containers tr:contains("busybox-without-publish")')
 
         b.set_input_text('#containers-filter', 'tty')
         self.check_containers(["busybox-with-tty"], ["busybox-without-publish"])
@@ -502,15 +537,22 @@ class TestApplication(testlib.MachineCase):
         self.check_containers(["busybox-with-tty", "busybox-without-publish"], [])
         self.check_images(["busybox:latest", "alpine:latest", "registry:2"], [])
 
+        if m.image != "fedora-29":
+            b.set_val("#containers-containers-filter", "all")
+            self.check_container('busybox-without-publish', ['busybox-without-publish', 'busybox:latest', '/bin/sh', 'exited'])
+            b.click('#containers-containers tr:contains("busybox-without-publish")')
+            b.click("a:contains('Console')")
+            b.wait_text("span.empty-message", "Container is not running")
+
         b.set_input_text('#containers-filter', 'foobar')
         b.wait_present('#containers-containers thead tr td:contains("No containers that match the current filter")')
         b.wait_present('#containers-images thead tr td:contains("No images that match the current filter")')
         b.set_input_text('#containers-filter', '')
         m.execute("podman rmi -f $(podman images -q)")
+        b.wait_present('#containers-containers thead tr td:contains("No containers")')
+        b.set_val("#containers-containers-filter", "running")
         b.wait_present('#containers-containers thead tr td:contains("No running containers")')
         b.wait_present('#containers-images thead tr td:contains("No images")')
-        b.set_val("#containers-containers-filter", "all")
-        b.wait_present('#containers-containers thead tr td:contains("No containers")')
 
     def check_content(self, type, present, not_present):
         b = self.browser


### PR DESCRIPTION
When container is not running not terminal is shown.
When container is started while container details are opened, terminal
shows up. When container stopped while details are opened, "disconnected"
message is shown and terminal is kept open (however you cannot write
into it).

When container is interactive (such as executed `sh`) a prompt is shown.
This is done by sending SIGWINCH signal (podman does the same on
`attach`).

TODO:

- [x] Opening terminal tab of stopped container and then starting container attaches container outside of parent
- [x] Resizing works only when making window bigger - when making smaller it stick outside of viewport
- [ ] Resizing is set through control channel which is FIFO - `cockpit.file` did not work (very likely I used it incorrectly). Using `cockpit.spawn` is not elegant neither it can read from the pipe.
- [x] Tests needs to be adjusted to a new location (just opening another tab and then changing selectors a bit)
- [ ] When container is not running show(?) also button to start container as in the design (I find it bit redundant)

Used to look like this:
![terminaleins](https://user-images.githubusercontent.com/12330670/58235460-23e3f900-7d41-11e9-9e1f-8d8bc696aac1.png)
Stopping container shows disconnected:
![stopedterminal](https://user-images.githubusercontent.com/12330670/58235503-3827f600-7d41-11e9-82a5-8c69fdfe42cc.png)


There is one small issue I am aware of and that being that when terminal is not interactive and is just logging (like `sh -c "while echo hello; do :; done"`) then SIGWINCH signal leaves `^L` on first line. But for now I take this as for follow up. Ideas welcomed :)

Note about tests:
This won't work because it needs https://github.com/cockpit-project/cockpit/pull/11872 which will reach this image only when released. So hopefully sometime after next release. I tested this with F30 image which I manually prepared to contain these changes.