### PR TITLE
Fix spelling

### DIFF
--- a/lib/page.css
+++ b/lib/page.css
@@ -223,7 +223,7 @@ input[type=number] {
 }
 
 @-moz-document url-prefix() {
-    /* Accomodate Firefox styling selects with slightly different padding. */
+    /* Accommodate Firefox styling selects with slightly different padding. */
     .ct-select {
         padding-left: 0.25em;
     }

--- a/lib/patternfly/patternfly-4-cockpit.scss
+++ b/lib/patternfly/patternfly-4-cockpit.scss
@@ -2,7 +2,7 @@
  * Keep in sync with https://github.com/cockpit-project/cockpit/tree/master/src/base1/patternfly-4-cockpit.scss
  */
 
-/* Set fake font and icon path variables - we are going to indentify these through
+/* Set fake font and icon path variables - we are going to identify these through
  * patternfly.sed and remove the relevant font-face declarations
  */
 $pf-global--font-path: 'patternfly-fonts-fake-path';

--- a/lib/patternfly/patternfly-overrides.scss
+++ b/lib/patternfly/patternfly-overrides.scss
@@ -168,7 +168,7 @@ select.form-control {
         height: 100%;
       }
 
-      // Shave off the border and padding, as these misalign the elemnt
+      // Shave off the border and padding, as these misalign the element
       // (as this widget uses inline styles (ugh!), we _have to_ use !important)
       > input {
         border-width: 0 1px !important;

--- a/src/ImageSearchModal.css
+++ b/src/ImageSearchModal.css
@@ -100,7 +100,7 @@
 }
 
 @media (max-width: 340px) {
-    /* Shrink buttons to accomodate iPhone 5/SE */
+    /* Shrink buttons to accommodate iPhone 5/SE */
     .podman-search .modal-footer > .btn {
         padding-left: 0.25rem;
         padding-right: 0.25rem;

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -249,7 +249,7 @@ class Application extends React.Component {
         case 'import':
         case 'init':
         case 'wait':
-        case 'restart': // We get seperate died-init-start events after the restart event
+        case 'restart': // We get separate died-init-start events after the restart event
             break;
         /* The following events need only to update the Container list
          * We do get the container affected in the event object but for

--- a/src/podman.scss
+++ b/src/podman.scss
@@ -31,7 +31,7 @@
 }
 
 /*
- * Used to make a table cell that containts buttons have less padding
+ * Used to make a table cell that contains buttons have less padding
  * HACK: Because CSS has no parant selector.
  */
 .cell-buttons,


### PR DESCRIPTION
I ran codespell across cockpit-podman and it found these errors. Some of these are probably fixed in Cockpit itself, so a sync up would fix a bunch anyway.

(There were a few with "master" as well, but those are all URLs to git repos.)