### PR TITLE
spec: Drop epoch from dependency

### DIFF
--- a/cockpit-podman.spec.in
+++ b/cockpit-podman.spec.in
@@ -1,8 +1,3 @@
-# we generally want CentOS packages to be like RHEL; special cases need to check %{centos} explicitly
-%if 0%{?centos}
-%define rhel %{centos}
-%endif
-
 Name:           cockpit-podman
 Version:        @VERSION@
 Release:        1%{?dist}
@@ -16,11 +11,7 @@ BuildRequires:  libappstream-glib
 
 Requires:       cockpit-bridge >= 138
 Requires:       cockpit-shell >= 138
-%if 0%{?rhel}
 Requires:       podman >= 1.2.0
-%else
-Requires:       podman >= 1:1.2.0
-%endif
 
 %description
 The Cockpit user interface for Podman containers.


### PR DESCRIPTION
This doesn't work with our current approach of building the srpm on the
container host, and it's also unnecessary now: All our supported target
OSes have a recent enough podman.

 - [x] Get fixed podman on rhel-8-1 image: https://github.com/cockpit-project/cockpit/issues/12078