### PR TITLE
Arrange container and image details in a grid

### DIFF
--- a/src/podman.scss
+++ b/src/podman.scss
@@ -635,3 +635,23 @@ table.drive-list td:nth-child(2) img {
 .pf-c-alert__description {
     overflow-wrap: anywhere;
 }
+
+/* Place details definition list into a grid, with PF4-like style */
+.container-details,
+.image-details {
+    display: grid;
+    grid-template-columns: [label] auto [value] 1fr;
+    grid-gap: var(--pf-global--spacer--sm) var(--pf-global--spacer--lg);
+    align-items: baseline;
+    justify-content: left;
+
+    > dt {
+        grid-column: label;
+        font-size: var(--pf-global--FontSize--sm);
+    }
+
+    > dd {
+        grid-column: value;
+        font-size: var(--pf-global--FontSize--md);
+    }
+}


### PR DESCRIPTION
When reviewing #244, I noticed the details for the containers and images are in a simple definition list. I've added a bit of CSS that uses PF4 variables to arrange the same content in a simple grid, consistent with the look of PF4's forms. (This isn't a form, so it shouldn't use `<label>`s and various form widgets. A `dl` is fine.)