### PR TITLE
eslintrc: Set "root" to true

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "env": {
         "browser": true,
         "es6": true


### PR DESCRIPTION
Eslint shimmies up directories looking for more eslintrcs. As
make-checkout now clones projects in a subdirectory, this can result in
some strange interactions.

https://eslint.org/docs/user-guide/configuring