### PR TITLE
Align filtering and searching fields

### DIFF
--- a/src/podman.scss
+++ b/src/podman.scss
@@ -343,7 +343,6 @@
 
 .content-filter input[type="text"] {
     display: inline-block;
-    vertical-align: middle;
     width: 200px;
     margin-left: 6px;
     margin-top: 2px;


### PR DESCRIPTION
This little thing was too annoying, needed to fix it :)

Current master:
![beforeallignpatch](https://user-images.githubusercontent.com/12330670/58239481-6f9aa080-7d49-11e9-89e4-dfce10034b95.png)
With this patch:
![afterallignedpatch](https://user-images.githubusercontent.com/12330670/58239483-6f9aa080-7d49-11e9-8748-88af43ffa46d.png)
