### PR TITLE
test: Adjust to new services page

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -575,7 +575,7 @@ class TestApplication(testlib.MachineCase):
         # Troubleshoot action
         b.click("#app .pf-c-empty-state button.pf-m-link")
         b.enter_page("/system/services")
-        b.wait_in_text("#service", "io.podman.socket")
+        b.wait_in_text("#service-details", "io.podman.socket")
 
         # Start action, with enabling (by default)
         b.go("/podman")


### PR DESCRIPTION
Both old and new services page has `#service-details`.

As found in #381 and #382