### PR TITLE
Enable to limit cpu

### DIFF
--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -205,7 +205,9 @@ export class ImageRunModal extends React.Component {
             publish: [],
             image: props.image,
             memory: 512,
+            cpuShares: 0,
             memoryConfigure: false,
+            cpuSharesConfigure: false,
             memoryUnit: 'MiB',
             validationFailed: {},
             volumes: [],
@@ -227,6 +229,9 @@ export class ImageRunModal extends React.Component {
         if (this.state.memoryConfigure && this.state.memory) {
             const memorySize = this.state.memory * (1024 ** units[this.state.memoryUnit].base1024Exponent);
             createConfig.memory = memorySize.toString();
+        }
+        if (this.state.cpuSharesConfigure) {
+            createConfig.cpuShares = this.state.cpuShares;
         }
         if (this.state.hasTTY)
             createConfig.tty = true;
@@ -331,6 +336,28 @@ export class ImageRunModal extends React.Component {
                         </Select.SelectEntry>
                     </Select.Select>
                 </div>
+
+                { this.state.image.isSystem &&
+                    <>
+                        <label className='control-label' htmlFor='run-image-cpu-priority'>
+                            {_("CPU Shares")}
+                        </label>
+                        <div role='group' className='form-inline' id="run-image-dialog-cpu-priority">
+                            <div className="checkbox">
+                                <input id="run-image-dialog-cpu-priority-checkbox" type="checkbox"
+                                       checked={this.state.cpuSharesConfigure}
+                                       onChange={e => this.onValueChanged('cpuSharesConfigure', e.target.checked)} />
+                            </div>
+                            <input className='form-control'
+                                   type='number'
+                                   value={dialogValues.cpuShares}
+                                   step={1}
+                                   min={0}
+                                   disabled={!this.state.cpuSharesConfigure}
+                                   onChange={e => this.onValueChanged('cpuShares', parseInt(e.target.value))} />
+                        </div>
+                    </>
+                }
 
                 <label className='control-label'> {_("With terminal")} </label>
                 <label className="checkbox-inline">

--- a/test/check-application
+++ b/test/check-application
@@ -673,6 +673,15 @@ class TestApplication(testlib.MachineCase):
             b.set_input_text("#run-image-dialog-memory-limit input.form-control", "0.5")
             b.set_val('#memory-unit-select', "GiB")
 
+        # CPU shares work only with system containers
+        if auth:
+            b.set_checked("#run-image-dialog-cpu-priority-checkbox", True)
+            b.wait_present("#run-image-dialog-cpu-priority-checkbox:checked")
+            b.wait_present('div.modal-body label:contains("CPU Shares") + div.form-inline > input[value="0"]')
+            b.set_input_text("#run-image-dialog-cpu-priority input.form-control", "512")
+        else:
+            b.wait_not_present("#run-image-dialog-cpu-priority-checkbox")
+
         # Enable tty
         b.set_checked("#run-image-dialog-tty", True)
 
@@ -736,6 +745,10 @@ class TestApplication(testlib.MachineCase):
             memory = self.execute(auth, "podman inspect --format '{{.HostConfig.Memory}}' busybox-with-tty").strip()
             self.assertEqual(memory, '536870912')
 
+        if auth:
+            cpuShares = self.execute(auth, "podman inspect --format '{{.HostConfig.CpuShares}}' busybox-with-tty || podman inspect --format '{{.HostConfig.CPUShares}}' busybox-with-tty").strip()
+            self.assertEqual(cpuShares, '512')
+
         b.wait(lambda: "Hello World" in self.execute(auth, "podman logs busybox-with-tty"))
 
         b.click('#containers-containers tbody tr:contains("busybox:latest") td.listing-ct-toggle')
@@ -787,6 +800,11 @@ class TestApplication(testlib.MachineCase):
         b.click('#containers-containers tbody tr:contains("busybox-without-publish") td.listing-ct-toggle')
         b.wait_present('#containers-containers tbody tr:contains("busybox-without-publish") + tr dt:contains("Ports")')
         b.wait_text('#containers-containers tr:contains("busybox-without-publish") + tr dt:contains("Ports") + dd', "")
+
+        # Only works with CGroupsV2
+        if m.image != "rhel-8-1" and (auth or m.image not in ["fedora-30"]):
+            cpuShares = self.execute(auth, "podman inspect --format '{{.HostConfig.CpuShares}}' busybox-without-publish").strip()
+            self.assertEqual(cpuShares, '0')
 
         b.set_val("#containers-containers-filter", "all")
 


### PR DESCRIPTION
Fixes #167

I am not sure what the default value should be. In docker we had 1024, but when I don't specify it, podman starts with 0. So should I use 0 as well?

![cpushares](https://user-images.githubusercontent.com/12330670/70994893-71ee8e80-20cf-11ea-999b-ac0f8a790ee1.png)
