### PR TITLE
Fix default and minimum value for CPU Shares

### DIFF
--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -205,7 +205,7 @@ export class ImageRunModal extends React.Component {
             publish: [],
             image: props.image,
             memory: 512,
-            cpuShares: 0,
+            cpuShares: "",
             memoryConfigure: false,
             cpuSharesConfigure: false,
             memoryUnit: 'MiB',
@@ -230,7 +230,7 @@ export class ImageRunModal extends React.Component {
             const memorySize = this.state.memory * (1024 ** units[this.state.memoryUnit].base1024Exponent);
             createConfig.memory = memorySize.toString();
         }
-        if (this.state.cpuSharesConfigure) {
+        if (this.state.cpuSharesConfigure && this.state.cpuShares !== "") {
             createConfig.cpuShares = this.state.cpuShares;
         }
         if (this.state.hasTTY)
@@ -352,9 +352,9 @@ export class ImageRunModal extends React.Component {
                                    type='number'
                                    value={dialogValues.cpuShares}
                                    step={1}
-                                   min={0}
+                                   min={2}
                                    disabled={!this.state.cpuSharesConfigure}
-                                   onChange={e => this.onValueChanged('cpuShares', parseInt(e.target.value))} />
+                                   onChange={e => this.onValueChanged('cpuShares', e.target.value === "" ? "" : parseInt(e.target.value))} />
                         </div>
                     </>
                 }

--- a/test/check-application
+++ b/test/check-application
@@ -710,7 +710,7 @@ class TestApplication(testlib.MachineCase):
         if auth:
             b.set_checked("#run-image-dialog-cpu-priority-checkbox", True)
             b.wait_present("#run-image-dialog-cpu-priority-checkbox:checked")
-            b.wait_present('div.modal-body label:contains("CPU Shares") + div.form-inline > input[value="0"]')
+            b.wait_present('div.modal-body label:contains("CPU Shares") + div.form-inline > input[value=""]')
             b.set_input_text("#run-image-dialog-cpu-priority input.form-control", "512")
         else:
             b.wait_not_present("#run-image-dialog-cpu-priority-checkbox")


### PR DESCRIPTION
Minimum value is 2.
Default value is 1024. We still test that if we don't set it up, it is
0, but for that see https://github.com/containers/libpod/issues/4822

Fixes #287