### PR TITLE
test: Drop existing podman images

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -155,11 +155,11 @@ class TestApplication(testlib.MachineCase):
 
         # Test owner filtering
         if auth:
-            b.wait_js_func("ph_count_check", "#containers-images tbody", 8)
+            b.wait_js_func("ph_count_check", "#containers-images tbody", 6)
             b.wait_js_func("ph_count_check", "#containers-containers tbody", 2)
 
             b.set_val("#containers-containers-owner", "system")
-            b.wait_js_func("ph_count_check", "#containers-images tbody", 5)
+            b.wait_js_func("ph_count_check", "#containers-images tbody", 3)
             b.wait_in_text("#containers-images", "system")
             b.wait_js_func("ph_count_check", "#containers-containers tbody", 1)
             b.wait_in_text("#containers-containers", "system")
@@ -171,7 +171,7 @@ class TestApplication(testlib.MachineCase):
             b.wait_in_text("#containers-containers", "admin")
 
             b.set_val("#containers-containers-owner", "all")
-            b.wait_js_func("ph_count_check", "#containers-images tbody", 8)
+            b.wait_js_func("ph_count_check", "#containers-images tbody", 6)
             b.wait_js_func("ph_count_check", "#containers-containers tbody", 2)
         else: # No 'owner' selector when not privileged
             b.wait_not_present("#containers-containers-owner")
@@ -435,7 +435,7 @@ class TestApplication(testlib.MachineCase):
             # `User Service is also available` banner should not be present
             b.wait_not_present("#overview div.pf-c-alert")
             # There should not be any duplicate images listed
-            b.wait_js_func("ph_count_check", "#containers-images tbody", 3)
+            b.wait_js_func("ph_count_check", "#containers-images tbody", 1)
             # There should not be 'owner' selector
             b.wait_not_present("#containers-containers-owner")
 

--- a/test/vm.install
+++ b/test/vm.install
@@ -55,6 +55,7 @@ if type firewall-cmd >/dev/null 2>&1; then
 fi
 
 # grab a few images to play with; tests run offline, so they cannot download images
+podman rmi --all
 podman pull docker.io/busybox
 podman pull docker.io/alpine
 podman pull docker.io/registry:2
@@ -63,6 +64,7 @@ podman pull docker.io/registry:2
 loginctl enable-linger $(id -u admin)
 sudo -i -u admin bash << EOF
 systemctl --user disable --now systemd-tmpfiles-clean.timer
+podman rmi --all
 podman pull docker.io/busybox
 podman pull docker.io/alpine
 podman pull docker.io/registry:2

--- a/test/vm.install
+++ b/test/vm.install
@@ -6,16 +6,20 @@ set -eu
 if [ -d /var/tmp/debian ]; then
     apt-get update
     eatmydata apt-get install -y cockpit-ws cockpit-system podman
+    # HACK: 2.0.3 breaks API: https://bugs.debian.org/966501; upgrade to 2.0.4 in unstable
+    if dpkg --compare-versions $(dpkg-query --show -f '${Version}' podman) lt 2.0.4; then
+        echo 'deb http://deb.debian.org/debian unstable main' > /etc/apt/sources.list.d/unstable.list
+        apt-get update
+        eatmydata apt-get install -y podman
+    fi
 
     # HACK: starting podman.service complains about missing crun: https://bugs.debian.org/961016
     eatmydata apt-get install -y crun
 
-    # HACK: deb is not yet shipping the REST and user units: https://bugs.debian.org/966118
-    (cd /lib/systemd/system
-     curl -O https://raw.githubusercontent.com/containers/podman/master/contrib/systemd/system/podman.service
-     curl -O https://raw.githubusercontent.com/containers/podman/master/contrib/systemd/system/podman.socket
-     ln -s ../system/podman.service /lib/systemd/user/podman.service
-     ln -s ../system/podman.socket /lib/systemd/user/podman.socket)
+    # HACK: podman.service should not be enabled: https://github.com/containers/podman/issues/7190
+    systemctl disable podman.service
+    systemctl disable --global podman.service
+    sed -i '/\[Install\]/,$ d' /lib/systemd/system/podman.service /lib/systemd/user/podman.service
 
     # build source package
     cd /var/tmp


### PR DESCRIPTION
Our Fedora/RHEL CI images have the cockpit/base and the underlying
fedora container image, but the Debian image does not. Avoid the
ambiguity by cleaning up all existing images in vm.install.

 - [x] Work around podman API breakage after idle timeout: PR #473 