### PR TITLE
Update vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure(2) do |config|
-    config.vm.box = "fedora/28-cloud-base"
+    config.vm.box = "fedora/32-cloud-base"
     config.vm.network "forwarded_port", guest: 9090, host: 9090
 
     if Dir.glob("dist/*").length == 0

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure(2) do |config|
         systemctl enable cockpit.socket
         systemctl start cockpit.socket
 
-        systemctl enable io.podman.{socket,service}
-        systemctl start io.podman.{socket,service}
+        systemctl enable io.podman.socket
+        systemctl start io.podman.socket
     EOF
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,11 +20,14 @@ Vagrant.configure(2) do |config|
     config.vm.provision "shell", inline: <<-EOF
         set -eu
 
-        sudo dnf install -y cockpit
+        sudo dnf install -y cockpit podman
 
         printf "[WebService]\nAllowUnencrypted=true\n" > /etc/cockpit/cockpit.conf
 
         systemctl enable cockpit.socket
         systemctl start cockpit.socket
+
+        systemctl enable io.podman.{socket,service}
+        systemctl start io.podman.{socket,service}
     EOF
 end


### PR DESCRIPTION
Fedora 28 is not available anymore as box this bumps it to the latest version 32.
It also adds `podman` as package to install for convenience.