### PR TITLE
test: Clean up unexpected system podman images

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -17,6 +17,10 @@ if type firewall-cmd >/dev/null 2>&1; then
     firewall-cmd --add-service=cockpit --permanent
 fi
 
+# clean up cockpit/base and fedora images from cockpit's fedora-* VMs
+podman images -aq cockpit/base | xargs --no-run-if-empty podman rmi
+podman images -aq fedora:* | xargs --no-run-if-empty podman rmi
+
 # grab a few images to play with; tests run offline, so they cannot download images
 podman pull busybox
 podman pull docker.io/alpine


### PR DESCRIPTION
fedora-* ≥ 31 images start to have a cockpit/base and its parent fedora
container image in <https://github.com/cockpit-project/bots/pull/562>.
Our tests don't expect that. Keep the test strict (as we want to check
precise ordering) and remove the unexpected images instead.