### PR TITLE
Bump podman dependency to 2.0.4

### DIFF
--- a/cockpit-podman.spec.in
+++ b/cockpit-podman.spec.in
@@ -11,7 +11,7 @@ BuildRequires:  libappstream-glib
 
 Requires:       cockpit-bridge >= 138
 Requires:       cockpit-shell >= 138
-Requires:       podman >= 2.0.2
+Requires:       podman >= 2.0.4
 
 %description
 The Cockpit user interface for Podman containers.

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -12,7 +12,7 @@ Multi-Arch: foreign
 Depends: ${misc:Depends},
          cockpit-bridge (>= 138),
          cockpit-system (>= 138),
-         podman (>= 2.0.2),
+         podman (>= 2.0.4),
 Description: Cockpit component for Podman containers
  The Cockpit Web Console enables users to administer GNU/Linux servers using a
  web browser.


### PR DESCRIPTION
This makes sure that we don't use this with the broken 2.0.3 version.