### PR TITLE
Add import and export of checkpoints

### DIFF
--- a/src/ContainerCheckpointModal.jsx
+++ b/src/ContainerCheckpointModal.jsx
@@ -11,7 +11,8 @@ class ContainerCheckpointModal extends React.Component {
             keep: false,
             leaveRunning: false,
             tcpEstablished: false,
-            ignoreRootFS: false
+            ignoreRootFS: false,
+            export: false
         };
         this.handleChange = this.handleChange.bind(this);
     }
@@ -51,6 +52,9 @@ class ContainerCheckpointModal extends React.Component {
                     <Checkbox label={_("Do not include root file-system changes when exporting")}
                                   id="checkpoint-dialog-ignoreRootFS" name="ignoreRootFS"
                                   isChecked={this.state.ignoreRootFS} onChange={this.handleChange} />
+                    <Checkbox label={_("Export the checkpoint into a tarball and download it")}
+                                  id="checkpoint-dialog-export" name="export" isChecked={this.state.export}
+                                  onChange={this.handleChange} />
                 </Form>
             </Modal>
         );

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -197,7 +197,7 @@ class Containers extends React.Component {
             </Button>,
         ];
         if (!isRunning) {
-            if (container.isSystem && container.hasCheckpoint) {
+            if (container.isSystem) {
                 const runActions = [];
                 runActions.push({ label: _("Start"), onActivate: () => this.startContainer(container) });
                 runActions.push({ label: _("Restore"), onActivate: () => this.restoreContainer(container) });
@@ -275,10 +275,13 @@ class Containers extends React.Component {
                 });
     }
 
-    handleRestoreContainer(args) {
+    handleRestoreContainer(params, tarball) {
         const container = this.state.containerWillRestore;
         this.setState({ restoreInProgress: true });
-        client.postContainer(container.isSystem, "restore", container.Id, args)
+
+        (params.import
+            ? client.postContainerWithUpload(container.isSystem, "restore", container.Id, tarball.stream(), params)
+            : client.postContainer(container.isSystem, "restore", container.Id, params))
                 .catch(ex => {
                     const error = cockpit.format(_("Failed to restore container $0"), container.Names);
                     this.props.onAddNotification({ type: 'danger', error, errorDetail: ex.message });
@@ -296,9 +299,7 @@ class Containers extends React.Component {
     }
 
     handleRestoreContainerDeleteModal() {
-        this.setState((prevState) => ({
-            selectContainerRestoreModal: !prevState.selectContainerRestoreModal,
-        }));
+        this.setState({ selectContainerRestoreModal: false });
     }
 
     handleCancelRemoveError() {

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -259,7 +259,10 @@ class Containers extends React.Component {
     handleCheckpointContainer(args) {
         const container = this.state.containerWillCheckpoint;
         this.setState({ checkpointInProgress: true });
-        client.postContainer(container.isSystem, "checkpoint", container.Id, args)
+        (args.export
+            ? client.postContainerAndDownload(container.isSystem, "checkpoint", container.Id,
+                                              `checkpoint-${container.Id}.tar.gz`, args)
+            : client.postContainer(container.isSystem, "checkpoint", container.Id, args))
                 .catch(ex => {
                     const error = cockpit.format(_("Failed to checkpoint container $0"), container.Names);
                     this.props.onAddNotification({ type: 'danger', error, errorDetail: ex.message });
@@ -289,9 +292,7 @@ class Containers extends React.Component {
     }
 
     handleCheckpointContainerDeleteModal() {
-        this.setState((prevState) => ({
-            selectContainerCheckpointModal: !prevState.selectContainerCheckpointModal,
-        }));
+        this.setState({ selectContainerCheckpointModal: false });
     }
 
     handleRestoreContainerDeleteModal() {

--- a/src/rest.js
+++ b/src/rest.js
@@ -34,6 +34,16 @@ function connect(address, system) {
         });
     };
 
+    connection.upload = function(options, send_raw) {
+        const req = http.request(options);
+        return {
+            input: (input, stream) => send_raw ? req.input(input, stream) : req.input(JSON.stringify(input), stream),
+            then: req.then,
+            catch: req.catch,
+            close: req.close
+        };
+    };
+
     connection.call = function (options) {
         return new Promise((resolve, reject) => {
             options = options || {};

--- a/src/util.js
+++ b/src/util.js
@@ -172,3 +172,36 @@ export function compare_versions(a, b) {
 
     return a_ints.length - b_ints.length;
 }
+
+/*
+ * Generates a link for downloading a file from a server.
+ * This is adopted from Cockpit's SOS report code.
+ */
+export async function downloadFile(path, filename) {
+    // Construct the download URL
+    const file_size = await cockpit.script(`du -b "${path}" | cut -f1`);
+    const query = window.btoa(JSON.stringify({
+        payload: "fsread1",
+        binary: "raw",
+        path: path,
+        superuser: true,
+        max_read_size: parseInt(file_size),
+        external: {
+            "content-disposition": 'attachment; filename="' + filename + '"',
+            "content-type": "application/octet-stream"
+        }
+    }));
+    const prefix = (new URL(cockpit.transport.uri("channel/" + cockpit.transport.csrf_token))).pathname;
+    const file_url = prefix + '?' + query;
+
+    // Trigger the download
+    /* const iframe = document.createElement("iframe");
+    iframe.style.display = "none";
+    iframe.style.visibility = "hidden";
+    document.body.appendChild(iframe);
+    iframe.src = file_url; */
+    const link = document.createElement("a");
+    document.body.appendChild(link);
+    link.href = file_url;
+    link.click();
+}

--- a/test/check-application
+++ b/test/check-application
@@ -927,25 +927,45 @@ class TestApplication(testlib.MachineCase):
         b.wait_visible("#app")
         self.filter_containers('all')
 
+        def checkpointContainer(keep=False, tcpEstablished=False, leaveRunning=False, ignoreRootFS=False, export=False):
+            b.click('#containers-containers tr:contains("busybox:latest") + tr button:contains(Stop) + button')
+            b.click('#containers-containers tr:contains("busybox:latest") + tr #Stop-dropdown ul li:has(a:contains(Checkpoint))')
+            b.set_checked('.pf-c-modal-box input#checkpoint-dialog-keep', keep)
+            b.set_checked('.pf-c-modal-box input#checkpoint-dialog-tcpEstablished', tcpEstablished)
+            b.set_checked('.pf-c-modal-box input#checkpoint-dialog-leaveRunning', leaveRunning)
+            b.set_checked('.pf-c-modal-box input#checkpoint-dialog-ignoreRootFS', ignoreRootFS)
+            b.set_checked('.pf-c-modal-box input#checkpoint-dialog-export', export)
+            b.click('.pf-c-modal-box button:contains(Checkpoint)')
+
+        def restoreContainer(keep=False, tcpEstablished=False, ignoreStaticIP=False, ignoreStaticMAC=False):
+            b.click('#containers-containers tr:contains("busybox:latest") + tr button:contains(Start) + button')
+            b.click('#containers-containers tr:contains("busybox:latest") + tr #Start-dropdown ul li:has(a:contains(Restore))')
+            b.set_checked('.pf-c-modal-box input#restore-dialog-use-local-checkpoint', True)
+            b.set_checked('.pf-c-modal-box input#restore-dialog-keep', keep)
+            b.set_checked('.pf-c-modal-box input#restore-dialog-tcpEstablished', tcpEstablished)
+            b.set_checked('.pf-c-modal-box input#restore-dialog-ignoreStaticIP', ignoreStaticIP)
+            b.set_checked('.pf-c-modal-box input#restore-dialog-ignoreStaticMAC', ignoreStaticMAC)
+            b.click('.pf-c-modal-box button:contains(Restore)')
+
         # Run a container
         self.execute(True, "podman run -dit --name swamped-crate busybox:latest sh; podman stop swamped-crate")
         b.wait(lambda: self.execute(True, "podman ps --all | grep -e swamped-crate -e Exited"))
         b.click('#containers-containers tbody tr:contains(swamped-crate) td.pf-c-table__toggle button')
 
-        # Check that the restore option is not present (i.e. start is a regular button)
-        b.wait_visible('#containers-containers tbody tr:contains(swamped-crate) + tr button.pf-c-button:contains(Start)')
+        # Check that restore from local checkpoint is disabled.
+        b.click('#containers-containers tr:contains(swamped-crate) + tr button:contains(Start) + button')
+        b.click('#containers-containers tr:contains(swamped-crate) + tr #Start-dropdown ul li:has(a:contains(Restore))')
+        b.wait_present('.pf-c-modal-box input#restore-dialog-use-local-checkpoint[disabled]:not(:checked)')
+        b.wait_present('.pf-c-modal-box button[disabled]:contains(Restore)')
+        b.click('.pf-c-modal-box button:contains(Cancel)')
 
         # Start the container
         b.click('#containers-containers tbody tr:contains(swamped-crate) + tr button:contains(Start)')
         b.wait_in_text('#containers-containers tr:contains(swamped-crate)', 'running')
 
         # Checkpoint the container
-        b.click('#containers-containers tr:contains(swamped-crate) + tr button:contains(Stop) + button')
-        b.click('#containers-containers tr:contains(swamped-crate) + tr #Stop-dropdown ul li:has(a:contains(Checkpoint))')
-        b.set_checked('.pf-c-modal-box input#checkpoint-dialog-keep', True)
-        b.set_checked('.pf-c-modal-box input#checkpoint-dialog-tcpEstablished', True)
-        b.set_checked('.pf-c-modal-box input#checkpoint-dialog-ignoreRootFS', True)
-        b.click('.pf-c-modal-box button:contains(Checkpoint)')
+        checkpointContainer()
+        b.wait_not_present('.modal_dialog')
 
         with b.wait_timeout(300):
             b.wait_not_present(".pf-c-modal-box")
@@ -960,21 +980,11 @@ class TestApplication(testlib.MachineCase):
 
         # Restore the container
         b.wait_visible('#containers-containers td[data-label="Container"]:contains(swamped-crate)')
-        b.click('#containers-containers tr:contains(swamped-crate) + tr button:contains(Start) + button')
-        b.click('#containers-containers tr:contains(swamped-crate) + tr #Start-dropdown ul li:has(a:contains(Restore))')
-        b.set_checked('.pf-c-modal-box input#restore-dialog-keep', True)
-        b.set_checked('.pf-c-modal-box input#restore-dialog-tcpEstablished', True)
-        b.set_checked('.pf-c-modal-box input#restore-dialog-ignoreStaticIP', True)
-        b.set_checked('.pf-c-modal-box input#restore-dialog-ignoreStaticMAC', True)
-        b.click('.pf-c-modal-box button:contains(Restore)')
+        restoreContainer()
         b.wait(lambda: b.text('#containers-containers tr:contains(swamped-crate) td:nth-of-type(6)') == 'running')
 
         # Checkpoint the container without stopping
-        b.wait_visible('#containers-containers td[data-label="Container"]:contains(swamped-crate)')
-        b.click('#containers-containers tr:contains(swamped-crate) + tr button:contains(Stop) + button')
-        b.click('#containers-containers tr:contains(swamped-crate) + tr #Stop-dropdown ul li:has(a:contains(Checkpoint))')
-        b.set_checked('.pf-c-modal-box input#checkpoint-dialog-leaveRunning', True)
-        b.click('.pf-c-modal-box button:contains(Checkpoint)')
+        checkpointContainer(leaveRunning=True)
         b.wait_not_present('.modal_dialog')
 
         # Stop the container
@@ -982,9 +992,7 @@ class TestApplication(testlib.MachineCase):
         b.wait(lambda: b.text('#containers-containers tr:contains(swamped-crate) td:nth-of-type(6)') in NOT_RUNNING)
 
         # Restore the container
-        b.click('#containers-containers tr:contains(swamped-crate) + tr button:contains(Start) + button')
-        b.click('#containers-containers tr:contains(swamped-crate) + tr #Start-dropdown ul li:has(a:contains(Restore))')
-        b.click('.pf-c-modal-box button:contains(Restore)')
+        restoreContainer()
         b.wait(lambda: b.text('#containers-containers tr:contains(swamped-crate) td:nth-of-type(6)') == 'running')
 
     @testlib.nondestructive


### PR DESCRIPTION
Adds export (download of checkpoint tarball after making a checkpoint) and import (upload of checkpoint tarball for restore) support.

Upload is done by directly reading a file selected by the PatternFly file upload component; ~download is handled using a service worker (it's a little bit hacky, but seems to work fine in both Firefox and Chromium and doesn't store the tarball in memory; maybe there is a better way, but as far as I know Cockpit can download only files from the file system, not channels/HTTP streams)~ download uses channel redirection to save the checkpoint into a file, which is then downloaded directly using a read channel. (Direct download of the checkpoint stream is not possible, because the checkpoint process takes some time, and also errors have to be handled in the UI, not downloaded instead of the tarball).

There are currently no tests - I'm not sure how Selenium handles downloads (the download has to be done in the test browser because of the service worker); I can have a look at it.

![checkpoint](https://user-images.githubusercontent.com/1266171/89874049-9990ea80-dbbb-11ea-811b-25f46412cb6c.png)
![restore](https://user-images.githubusercontent.com/1266171/89874052-9ac21780-dbbb-11ea-8b50-a8e503b56d28.png)
