### PR TITLE
test: Fix testRunImageSystem for podman 1.8

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -827,7 +827,8 @@ class TestApplication(testlib.MachineCase):
         # Rootless only works with CGroupsV2
         if auth or m.image not in ["rhel-8-2"]:
             cpuShares = self.execute(auth, "podman inspect --format '{{.HostConfig.CpuShares}}' busybox-without-publish").strip()
-            self.assertEqual(cpuShares, '0')
+            # podman ≥ 1.8 translates 0 default into actual value
+            self.assertIn(cpuShares, ['0', '1024'])
 
         b.set_val("#containers-containers-filter", "all")
 


### PR DESCRIPTION
With https://github.com/containers/libpod/commit/c1e269 the default CPU
share now gets displayed as 1024 instead of 0.