### PR TITLE
test: Bump Cockpit test API to 223

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ bots:
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 220
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 223
 	git checkout --force FETCH_HEAD -- test/common
 	git reset test/common
 


### PR DESCRIPTION
This brings in the run-tests fix that breaks Fedora dist-git gating
tests: https://github.com/cockpit-project/cockpit/commit/4d3841e321a8