### PR TITLE
test: Specify registry for busybox

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -18,12 +18,12 @@ if type firewall-cmd >/dev/null 2>&1; then
 fi
 
 # grab a few images to play with; tests run offline, so they cannot download images
-podman pull busybox
+podman pull docker.io/busybox
 podman pull docker.io/alpine
 podman pull docker.io/registry:2
 
 sudo -i -u admin bash << EOF
-podman pull busybox
+podman pull docker.io/busybox
 podman pull docker.io/alpine
 podman pull docker.io/registry:2
 EOF


### PR DESCRIPTION
Just like with the other two images, explicitly pull busybox from the
docker.io registry. This avoids unnecessary lookups to, and possibly
getting a different image from e. g. the Fedora registry. Latest skopeo
also seems to either disallow (deliberately) or break (inadvertently)
lookups without a registry.