### PR TITLE
test: Adjust to changed Cockpit Services page

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -329,7 +329,7 @@ class TestApplication(testlib.MachineCase):
         # Troubleshoot action
         b.click("#app .blank-slate-pf button.btn-default")
         b.enter_page("/system/services")
-        b.wait_in_text("#service-unit", "io.podman.socket")
+        b.wait_in_text("#service", "io.podman.socket")
 
         # Start action, with enabling (by default)
         b.go("/podman")


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit/pull/12265 changed the design
a lot, so that `#service-unit` does not exist any more.

The tests need to get along with the old and new design, so just relax
the check.