### PR TITLE
Swap new image button from link-style to secondary

### DIFF
--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button } from '@patternfly/react-core';
-import { PlusCircleIcon } from '@patternfly/react-icons';
+import { PlusIcon } from '@patternfly/react-icons';
 
 import cockpit from 'cockpit';
 import { ListingTable } from "../lib/cockpit-components-table.jsx";
@@ -172,10 +172,10 @@ class Images extends React.Component {
         else if (this.props.textFilter.length > 0)
             emptyCaption = _("No images that match the current filter");
         const getNewImageAction = [
-            <Button variant="link" key="get-new-image-action"
+            <Button variant="secondary" key="get-new-image-action"
                     onClick={() => this.setState({ showSearchImageModal: true })}
                     className="pull-right"
-                    icon={<PlusCircleIcon />}>
+                    icon={<PlusIcon />}>
                 {_("Get new image")}
             </Button>
         ];

--- a/src/podman.scss
+++ b/src/podman.scss
@@ -7,6 +7,15 @@
     padding-top: 0;
 }
 
+/* Fix alignment with icons in buttons */
+/* Alignment works on the PF4 demo, but (oddly) not in cockpit-podman */
+.pf-c-button {
+    > &__icon {
+        vertical-align: middle;
+        margin-right: var(--pf-global--spacer--sm);
+    }
+}
+
 .container-block {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Aligning the style of the button to the rest of Cockpit.

(I'm unsure why it was ever a link. I know cockpit-docker did the same, so I know cockpit-podman inherited the style.)

Screenshot:
![Screenshot_2020-07-29 Podman Containers - garrett Rain](https://user-images.githubusercontent.com/10246/88799842-6572fe00-d1a7-11ea-9794-6afd8770919c.png)
