### PR TITLE
Support local checkpoint and restore

### DIFF
--- a/src/ContainerCheckpointModal.jsx
+++ b/src/ContainerCheckpointModal.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Modal } from 'patternfly-react';
+import { Button, Checkbox } from '@patternfly/react-core';
+import cockpit from 'cockpit';
+import * as utils from './util.js';
+
+const _ = cockpit.gettext;
+
+class ContainerCheckpointModal extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            keep: false,
+            leaveRunning: false,
+            tcpEstablished: false,
+            ignoreRootFS: false
+        };
+        this.handleChange = this.handleChange.bind(this);
+    }
+
+    handleChange(checked, event) {
+        if (event.target.type === "checkbox")
+            this.setState({ [event.target.name]: event.target.checked });
+    }
+
+    render() {
+        return (
+            <Modal show={this.props.selectContainerCheckpointModal}>
+                <Modal.Header>
+                    <Modal.Title>
+                        {cockpit.format(_("Checkpoint container $0"),
+                                        utils.truncate_id(this.props.containerWillCheckpoint.Id))}
+                    </Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <div className="ct-form">
+                        <Checkbox label={_("Keep all temporary checkpoint files")} id="checkpoint-dialog-keep"
+                                  name="keep" isChecked={this.state.keep} onChange={this.handleChange} />
+                        <Checkbox label={_("Leave running after writing checkpoint to disk")}
+                                  id="checkpoint-dialog-leaveRunning" name="leaveRunning"
+                                  isChecked={this.state.leaveRunning} onChange={this.handleChange} />
+                        <Checkbox label={_("Support preserving established TCP connections")}
+                                  id="checkpoint-dialog-tcpEstablished" name="tcpEstablished"
+                                  isChecked={this.state.tcpEstablished} onChange={this.handleChange} />
+                        <Checkbox label={_("Do not include root file-system changes when exporting")}
+                                  id="checkpoint-dialog-ignoreRootFS" name="ignoreRootFS"
+                                  isChecked={this.state.ignoreRootFS} onChange={this.handleChange} />
+                    </div>
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button variant="primary" isDisabled={this.props.checkpointInProgress}
+                            onClick={() => this.props.handleCheckpointContainer(this.state)}>
+                        {_("Checkpoint")}
+                    </Button>
+                    <Button variant="link" onClick={this.props.handleCheckpointContainerDeleteModal}>
+                        {_("Cancel")}
+                    </Button>
+                    {this.props.checkpointInProgress && <div className="spinner spinner-sm pull-right" />}
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+}
+
+export default ContainerCheckpointModal;

--- a/src/ContainerRestoreModal.jsx
+++ b/src/ContainerRestoreModal.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Modal } from 'patternfly-react';
+import { Button, Checkbox } from '@patternfly/react-core';
+import cockpit from 'cockpit';
+import * as utils from './util.js';
+
+const _ = cockpit.gettext;
+
+class ContainerRestoreModal extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            keep: false,
+            tcpEstablished: false,
+            ignoreRootFS: false,
+            ignoreStaticIP: false,
+            ignoreStaticMAC: false
+        };
+        this.handleChange = this.handleChange.bind(this);
+    }
+
+    handleChange(checked, event) {
+        if (event.target.type === "checkbox")
+            this.setState({ [event.target.name]: event.target.checked });
+    }
+
+    render() {
+        return (
+            <Modal show={this.props.selectContainerRestoreModal}>
+                <Modal.Header>
+                    <Modal.Title>
+                        {cockpit.format(_("Restore container $0"),
+                                        utils.truncate_id(this.props.containerWillCheckpoint.Id))}
+                    </Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <div className="ct-form">
+                        <Checkbox label={_("Keep all temporary checkpoint files")} id="restore-dialog-keep" name="keep"
+                                  isChecked={this.state.keep} onChange={this.handleChange} />
+                        <Checkbox label={_("Restore with established TCP connections")}
+                                  id="restore-dialog-tcpEstablished" name="tcpEstablished"
+                                  isChecked={this.state.tcpEstablished} onChange={this.handleChange} />
+                        <Checkbox label={_("Ignore IP address if set statically")} id="restore-dialog-ignoreStaticIP"
+                                  name="ignoreStaticIP" isChecked={this.state.ignoreStaticIP}
+                                  onChange={this.handleChange} />
+                        <Checkbox label={_("Ignore MAC address if set statically")} id="restore-dialog-ignoreStaticMAC"
+                                  name="ignoreStaticMAC" isChecked={this.state.ignoreStaticMAC}
+                                  onChange={this.handleChange} />
+                    </div>
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button variant="primary" isDisabled={this.props.restoreInProgress}
+                            onClick={() => this.props.handleRestoreContainer(this.state)}>
+                        {_("Restore")}
+                    </Button>
+                    <Button variant="link" onClick={this.props.handleRestoreContainerDeleteModal}>
+                        {_("Cancel")}
+                    </Button>
+                    {this.props.restoreInProgress && <div className="spinner spinner-sm pull-right" />}
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+}
+
+export default ContainerRestoreModal;

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -143,8 +143,28 @@ class Application extends React.Component {
                 .catch(e => console.log(e));
     }
 
+    isContainerCheckpointPresent(id, system) {
+        return client.inspectContainer(system, id)
+                .then(inspectResult => {
+                    const checkpointPath = inspectResult.StaticDir + "/checkpoint";
+                    return cockpit.script(`test -d ${checkpointPath}; echo $?`, [],
+                                          system ? { superuser: "require" } : {});
+                })
+                .then(scriptResult => scriptResult === "0\n");
+    }
+
     updateContainersAfterEvent(system, init) {
         client.getContainers(system)
+                .then(reply => Promise.all(
+                    (reply || []).map(container =>
+                        this.isContainerCheckpointPresent(container.Id, system)
+                                .then(checkpointPresent => {
+                                    const newContainer = Object.assign({}, container);
+                                    newContainer.hasCheckpoint = checkpointPresent;
+                                    return newContainer;
+                                })
+                    )
+                ))
                 .then(reply => {
                     this.setState(prevState => {
                         // Copy only containers that could not be deleted with this event
@@ -204,6 +224,16 @@ class Application extends React.Component {
 
     updateContainerAfterEvent(id, system) {
         client.getContainers(system, id)
+                .then(reply => Promise.all(
+                    (reply || []).map(container =>
+                        this.isContainerCheckpointPresent(container.Id, system)
+                                .then(checkpointPresent => {
+                                    const newContainer = Object.assign({}, container);
+                                    newContainer.hasCheckpoint = checkpointPresent;
+                                    return newContainer;
+                                })
+                    )
+                ))
                 .then(reply => {
                     if (reply && reply.length > 0) {
                         reply = reply[0];

--- a/test/check-application
+++ b/test/check-application
@@ -34,7 +34,6 @@ def checkImage(browser, name, owner):
         return false;
         })""", name, owner)
 
-@testlib.nondestructive
 class TestApplication(testlib.MachineCase):
 
     def setUp(self):
@@ -76,9 +75,11 @@ class TestApplication(testlib.MachineCase):
         else:
             return self.admin_s.execute(cmd)
 
+    @testlib.nondestructive
     def testBasicSystem(self):
         self._testBasic(True)
 
+    @testlib.nondestructive
     def testBasicUser(self):
         self._testBasic(False)
 
@@ -375,6 +376,7 @@ class TestApplication(testlib.MachineCase):
             # There should not be any duplicate images listed
             b.wait_js_func("ph_count_check", "#containers-images tbody", 3)
 
+    @testlib.nondestructive
     def testDownloadImage(self):
         b = self.browser
         m = self.machine
@@ -513,9 +515,11 @@ class TestApplication(testlib.MachineCase):
               .selectImageAndDownload() \
               .expectDownloadErrorForNonExistingTag()
 
+    @testlib.nondestructive
     def testLifecycleOperationsUser(self):
         self._testLifecycleOperations(False)
 
+    @testlib.nondestructive
     def testLifecycleOperationsSystem(self):
         self._testLifecycleOperations(True)
 
@@ -538,6 +542,11 @@ class TestApplication(testlib.MachineCase):
         b.wait_present("#containers-containers")
         b.wait_present('#containers-containers tr:contains("swamped-crate")')
         b.click('#containers-containers tbody tr:contains("busybox:latest") td.pf-c-table__toggle button')
+
+        if not auth:
+            # Checkpoint/restore is not supported on user containers yet - the related buttons should not be shown
+            # Check that the restore option is not present (i.e. start is a regular button)
+            b.wait_present('#containers-containers tbody tr:contains("busybox:latest") + tr button.pf-c-button:contains(Start)')
 
         # Start the container
         b.click('#containers-containers tbody tr:contains("busybox:latest") + tr button:contains(Start)')
@@ -589,6 +598,10 @@ class TestApplication(testlib.MachineCase):
         # Stop the container
         b.wait_present('#containers-containers tr:contains("busybox:latest")')
         b.click('#containers-containers tbody tr:contains("busybox:latest") + tr button:contains(Stop) + button')
+        if not auth:
+            # Check that the checkpoint option is not present for rootless
+            b.wait_visible('#containers-containers tr:contains("busybox:latest") + tr a:contains("Force Stop")')
+            b.wait_not_present('#containers-containers tr:contains("busybox:latest") + tr #Stop-dropdown ul li:has(a:contains(Checkpoint))')
         b.click('#containers-containers tbody tr:contains("busybox:latest") + tr ul.pf-c-dropdown__menu li a:contains(Force Stop)')
 
         self.check_container(container_sha, auth, ['swamped-crate', 'busybox:latest', 'sh'])
@@ -596,6 +609,97 @@ class TestApplication(testlib.MachineCase):
         b.wait_text("#containers-containers tbody tr:contains('busybox:latest') > td:nth-child(3)", "")
         b.wait_text("#containers-containers tbody tr:contains('busybox:latest') > td:nth-child(4)", "")
 
+    def testCheckpointRestoreSystem(self):
+        b = self.browser
+        m = self.machine
+
+        # Set machine to cgroup1 and reboot
+        self.execute(True, 'grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"; reboot')
+        m.wait_reboot()
+
+        self.login_and_go("/podman", authorized=True, superuser=True)
+        b.wait_present("#app")
+        self.filter_containers('all')
+
+        # Run a container
+        self.execute(True, "podman run -dit --name swamped-crate busybox sh; podman stop swamped-crate")
+        b.wait(lambda: self.execute(True, "podman ps --all | grep -e swamped-crate -e Exited"))
+        b.click('#containers-containers tbody tr:contains("busybox:latest") td.pf-c-table__toggle button')
+
+        # Check that the restore option is not present (i.e. start is a regular button)
+        b.wait_present('#containers-containers tbody tr:contains("busybox:latest") + tr button.pf-c-button:contains(Start)')
+
+        # Start the container
+        b.click('#containers-containers tbody tr:contains("busybox:latest") + tr button:contains(Start)')
+        b.wait_in_text('#containers-containers tr:contains(swamped-crate)', 'running')
+
+        # Checkpoint the container
+        b.click('#containers-containers tr:contains("busybox:latest") + tr button:contains(Stop) + button')
+        b.click('#containers-containers tr:contains("busybox:latest") + tr #Stop-dropdown ul li:has(a:contains(Checkpoint))')
+        b.set_checked('.modal-dialog input#checkpoint-dialog-keep', True)
+        b.set_checked('.modal-dialog input#checkpoint-dialog-tcpEstablished', True)
+        b.set_checked('.modal-dialog input#checkpoint-dialog-ignoreRootFS', True)
+        b.click('.modal-dialog button:contains(Checkpoint)')
+        b.wait(lambda: b.text('#containers-containers tr:contains(swamped-crate) td:nth-of-type(6)') in ['stopped', 'exited'])
+
+        # Restore the container
+        b.wait_present('#containers-containers tr:contains("busybox:latest")')
+        b.click('#containers-containers tr:contains("busybox:latest") + tr button:contains(Start) + button')
+        b.click('#containers-containers tr:contains("busybox:latest") + tr #Start-dropdown ul li:has(a:contains(Restore))')
+        b.set_checked('.modal-dialog input#restore-dialog-keep', True)
+        b.set_checked('.modal-dialog input#restore-dialog-tcpEstablished', True)
+        b.set_checked('.modal-dialog input#restore-dialog-ignoreStaticIP', True)
+        b.set_checked('.modal-dialog input#restore-dialog-ignoreStaticMAC', True)
+        b.click('.modal-dialog button:contains(Restore)')
+        b.wait(lambda: b.text('#containers-containers tr:contains(swamped-crate) td:nth-of-type(6)') == 'running')
+
+        # Checkpoint the container without stopping
+        b.wait_present('#containers-containers tr:contains("busybox:latest")')
+        b.click('#containers-containers tr:contains("busybox:latest") + tr button:contains(Stop) + button')
+        b.click('#containers-containers tr:contains("busybox:latest") + tr #Stop-dropdown ul li:has(a:contains(Checkpoint))')
+        b.set_checked('.modal-dialog input#checkpoint-dialog-leaveRunning', True)
+        b.click('.modal-dialog button:contains(Checkpoint)')
+        b.wait_not_present('.modal_dialog')
+
+        # Stop the container
+        b.wait_present('#containers-containers tr:contains("busybox:latest")')
+        b.click('#containers-containers tbody tr:contains("busybox:latest") + tr button:contains(Stop) + button')
+        b.click('#containers-containers tbody tr:contains("busybox:latest") + tr ul.pf-c-dropdown__menu li a:contains(Force Stop)')
+        b.wait(lambda: b.text('#containers-containers tr:contains(swamped-crate) td:nth-of-type(6)') in ['stopped', 'exited'])
+
+        # Restore the container
+        b.wait_present('#containers-containers tr:contains("busybox:latest")')
+        b.click('#containers-containers tr:contains("busybox:latest") + tr button:contains(Start) + button')
+        b.click('#containers-containers tr:contains("busybox:latest") + tr #Start-dropdown ul li:has(a:contains(Restore))')
+        b.click('.modal-dialog button:contains(Restore)')
+        b.wait(lambda: b.text('#containers-containers tr:contains(swamped-crate) td:nth-of-type(6)') == 'running')
+
+    @testlib.nondestructive
+    def testCheckpointRestoreSystemCrun(self):
+        # With crun (CgroupsV2) checkpoint doesn't work yet
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/podman", authorized=True, superuser=True)
+        b.wait_present("#app")
+        self.filter_containers('all')
+
+        # Run a container
+        self.execute(True, "podman run -dit --name swamped-crate busybox sh")
+        b.wait(lambda: self.execute(True, "podman ps --all | grep -e swamped-crate"))
+        b.click('#containers-containers tbody tr:contains("busybox:latest") td.pf-c-table__toggle button')
+
+        # Checkpoint the container
+        b.click('#containers-containers tr:contains("busybox:latest") + tr button:contains(Stop) + button')
+        b.click('#containers-containers tr:contains("busybox:latest") + tr #Stop-dropdown ul li:has(a:contains(Checkpoint))')
+        b.set_checked('.modal-dialog input#checkpoint-dialog-keep', True)
+        b.set_checked('.modal-dialog input#checkpoint-dialog-tcpEstablished', True)
+        b.set_checked('.modal-dialog input#checkpoint-dialog-ignoreRootFS', True)
+        b.click('.modal-dialog button:contains(Checkpoint)')
+        b.wait_not_present('.modal_dialog')
+        b.wait_in_text('.pf-c-alert__description', 'Configured runtime does not support checkpoint/restore')
+
+    @testlib.nondestructive
     def testNotRunning(self):
         b = self.browser
         m = self.machine
@@ -710,9 +814,11 @@ class TestApplication(testlib.MachineCase):
         self.allow_authorize_journal_messages()
         self.allow_journal_messages(".*podman/podman.sock/.*: couldn't connect:.*")
 
+    @testlib.nondestructive
     def testRunImageSystem(self):
         self._testRunImage(True)
 
+    @testlib.nondestructive
     def testRunImageUser(self):
         self.allow_authorize_journal_messages()
         self._testRunImage(False)

--- a/test/vm.install
+++ b/test/vm.install
@@ -20,6 +20,7 @@ podman pull docker.io/registry:2
 # pull images for user podman tests; podman insists on user session
 loginctl enable-linger $(id -u admin)
 sudo -i -u admin bash << EOF
+systemctl --user disable --now systemd-tmpfiles-clean.timer
 podman pull docker.io/busybox
 podman pull docker.io/alpine
 podman pull docker.io/registry:2
@@ -33,3 +34,6 @@ rm /usr/libexec/virt-what-cpuid-helper
 
 # HACK: See https://github.com/cockpit-project/cockpit/issues/14133
 mkdir -p /usr/share/cockpit/packagekit
+
+# 15minutes after boot tmp files are removed and podman stores some tmp lock files
+systemctl disable --now systemd-tmpfiles-clean.timer


### PR DESCRIPTION
Adds support of local container checkpoint and restore (without export and import) using the CRIU integration with Podman.

Tests for this feature are not included, because Podman checkpoint and restore doesn't work on Fedora 31 yet.

![checkpoint-1](https://user-images.githubusercontent.com/1266171/87528974-98d56900-c68e-11ea-9481-74fb0f6f1087.png)
![checkpoint-2](https://user-images.githubusercontent.com/1266171/87528981-9a069600-c68e-11ea-8bcc-28f12cdd9447.png)
![checkpoint-3](https://user-images.githubusercontent.com/1266171/87528983-9b37c300-c68e-11ea-997f-0557de7d9ee9.png)
![checkpoint-4](https://user-images.githubusercontent.com/1266171/87528985-9c68f000-c68e-11ea-9ad9-97c4bf4f1ae3.png)



