### PR TITLE
test: Drop rhel-8-3 special case for podman < 1.7

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -241,9 +241,6 @@ class TestApplication(testlib.MachineCase):
             toggle_sel = '#containers-images tbody tr:contains("{0}:{1}") td.listing-ct-toggle'.format(image_name, image_tag)
             b.click(toggle_sel)
             b.wait_present('#containers-images tbody tr:contains("{0}:{1}"):has(dd:contains("localhost/{0}:{1}"))'.format(image_name, image_tag))
-            if m.image in ["rhel-8-3"]: # podman < 1.7 quotes command
-                image_command = image_command.replace(r'\"', r'\\\"')
-                image_command = image_command.replace(r' "', r' \"')
             b.wait_in_text('#containers-images tbody tr:contains("{0}:{1}") dd:nth-child(8)'.format(image_name, image_tag), image_command)
             b.wait_present('#containers-images tbody tr:contains("{0}:{1}"):has(dd:contains({2}))'.format(image_name, image_tag, image_author))
             # close listing toggle again


### PR DESCRIPTION
RHEL 8.3 nightly has podman 1.9 now.