### PR TITLE
test: RHEL-8.2 has sufficent podman version now

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -241,7 +241,7 @@ class TestApplication(testlib.MachineCase):
             toggle_sel = '#containers-images tbody tr:contains("{0}:{1}") td.listing-ct-toggle'.format(image_name, image_tag)
             b.click(toggle_sel)
             b.wait_present('#containers-images tbody tr:contains("{0}:{1}"):has(dd:contains("localhost/{0}:{1}"))'.format(image_name, image_tag))
-            if m.image in ["rhel-8-2", "rhel-8-3"]: # podman < 1.7 quotes command
+            if m.image in ["rhel-8-3"]: # podman < 1.7 quotes command
                 image_command = image_command.replace(r'\"', r'\\\"')
                 image_command = image_command.replace(r' "', r' \"')
             b.wait_in_text('#containers-images tbody tr:contains("{0}:{1}") dd:nth-child(8)'.format(image_name, image_tag), image_command)


### PR DESCRIPTION
Should fix https://github.com/cockpit-project/bots/pull/826

It is gonna be a bit tricky to get tests green, so I will do:
1. trigger all tests + `rhel-8-2@bots#826`
2. If passed merge the bots PR
3. re-test this