### PR TITLE
Stop releasing to Fedora 29

### DIFF
--- a/cockpituous-release
+++ b/cockpituous-release
@@ -18,9 +18,7 @@ job release-srpm
 cat ~/.fedora-password | kinit cockpit@FEDORAPROJECT.ORG
 # Do fedora builds for the tag, using tarball
 job release-koji master
-job release-koji f29
 job release-koji f30
-job release-bodhi F29
 job release-bodhi F30
 
 # These are likely the first of your release targets; but run them after Fedora uploads,


### PR DESCRIPTION
Similar to cockpit itself, Fedora 30 has been out for long enough now.