### PR TITLE
Better manage intermediate images

### DIFF
--- a/src/podman.scss
+++ b/src/podman.scss
@@ -224,3 +224,9 @@
         font-size: var(--pf-global--FontSize--md);
     }
 }
+
+.listing-action {
+    width: 100%;
+    display: flex;
+    justify-content: space-around;
+}

--- a/test/check-application
+++ b/test/check-application
@@ -331,6 +331,24 @@ class TestApplication(testlib.MachineCase):
         else:
             b.wait_collected_text("#containers-containers .container-name", "abc")
 
+        # Test intermediate images
+        b.wait_not_present(".listing-action")
+        tmpdir = self.execute(auth, "mktemp -d").strip()
+        self.execute(auth, "echo 'FROM docker.io/library/registry:2\nRUN ls' > {0}/Dockerfile".format(tmpdir))
+        self.execute(auth, "podman build {0}".format(tmpdir))
+
+        # HACK due to https://github.com/containers/podman/issues/7022
+        b.reload()
+        b.enter_page("/podman")
+        b.wait_present(".listing-action")
+        b.wait_in_text("#containers-images", "registry")
+
+        b.wait_not_in_text("#containers-images", "<none>:<none>")
+        b.click(".listing-action button:contains('Show intermediate images')")
+        b.wait_in_text("#containers-images", "<none>:<none>")
+        b.click(".listing-action button:contains('Hide intermediate images')")
+        b.wait_not_in_text("#containers-images", "<none>:<none>")
+
         # Test that when root is logged in we don't present "user" and "system"
         if auth:
             b.logout()


### PR DESCRIPTION
If there is at least one such image, show 'Show intermediate images'
button, but don't show these images in the list. When this button is
clicked, these images are shown and button label changes to 'Hide
intermediate images'.

Fixes #214

![opened](https://user-images.githubusercontent.com/12330670/87914693-51295580-ca71-11ea-903f-6a34f00661e6.png)
![hidden](https://user-images.githubusercontent.com/12330670/87914697-51c1ec00-ca71-11ea-89d7-364643b86959.png)
