### PR TITLE
Keep order of containers and images

### DIFF
--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -238,6 +238,14 @@ class Containers extends React.Component {
                     this.props.containers[id].image.toLowerCase().indexOf(lcf) >= 0
             );
         }
+
+        filtered.sort((a, b) => {
+            // User containers are in front of system ones
+            if (this.props.containers[a].isSystem !== this.props.containers[b].isSystem)
+                return this.props.containers[a].isSystem ? 1 : -1;
+            return this.props.containers[a].names > this.props.containers[b].names ? 1 : -1;
+        });
+
         const rows = filtered.map(id => this.renderRow(containersStats, this.props.containers[id]));
         const containerDeleteModal =
             <ContainerDeleteModal

--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -225,6 +225,20 @@ class Images extends React.Component {
                     return false;
                 });
         }
+
+        filtered.sort((a, b) => {
+            // User images are in front of system ones
+            if (this.props.images[a].isSystem !== this.props.images[b].isSystem)
+                return this.props.images[a].isSystem ? 1 : -1;
+            const name_a = this.props.images[a].repoTags ? this.props.images[a].repoTags[0] : "";
+            const name_b = this.props.images[b].repoTags ? this.props.images[b].repoTags[0] : "";
+            if (name_a === "")
+                return 1;
+            if (name_b === "")
+                return -1;
+            return name_a > name_b ? 1 : -1;
+        });
+
         const imageRows = filtered.map(id => this.renderRow(this.props.images[id]));
         const imageDeleteModal =
             <ModalExample

--- a/test/check-application
+++ b/test/check-application
@@ -103,6 +103,13 @@ class TestApplication(testlib.MachineCase):
             checkImage(b, "docker.io/library/alpine:latest", "admin")
             checkImage(b, "docker.io/library/registry:2", "admin")
 
+        # Check order of images
+        common = "docker.io/library/alpine:latestdocker.io/library/busybox:latestdocker.io/library/registry:2"
+        ordered = common
+        if auth and m.image != "rhel-8-1":
+            ordered += ordered
+        b.wait_collected_text("#containers-images table > tbody th:nth-child(2)", ordered)
+
         # prepare image ids - much easier to pick a specific container
         images = {}
         for image in self.execute(auth, "podman images --noheading --no-trunc").strip().split("\n"):
@@ -172,6 +179,14 @@ class TestApplication(testlib.MachineCase):
             b.click('#containers-containers tbody tr:contains("swamped-crate-system") td.listing-ct-toggle')
             b.wait_present('#containers-containers tbody tr:contains("swamped-crate-system") + tr button.btn-delete')
 
+        # Checked order of containers
+        if m.image == 'rhel-8-1':
+            b.wait_collected_text("#containers-containers table > tbody th:nth-child(2)", "swamped-crate-systemtest-sh-system")
+        elif auth:
+            b.wait_collected_text("#containers-containers table > tbody th:nth-child(2)", "swamped-crate-usertest-sh-userswamped-crate-systemtest-sh-system")
+        else:
+            b.wait_collected_text("#containers-containers table > tbody th:nth-child(2)", "swamped-crate-usertest-sh-user")
+
         # show running container
         self.filter_containers('running')
         if auth:
@@ -235,11 +250,19 @@ class TestApplication(testlib.MachineCase):
         if auth:
             self.execute(True, "podman run -d --name test-sh alpine sh")
             container_commit("test-sh")
+            ordered = common + "localhost/testimg:testtag"
+            if m.image != "rhel-8-1":
+                ordered = common + ordered
+            b.wait_collected_text("#containers-images table > tbody th:nth-child(2)", ordered)
             self.execute(True, "podman rm -f test-sh; podman rmi testimg:testtag")
 
         if m.image != "rhel-8-1":
             self.execute(False, "podman run -d --name test-sh alpine sh")
             container_commit("test-sh", owner="admin")
+            ordered = common + "localhost/testimg:testtag"
+            if auth:
+                ordered += common
+            b.wait_collected_text("#containers-images table > tbody th:nth-child(2)", ordered)
             self.execute(False, "podman rm -f test-sh; podman rmi testimg:testtag")
 
         # test commit of a running container
@@ -298,6 +321,20 @@ class TestApplication(testlib.MachineCase):
         b.click(".modal-dialog div #btn-img-deleteerror")
         b.wait_not_present("modal-dialog div #btn-img-deleteerror")
         b.wait_not_in_text("#containers-images", alpine_sel)
+
+        b.wait_collected_text("#containers-containers table > tbody th:nth-child(2)", "")
+        self.execute(auth, "podman run -d --name c registry:2 sh")
+        b.wait_collected_text("#containers-containers table > tbody th:nth-child(2)", "c")
+        self.execute(auth, "podman run -d --name a registry:2 sh")
+        b.wait_collected_text("#containers-containers table > tbody th:nth-child(2)", "ac")
+        if m.image != "rhel-8-1":
+            self.execute(False, "podman run -d --name b registry:2 sh")
+            if auth:
+                b.wait_collected_text("#containers-containers table > tbody th:nth-child(2)", "bac")
+                self.execute(False, "podman run -d --name d registry:2 sh")
+                b.wait_collected_text("#containers-containers table > tbody th:nth-child(2)", "bdac")
+            else:
+                b.wait_collected_text("#containers-containers table > tbody th:nth-child(2)", "abc")
 
     def testDownloadImage(self):
         b = self.browser


### PR DESCRIPTION
Both images and containers need to be grouped by the user. And each
group needs to be ordered by names.
Before this commit, if you would create new container or download a new
image, it would be appended at the bottom of the list. Also there was no
given order of which group (if system or user) would be first.

I decided to show user images above system ones and the same with
containers.

Fixes #222