### PR TITLE
test: Allow tests to run on existing testbed

### DIFF
--- a/src/ContainerRemoveErrorModal.jsx
+++ b/src/ContainerRemoveErrorModal.jsx
@@ -17,7 +17,7 @@ const ContainerRemoveErrorModal = (props) => {
                 </Modal.Body>
                 <Modal.Footer>
                     <Button onClick={props.handleCancelRemoveError}>{_("Cancel")}</Button>
-                    <Button bsStyle="danger" className="btn-ctr-focedelete" onClick={props.handleForceRemoveContainer}>{_("Force Delete")}</Button>
+                    <Button bsStyle="danger" className="btn-ctr-forcedelete" onClick={props.handleForceRemoveContainer}>{_("Force Delete")}</Button>
                 </Modal.Footer>
             </Modal>
         </div>

--- a/test/check-application
+++ b/test/check-application
@@ -24,6 +24,16 @@ registries = ['localhost:5000']
 
 class TestApplication(testlib.MachineCase):
 
+    def setUp(self):
+        # backup/restore pristine podman state, so that tests can run on existing testbeds
+        # HACK: sometimes podman leaks mounts
+        super().setUp()
+        self.machine.execute("cp -a /var/lib/containers /var/lib/containers.orig")
+        self.addCleanup(self.machine.execute, "podman rm --force --all && "
+            "findmnt --list -otarget | grep /var/lib/containers | xargs -r umount && "
+            "rm -r /var/lib/containers && "
+            "mv /var/lib/containers.orig /var/lib/containers")
+
     def testBasic(self):
         b = self.browser
         m = self.machine

--- a/test/check-application
+++ b/test/check-application
@@ -77,7 +77,7 @@ class TestApplication(testlib.MachineCase):
 
         # delete running container busybox using force delete
         b.click('#containers-containers tbody tr:contains("busybox:latest") + tr button.btn-delete')
-        self.confirm_modal("btn-ctr-focedelete")
+        self.confirm_modal("btn-ctr-forcedelete")
         b.wait_not_in_text("#containers-containers", "busybox:latest")
 
         # delete the exited alpine


### PR DESCRIPTION
Can be tested with
```
make vm
bots/vm-run fedora-30
test/check-application -tv --machine 127.0.0.2:2201  --browser 127.0.0.2:9091
```