### PR TITLE
test: Wait for proper containers in the UI

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -352,35 +352,32 @@ class TestApplication(testlib.MachineCase):
 
         # run a container (will exit immediately) and test the display of commit modal
         if auth:
-            self.execute(True, "podman run -d --name test-sh alpine sh")
-            container_commit("test-sh")
+            self.execute(True, "podman run -d --name test-sh0 alpine sh")
+            container_commit("test-sh0")
             checkImage(b, "localhost/testimg:testtag", "system")
-            self.execute(True, "podman rm -f test-sh; podman rmi testimg:testtag")
+            self.execute(True, "podman rm -f test-sh0; podman rmi testimg:testtag")
 
-        self.execute(False, "podman run -d --name test-sh alpine sh")
-        container_commit("test-sh", owner="admin")
+        self.execute(False, "podman run -d --name test-sh1 alpine sh")
+        container_commit("test-sh1", owner="admin")
         checkImage(b, "localhost/testimg:testtag", "admin")
-        self.execute(False, "podman rm -f test-sh; podman rmi testimg:testtag")
+        self.execute(False, "podman rm -f test-sh1; podman rmi testimg:testtag")
 
         # test commit of a running container
         if auth:
-            self.execute(True, "podman run -d --name test-sh busybox sleep 1000")
-            container_commit("test-sh", image_command=r'sh -c "while echo \"Hello World\"; do sleep 1; done "')
-            self.execute(True, "podman rm -f test-sh; podman rmi testimg:testtag")
+            self.execute(True, "podman run -d --name test-sh2 busybox sleep 1000")
+            container_commit("test-sh2", image_command=r'sh -c "while echo \"Hello World\"; do sleep 1; done "')
+            self.execute(True, "podman rm -f test-sh2; podman rmi testimg:testtag")
 
         # HACK - this does not work, see https://github.com/containers/libpod/issues/3970
-        # self.execute(False, "podman run -d --name test-sh alpine sleep 1000")
-        # container_commit("test-sh", owner="admin")
-        # self.execute(False, "podman rm -f test-sh; podman rmi testimg:testtag")
+        # self.execute(False, "podman run -d --name test-sh3 alpine sleep 1000")
+        # container_commit("test-sh3", owner="admin")
+        # self.execute(False, "podman rm -f test-sh3; podman rmi testimg:testtag")
 
-        if auth:
-            self.execute(True, "podman run -d --name test-sh alpine sh")
-        else:
-            self.execute(False, "podman run -d --name test-sh alpine sh")
-        b.wait_present('#containers-containers tr:contains("alpine:latest")')
-        b.click('#containers-containers tbody tr:contains("alpine:latest") td.pf-c-table__toggle button')
+        self.execute(auth, "podman run -d --name test-sh4 alpine sh")
+        b.wait_present('#containers-containers tr:contains("test-sh4")')
+        b.click('#containers-containers tbody tr:contains("test-sh4") td.pf-c-table__toggle button')
         # open commit modal and check error modal
-        b.click('#containers-containers tbody tr:contains("alpine:latest") + tr button.btn-commit')
+        b.click('#containers-containers tbody tr:contains("test-sh4") + tr button.btn-commit')
         # check required field error
         b.click(".modal-dialog div .btn-ctr-commit")
         b.wait_present('.modal-dialog div:contains("Image name is required")')
@@ -439,7 +436,7 @@ class TestApplication(testlib.MachineCase):
         # Rootless don't have this info
         if auth:
             # Remove current container for easier selectors
-            self.execute(auth, "podman rm -f test-sh")
+            self.execute(auth, "podman rm -f test-sh4")
             b.wait_not_present(".container-details")
 
             self.execute(auth, "podman run -dt --name net_check alpine")


### PR DESCRIPTION
In this test we create and delete many containers named 'test-sh' from
'alpine' image. There exists race, where in the UI we still see the
previous 'test-sh' container, that we think we already deleted and
expect to see a new 'test-sh' container in the UI we just created. When
we are fast enough, we have time to toggle open the container details,
but then it gets deleted, a new container is rendered but it does not
have details expanded.

Thus let's name every container uniquely and when we target specific
container line, let's do it by its name and not by its image (which
makes so much more sense anyway).

Should fix flake like [this](https://logs.cockpit-project.org/logs/pull-499-20200806-160515-6e8157f5-fedora-32-rawhide/log.html)