### PR TITLE
Fix AppStream ID

### DIFF
--- a/org.cockpit-project.podman.metainfo.xml
+++ b/org.cockpit-project.podman.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
-  <id>org.cockpit-project.podman</id>
+  <id>org.cockpit_project.podman</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Cockpit Podman</name>
   <summary>
@@ -11,6 +11,6 @@
       The Cockpit user interface for Podman containers.
     </p>
   </description>
-  <extends>cockpit.desktop</extends>
+  <extends>org.cockpit_project.cockpit</extends>
   <launchable type="cockpit-manifest">cockpit-podman</launchable>
 </component>


### PR DESCRIPTION
Cockpit renamed its ID to "org.cockpit_project.cockpit" to conform to
the AppStream spec [1]. Follow suit and also fix our own ID to not
contain hyphens.

[1] https://github.com/cockpit-project/cockpit/commit/4a9ffe669c