### PR TITLE
Use and ship package-lock.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,8 @@ test/common:
 $(NODE_MODULES_TEST): package.json
 	# if it exists already, npm install won't update it; force that so that we always get up-to-date packages
 	rm -f package-lock.json
-	npm install
-	npm prune
+	# unset NODE_ENV, skips devDependencies otherwise
+	env -u NODE_ENV npm install
+	env -u NODE_ENV npm prune
 
 .PHONY: all clean install devel-install dist-gzip srpm rpm check vm update-po


### PR DESCRIPTION
npm install has been generating package-lock.json [1] for long enough
for us to start relying on it.

Replace the unreliable and hacky `$NODE_MODULES_TEST` file with just
comparing package.json against package-lock.json to decide when to run
npm install. This will finally avoid unnecessary `npm install` runs, but
start to run these when git switching branches that have a different
package.json.

Also prune node_modules/ when we refresh it, so that switching branches
with different/removed/added npm modules works correctly.

Ship package-lock.json in release tarballs, so that node_modules/ can be
reconstructed exactly as it was when making the release.

[1] https://docs.npmjs.com/files/package-lock.json