### PR TITLE
test: Include testRootUser into testBasicSystem

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -72,18 +72,6 @@ class TestApplication(testlib.MachineCase):
         else:
             return self.admin_s.execute(cmd)
 
-    def testRootUser(self):
-        b = self.browser
-        m = self.machine
-
-        self.login_and_go("/podman", user="root")
-        b.wait_present("#app")
-
-        # `User Service is also available` banner should not be present
-        b.wait_not_present("#overview div.pf-c-alert")
-        # There should not be any duplicate images listed
-        b.wait_js_func("ph_count_check", "#containers-images tbody", 5)
-
     def testBasicSystem(self):
         self._testBasic(True)
 
@@ -333,10 +321,22 @@ class TestApplication(testlib.MachineCase):
         self.execute(False, "podman run -d --name b registry:2 sh")
         if auth:
             b.wait_collected_text("#containers-containers .container-name", "bac")
-            self.execute(False, "podman run -d --name d registry:2 sh")
-            b.wait_collected_text("#containers-containers .container-name", "bdac")
+            self.execute(False, "podman run -d --name doremi registry:2 sh")
+            b.wait_collected_text("#containers-containers .container-name", "bdoremiac")
+            b.wait_in_text("#containers-containers tbody tr:contains('doremi') > td:nth-child(6)", "exited")
         else:
             b.wait_collected_text("#containers-containers .container-name", "abc")
+
+        # Test that when root is logged in we don't present "user" and "system"
+        if auth:
+            b.logout()
+            self.login_and_go("/podman", user="root")
+            b.wait_present("#app")
+
+            # `User Service is also available` banner should not be present
+            b.wait_not_present("#overview div.pf-c-alert")
+            # There should not be any duplicate images listed
+            b.wait_js_func("ph_count_check", "#containers-images tbody", 3)
 
     def testDownloadImage(self):
         b = self.browser


### PR DESCRIPTION
This simple tests was too quick and it left VM in destructed state.
I could not figure out the exact problem, it seems that we cleaned up
podman directories while it was still init-ing them.

Thus moved it into testBasicSystem. However if I logged out too quickly
and there was still some event coming in, it coredumped podman so I just
wait until the last container is exited. This needs report, but rather
tricky to reproduce.