### PR TITLE
metainfo: Fix launchable and update description

### DIFF
--- a/org.cockpit-project.podman.metainfo.xml
+++ b/org.cockpit-project.podman.metainfo.xml
@@ -2,9 +2,9 @@
 <component type="addon">
   <id>org.cockpit_project.podman</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <name>Cockpit Podman</name>
+  <name>Podman</name>
   <summary>
-    Cockpit component for Podman containers.
+    Cockpit component for Podman containers
   </summary>
   <description>
     <p>
@@ -12,5 +12,5 @@
     </p>
   </description>
   <extends>org.cockpit_project.cockpit</extends>
-  <launchable type="cockpit-manifest">cockpit-podman</launchable>
+  <launchable type="cockpit-manifest">podman</launchable>
 </component>


### PR DESCRIPTION
`<launchable>` must coincide with the actual URL path defined by the
manifest.

Also remove the redundant "Cockpit" from `<name>`, as all of these
extensions are about Cockpit. This makes the "Applications" page more
consistent.

Remove the period from `<summary>`, as the spec [1] suggests.

[1] https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#sect-Metadata-GenericComponent

https://bugzilla.redhat.com/show_bug.cgi?id=1854673