### PR TITLE
Makefile: Don't clobber an existing bots checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,11 +136,7 @@ check: $(NODE_MODULES_TEST) $(VM_IMAGE) test/common
 # checkout Cockpit's bots for standard test VM images and API to launch them
 # must be from master, as only that has current and existing images; but testvm.py API is stable
 bots:
-	if [ ! -d bots ]; then \
-		git clone --depth=1 https://github.com/cockpit-project/bots.git; \
-	else \
-		cd bots && git fetch && git reset --hard origin/master; \
-        fi
+	[ -d bots ] || git clone --depth=1 https://github.com/cockpit-project/bots.git
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest relese, and update it from time to time


### PR DESCRIPTION
Commit 00bf137506 was a thinko -- for our CI we *don't* want our test to
clobber a pre-existing bots/ checkout, as we often use this to run tests
against an updated image or to validate a changes to the bots project.

On developer machines, bots may also be a symlink to an actual bots
directory in development, so don't clobber that.