### PR TITLE
Fix alignment in 'Run Image' dialog

### DIFF
--- a/src/podman.scss
+++ b/src/podman.scss
@@ -627,6 +627,10 @@ table.drive-list td:nth-child(2) img {
     grid-template-columns: repeat(2, min-content);
 }
 
+.ct-form > [role=group] {
+    grid-template-columns: repeat(3, auto);
+}
+
 .run-image-dialog-actions .btn {
     padding: 0.25rem 0.75rem;
 }


### PR DESCRIPTION
This value is set to '2' in `lib/form-layout.scss` but it is getting
broken often on sync. (last such case was 0c8e511)

Lets have custom overwrite rather than being super careful on library sync.

Before:
![beforemodal](https://user-images.githubusercontent.com/12330670/87543716-7ac73300-c6a5-11ea-9d1b-be96a633f89a.png)

After:
![nowdialog](https://user-images.githubusercontent.com/12330670/87543604-50757580-c6a5-11ea-8f4b-d8e471cbff3b.png)
