### PR TITLE
Fix attaching to containers with new version

### DIFF
--- a/src/ContainerTerminal.jsx
+++ b/src/ContainerTerminal.jsx
@@ -189,7 +189,7 @@ class ContainerTerminal extends React.Component {
                     const body = JSON.stringify({ Detach: false, Tty: false });
                     channel.send("POST /v1.24/libpod/exec/" + encodeURIComponent(r.Id) +
                               "/start HTTP/1.0\r\n" +
-                              "Content-Length: " + body.length + "\r\n\r\n" + body);
+                              "Upgrade: WebSocket\r\nConnection: Upgrade\r\nContent-Length: " + body.length + "\r\n\r\n" + body);
 
                     const buffer = this.setUpBuffer(channel);
                     this.setState({ channel: channel, errorMessage: "", buffer: buffer, sessionId: r.Id }, () => this.resize(this.props.width));
@@ -207,7 +207,7 @@ class ContainerTerminal extends React.Component {
 
         channel.send("POST /v1.24/libpod/containers/" + encodeURIComponent(this.state.container) +
                       "/attach?&stdin=true&stdout=true&stderr=true HTTP/1.0\r\n" +
-                      "Content-Length: 0\r\n\r\n");
+                      "Upgrade: WebSocket\r\nConnection: Upgrade\r\nContent-Length: 0\r\n\r\n");
 
         const buffer = this.setUpBuffer(channel);
         this.setState({ channel: channel, errorMessage: "", buffer: buffer });

--- a/test/check-application
+++ b/test/check-application
@@ -910,6 +910,7 @@ class TestApplication(testlib.MachineCase):
         self.allow_restart_journal_messages()
         self.allow_authorize_journal_messages()
         self.allow_journal_messages(".*podman/podman.sock/.*: couldn't connect:.*")
+        self.allow_journal_messages(".*podman/podman.sock/.*/events.*: received truncated HTTP response.*")
 
     @testlib.nondestructive
     def testRunImageSystem(self):


### PR DESCRIPTION
These headers were ignored before 2.0.4, but are required since.