### PR TITLE
lib: Import patternfly-variables.css from main module

### DIFF
--- a/lib/page.css
+++ b/lib/page.css
@@ -1,4 +1,4 @@
-@import "../node_modules/@patternfly/react-styles/css/patternfly-variables.css";
+@import "../node_modules/@patternfly/patternfly/patternfly-variables.css";
 
 a {
     cursor: pointer;


### PR DESCRIPTION
@patternfly/react-styles 3.7 stopped shipping a copy of
patternfly-variables.css. Import it from @patternfly/patternfly instead.
package.json explicitly depends on the latter, but not on the former, so
we don't have control over react-styles.

The file is identical to the one from @patternfly/react-styles 3.6.4
(the version which we used until yesterday).

Cherry-picked from cockpit-project/cockpit from 4ace78c