### PR TITLE
Wait until both services are detected

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -383,7 +383,7 @@ class Application extends React.Component {
     }
 
     render() {
-        if (this.state.systemServiceAvailable === null && this.state.userServiceAvailable === null) // not detected yet
+        if (this.state.systemServiceAvailable === null || this.state.userServiceAvailable === null) // not detected yet
             return null;
 
         if (!this.state.systemServiceAvailable && !this.state.userServiceAvailable) {


### PR DESCRIPTION
We showed the page when one service was detected, which meant we always
shown alert mentioning the other service is available as well, even when
the service was running. We closed this warning after a few seconds.