### PR TITLE
Remove explicit import of font-awesome/variables from patternfly-cock…

### DIFF
--- a/lib/patternfly/patternfly-cockpit.scss
+++ b/lib/patternfly/patternfly-cockpit.scss
@@ -6,7 +6,6 @@ $icon-font-path: 'patternfly-icons-fake-path/';
 $font-path: 'patternfly-fonts-fake-path/';
 
 @import "./patternfly-overrides-variables";
-@import "~font-awesome-sass/assets/stylesheets/font-awesome/variables";
 @import "~patternfly/dist/sass/patternfly";
 @import "./patternfly-4-cockpit.scss";
 @import "./patternfly-overrides.scss";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,6 +99,9 @@ if (production) {
 module.exports = {
     mode: production ? 'production' : 'development',
     entry: info.entries,
+    resolve: {
+        alias: { 'font-awesome': path.resolve(nodedir, 'font-awesome-sass/assets/stylesheets') },
+    },
     externals: externals,
     output: output,
     devtool: "source-map",
@@ -155,7 +158,7 @@ module.exports = {
                                     replace: 'src:url("../base1/fonts/patternfly.woff") format("woff");',
                                 },
                                 {
-                                    search: /src:url[(]"\.\.\/fonts\/fontawesome[^}]*/,
+                                    search: /src:url[(]"patternfly-fonts-fake-path\/fontawesome[^}]*/,
                                     replace: 'font-display:block; src:url("../base1/fonts/fontawesome.woff?v=4.2.0") format("woff");',
                                 },
                                 {


### PR DESCRIPTION
…pit.scss

This import is normally done inside patternfly scss code.

There are however two npm modules from font-awesome,
* font-awesome
* font-awesome-sass

Since we are compiling patternfly from sass we are interested in
the second, but sadly patternfly is doing just:

@import 'font-awesome`

Which results in the import of the non sass module and gives a lot of
errors about missing variables if we don't explicitely import
font-awesome variables as we did until now.

Instead resolve.alias in webpack config to make sure we always resolve
the correct font-awesome module in the imports and drop the explicit
fa variable declaration.

Lastly this enables as to use the font-path variable from PF to
construct the FontAwesome path.