### PR TITLE
test: Add Fedora rawhide scenario

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,10 +155,16 @@ VM_DEP=$(RPMFILE)
 VM_PACKAGE=--install cockpit-ws --install `pwd`/$(RPMFILE)
 endif
 
+ifeq ($(TEST_SCENARIO),rawhide)
+# needs to run as a separate command, as --run-command is executed before --script
+RAWHIDE=bots/image-customize -v --run-command 'dnf update -y --releasever=$$(. /etc/os-release; echo $$(( VERSION_ID + 1)) ) podman conmon crun containernetworking-plugins containers-common kernel' $(TEST_OS)
+endif
+
 # build a VM with locally built rpm/dsc installed
 $(VM_IMAGE): $(VM_DEP) bots
 	rm -f $(VM_IMAGE) $(VM_IMAGE).qcow2
 	bots/image-customize -v $(VM_PACKAGE) -s $(CURDIR)/test/vm.install $(TEST_OS)
+	$(RAWHIDE)
 
 # convenience target for the above
 vm: $(VM_IMAGE)


### PR DESCRIPTION
Upgrade podman/container related packages and the kernel to rawhide, so
that we can test it on demand.

Note: The `--releasever` option is necessary to force dnf to download
and install the correct GPG keys. This assumes that this runs on the
most recent stable Fedora release (i.e. fedora-32 at the time of
writing) that precedes rawhide.