### PR TITLE
logs: When resetting the view, hide the cursor again

### DIFF
--- a/src/ContainerLogs.jsx
+++ b/src/ContainerLogs.jsx
@@ -132,6 +132,7 @@ class ContainerLogs extends React.Component {
                     .join(" "));
             if (this.state.loading) {
                 this.state.view.reset();
+                this.state.view._core.cursorHidden = true;
                 this.setState({ loading: false });
             }
             this.state.view.write(just_logs.join(""));


### PR DESCRIPTION
Seems that `reset()` displays the cursor again.