### PR TITLE
Support CI testing against a bots project PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,8 +135,11 @@ check: $(NODE_MODULES_TEST) $(VM_IMAGE) test/common
 
 # checkout Cockpit's bots for standard test VM images and API to launch them
 # must be from master, as only that has current and existing images; but testvm.py API is stable
+# support CI testing against a bots change
 bots:
-	[ -d bots ] || git clone --depth=1 https://github.com/cockpit-project/bots.git
+	git clone --quiet --reference-if-able $${XDG_CACHE_HOME:-$$HOME/.cache}/cockpit-project/bots https://github.com/cockpit-project/bots.git
+	if [ -n "$$COCKPIT_BOTS_REF" ]; then git -C bots fetch --quiet --depth=1 origin "$$COCKPIT_BOTS_REF"; git -C bots checkout --quiet FETCH_HEAD; fi
+	@echo "checked out bots/ ref $$(git -C bots rev-parse HEAD)"
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest relese, and update it from time to time
@@ -152,4 +155,4 @@ $(NODE_MODULES_TEST): package.json
 	env -u NODE_ENV npm install
 	env -u NODE_ENV npm prune
 
-.PHONY: all clean install devel-install dist-gzip srpm rpm check vm update-po bots
+.PHONY: all clean install devel-install dist-gzip srpm rpm check vm update-po


### PR DESCRIPTION
 * If `$COCKPIT_BOTS_REF` is set, check out that bots version instead of
   master.

 * Use git cache in $XDG_CACHE_HOME if available. Our CI uses that to
   save downloads, and it does not get in the way for local developers.

 * Stop making "bots" a phony target, and drop the now unnecessary
   `[ -d bots ]` check.

Ported from https://github.com/cockpit-project/starter-kit/pull/233