### PR TITLE
Only use "System service" when user is root

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -120,16 +120,6 @@ class Application extends React.Component {
         });
     }
 
-    updateServicesAvailable (system, newValue) {
-        const service = system ? "systemServiceAvailable" : "userServiceAvailable";
-        let value = newValue;
-        if (service === "userServiceAvailable" && utils.isRootUser()) {
-            value = false;
-        }
-
-        this.setState({ [service]: value });
-    }
-
     updateContainerStats(id, system) {
         utils.podmanCall("GetContainerStats", { name: id }, system)
                 .then(reply => {
@@ -305,8 +295,7 @@ class Application extends React.Component {
     init(system) {
         utils.podmanCall("GetVersion", {}, system)
                 .then(reply => {
-                    this.setState({ version: reply.version });
-                    this.updateServicesAvailable(system, true);
+                    this.setState({ [system ? "systemServiceAvailable" : "userServiceAvailable"]: true, version: reply.version });
                     this.updateImagesAfterEvent(system);
                     this.updateContainersAfterEvent(system);
                     utils.monitor("GetEvents", {},

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -120,6 +120,16 @@ class Application extends React.Component {
         });
     }
 
+    updateServicesAvailable (system, newValue) {
+        const service = system ? "systemServiceAvailable" : "userServiceAvailable";
+        let value = newValue;
+        if (service === "userServiceAvailable" && utils.isRootUser()) {
+            value = false;
+        }
+
+        this.setState({ [service]: value });
+    }
+
     updateContainerStats(id, system) {
         utils.podmanCall("GetContainerStats", { name: id }, system)
                 .then(reply => {

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -178,6 +178,7 @@ class Application extends React.Component {
                         // Copy only images that could not be deleted with this event
                         // So when event from system come, only copy user images and vice versa
                         const copyImages = {};
+                        console.log(prevState, reply);
                         Object.entries(prevState.images || {}).forEach(([id, image]) => {
                             if (image.isSystem !== system)
                                 copyImages[id] = image;
@@ -304,7 +305,8 @@ class Application extends React.Component {
     init(system) {
         utils.podmanCall("GetVersion", {}, system)
                 .then(reply => {
-                    this.setState({ [system ? "systemServiceAvailable" : "userServiceAvailable"]: true, version: reply.version });
+                    this.setState({ version: reply.version });
+                    this.updateServicesAvailable(system, true);
                     this.updateImagesAfterEvent(system);
                     this.updateContainersAfterEvent(system);
                     utils.monitor("GetEvents", {},

--- a/src/util.js
+++ b/src/util.js
@@ -268,3 +268,9 @@ export function compare_versions(a, b) {
 
     return a_ints.length - b_ints.length;
 }
+
+export function isRootUser() {
+    return window.cockpit.user().then((user) => {
+        return user.name === 'root';
+    });
+};

--- a/src/util.js
+++ b/src/util.js
@@ -273,4 +273,4 @@ export function isRootUser() {
     return window.cockpit.user().then((user) => {
         return user.name === 'root';
     });
-};
+}


### PR DESCRIPTION
When the user is `root` it will show images and containers twice. In such a case the "system service" can be skipped and avoid lists with duplicate items.

**Before:**
![Screenshot 2020-05-05 at 13 58 18](https://user-images.githubusercontent.com/7757/81063642-8691be80-8ed8-11ea-8058-9790052bbbe1.png)

**After:**
![Screenshot 2020-05-05 at 13 57 28](https://user-images.githubusercontent.com/7757/81063653-898caf00-8ed8-11ea-8176-dc80550276af.png)