### PR TITLE
cockpituous: Fix srpm Release:

### DIFF
--- a/cockpituous-release
+++ b/cockpituous-release
@@ -12,7 +12,7 @@ RELEASE_SPEC="cockpit-podman.spec"
 RELEASE_SRPM="_release/srpm"
 
 job release-source
-job release-srpm
+job release-srpm -V
 
 # Authenticate for pushing into Fedora dist-git (works in Cockpituous release container)
 cat ~/.fedora-password | kinit cockpit@FEDORAPROJECT.ORG


### PR DESCRIPTION
Use release-srpm's `-V` option [1] so that the generated srpm will get a
proper changelog and Release "1" instead of "2".

[1] https://github.com/cockpit-project/cockpituous/commit/abb2bdb5