### PR TITLE
lib: Sync up with current Cockpit master

### DIFF
--- a/lib/cockpit-components-listing.jsx
+++ b/lib/cockpit-components-listing.jsx
@@ -171,7 +171,7 @@ export class ListingRow extends React.Component {
         let expandToggle;
         if (allowExpand) {
             expandToggle = <td key="expandToggle" className="listing-ct-toggle" onClick={ allowNavigate ? this.handleExpandClick : undefined }>
-                <i className="fa fa-fw" />
+                <button className="pf-c-button pf-m-plain" type="button" aria-label="expand row"><i className="fa fa-fw" /></button>
             </td>;
         } else {
             expandToggle = <td key="expandToggle-empty" className="listing-ct-toggle" />;
@@ -257,9 +257,14 @@ export class ListingRow extends React.Component {
 
             let simpleBody, heading;
             if ('simpleBody' in this.props) {
-                simpleBody = (
-                    <div className="listing-ct-body" key="simplebody">{this.props.simpleBody}</div>
-                );
+                heading =
+                    <div className="listing-ct-actions listing-ct-simplebody-actions">
+                        {this.props.listingActions}
+                    </div>;
+                simpleBody =
+                    <div className="listing-ct-body" key="simplebody">
+                        {this.props.simpleBody}
+                    </div>;
             } else {
                 heading = (<div className="listing-ct-head">
                     <div className="listing-ct-actions">
@@ -318,7 +323,7 @@ ListingRow.propTypes = {
     simpleBody: PropTypes.node,
 };
 /* Implements a PatternFly 'List View' pattern
- * https://www.patternfly.org/list-view/
+ * https://www.patternfly.org/v3/pattern-library/content-views/list-view/index.html
  * Properties (all optional):
  * - title
  * - fullWidth: set width to 100% of parent, defaults to true
@@ -368,7 +373,7 @@ export const Listing = (props) => {
     return (
         <section className="ct-listing">
             {heading}
-            <table aria-labelledby="listing-ct-heading" className={ bodyClasses.join(" ") }>
+            <table aria-labelledby={heading && "listing-ct-heading"} className={ bodyClasses.join(" ") }>
                 <thead className={headerClasses}>
                     {headerRow}
                 </thead>

--- a/lib/listing.less
+++ b/lib/listing.less
@@ -22,6 +22,10 @@
     + .ct-listing {
         margin-top: 1rem;
     }
+
+    select, .btn, .dropdown, input {
+        font-size: var(--pf-global--FontSize--md);
+    }
 }
 
 .listing-ct-heading,
@@ -29,7 +33,8 @@
     margin: 0.5rem 0;
 }
 
-.listing-ct-heading {
+.listing-ct-heading,
+.listing-ct-simplebody-actions {
     flex: auto;
     padding: 0.25rem 1em 0.25rem 0;
 }
@@ -118,6 +123,7 @@ tbody.open > tr.listing-ct-item th {
 
 tbody.open td div.listing-ct-head {
     background-color: @color-pf-white;
+    align-items: end;
 }
 
 tbody.open > .listing-ct-panel > td > .listing-ct-body {
@@ -132,6 +138,7 @@ tbody.open > tr.listing-ct-panel + tr.listing-ct-body {
 tbody.open > tr.listing-ct-panel td div.listing-ct-head {
     border: none;
     border-bottom: 1px solid @listing-ct-border;
+    padding-top: 0;
 }
 
 /* only highlight the row if navigation is available */
@@ -171,6 +178,19 @@ tbody.open .listing-ct-toggle {
 .listing-ct-item > .listing-ct-toggle + th {
     padding-left: @listing-ct-padding / 2;
     position: relative;
+}
+
+td.listing-ct-toggle button {
+    border: 1px solid transparent;
+}
+
+td.listing-ct-toggle button:focus {
+    color: var(--pf-global--Color--100) !important;
+    border-color: var(--pf-global--BackgroundColor--light-300) !important;
+    @-moz-document url-prefix() {
+      /* Approximate Firefox's focus ring, for Firefox only */
+      border: 1px dotted rgba(0, 0, 0, 0.75);
+    }
 }
 
 td.listing-ct-toggle i {
@@ -249,7 +269,7 @@ tr.listing-ct-item.listing-ct-selected .badge {
 }
 
 .listing-ct-head .listing-ct-actions {
-    margin-top: -7px;
+    margin: 0.25rem 0;
     order: -1;
 }
 
@@ -320,7 +340,7 @@ tbody.active .listing-ct-head {
 
 .listing-ct-head .nav-tabs-pf {
     /* Counteract listing-ct-head padding */
-    margin: -@listing-ct-padding 0 0 -@listing-ct-padding;
+    margin: 0 0 0 -@listing-ct-padding;
     flex: auto;
 }
 
@@ -619,10 +639,10 @@ tbody tr.listing-ct-noexpand {
     left: 0px;
 }
 
-/* Force word-wraps when words are too long */
 .listing-ct-item td,
 .listing-ct-item th,
 .listing-ct-body {
+    /* Force wraps when words are too long */
     overflow-wrap: break-word;
     hyphens: auto;
 }

--- a/lib/page.css
+++ b/lib/page.css
@@ -1,3 +1,5 @@
+@import "../node_modules/@patternfly/react-styles/css/patternfly-variables.css";
+
 a {
     cursor: pointer;
 }
@@ -525,6 +527,8 @@ input[type=number] {
     --color-table-text                : #393f44;
 }
 
+[hidden] { display: none !important; }
+
 /*** PF4 overrides (when a mix of PF3 + PF4 is used at the same time) ***/
 
 /* WORKAROUND: Override word-break bug */
@@ -532,4 +536,17 @@ input[type=number] {
 .pf-c-table td {
     word-break: normal;
     overflow-wrap: break-word;
+}
+
+/* Fix alignment for icons inside of dropdown toggle (& split) buttons */
+/* Part 1 of 2 */
+.pf-c-dropdown__toggle {
+  align-items: stretch;
+  /* PF4 uses align-items: center here; stretch (the default) is what we need. */
+}
+
+/* Align the icons inside of the toggle. Part 2 of 2 */
+.pf-c-dropdown__toggle-button {
+  display: flex;
+  align-items: center;
 }


### PR DESCRIPTION
The obvious difference is that items in listing are taller (have more padding):
![taller](https://user-images.githubusercontent.com/12330670/73658776-3ca8fa80-4695-11ea-9663-56b76f2e7ad5.png)
