### PR TITLE
packaging/debian: Copyright clarifications

### DIFF
--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -1,14 +1,16 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: cockpit
+Upstream-Name: cockpit-podman
 Source: https://github.com/cockpit-project/cockpit-podman
 Comment:
- This does not directly cover the files in dist/*. These are "minified" and 
- compressed JavaScript/HTML files built from src/* and node_modules/* with
- node, npm, and webpack. Their copyrights and licenses are described below.
- Rebuilding these requires internet access as that process needs to download
- additional npm modules from the Internet, thus upstream ships the pre-minified
- webpacks as part of the upstream release tarball so that the package can be
- built without internet access and lots of extra unpackaged build dependencies.
+ This does not directly cover the files in dist/*. These are "minified" and
+ compressed JavaScript/HTML files built from src/, lib/, po/, and node_modules/
+ with node, npm, and webpack. node_modules/ is not shipped as part of the
+ upstream release tarballs, but can be reconstructed precisely through the
+ shipped package-lock.json with the command "npm install".  Rebuilding files in
+ dist/ requires internet access as that process needs to download additional
+ npm modules from the Internet, thus upstream ships the pre-minified webpacks
+ as part of the upstream release tarball so that the package can be built
+ without internet access and lots of extra unpackaged build dependencies.
 
 Files: *
 Copyright: 2016-2020  Red Hat, Inc.


### PR DESCRIPTION
Fix the Upstream-Name.

Adjust the comment to better describe how cockpit-podman release
tarballs look like.