### PR TITLE
Use container name in modal titles

### DIFF
--- a/src/ContainerCheckpointModal.jsx
+++ b/src/ContainerCheckpointModal.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Modal } from 'patternfly-react';
 import { Button, Checkbox } from '@patternfly/react-core';
 import cockpit from 'cockpit';
-import * as utils from './util.js';
 
 const _ = cockpit.gettext;
 
@@ -28,8 +27,7 @@ class ContainerCheckpointModal extends React.Component {
             <Modal show={this.props.selectContainerCheckpointModal}>
                 <Modal.Header>
                     <Modal.Title>
-                        {cockpit.format(_("Checkpoint container $0"),
-                                        utils.truncate_id(this.props.containerWillCheckpoint.Id))}
+                        {cockpit.format(_("Checkpoint container $0"), this.props.containerWillCheckpoint.Names)}
                     </Modal.Title>
                 </Modal.Header>
                 <Modal.Body>

--- a/src/ContainerDeleteModal.jsx
+++ b/src/ContainerDeleteModal.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Modal } from 'patternfly-react';
 import { Button } from '@patternfly/react-core';
 import cockpit from 'cockpit';
-import * as utils from './util.js';
 
 const _ = cockpit.gettext;
 
@@ -10,7 +9,7 @@ const ContainerDeleteModal = (props) => {
     return (
         <Modal show={props.selectContainerDeleteModal}>
             <Modal.Header>
-                <Modal.Title>{cockpit.format(_("Please confirm deletion of $0"), utils.truncate_id(props.containerWillDelete.Id))}</Modal.Title>
+                <Modal.Title>{cockpit.format(_("Please confirm deletion of $0"), props.containerWillDelete.Names)}</Modal.Title>
             </Modal.Header>
             <Modal.Body>
                 {_("Deleting a container will erase all data in it.")}

--- a/src/ContainerRemoveErrorModal.jsx
+++ b/src/ContainerRemoveErrorModal.jsx
@@ -6,7 +6,7 @@ import cockpit from 'cockpit';
 const _ = cockpit.gettext;
 
 const ContainerRemoveErrorModal = (props) => {
-    const name = props.containerWillDelete ? _(props.containerWillDelete.Name) : "";
+    const name = props.containerWillDelete ? _(props.containerWillDelete.Names) : "";
     const [inProgress, setInProgress] = useState(false);
     return (
         <Modal key={name} show={props.setContainerRemoveErrorModal}>


### PR DESCRIPTION
In `ContainerRemoveErrorModal` was typo and no container name was shown
and the two others shown container sha, which is not super user friendly
and not consistent with rest of c-podman.