### PR TITLE
Drop patternfly npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "docker-names": "1.1.1",
     "moment": "2.24.0",
     "node-sass": "4.12.0",
-    "patternfly": "3.59.1",
     "patternfly-react": "1.19.1",
     "prop-types": "15.7.2",
     "react": "16.8.6",


### PR DESCRIPTION
Our pages include cockpit's shipped patternfly.min.css, and our build
system does not do anything with this NPM module, so save a few seconds
during `npm install`.