### PR TITLE
Listen on event for image build

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -326,6 +326,7 @@ class Application extends React.Component {
         case 'untag':
         case 'remove':
         case 'prune':
+        case 'build':
             this.updateImagesAfterEvent(system);
             break;
         default:

--- a/test/check-application
+++ b/test/check-application
@@ -485,12 +485,6 @@ class TestApplication(testlib.MachineCase):
         self.execute(auth, "echo 'FROM docker.io/library/registry:2\nRUN ls' > {0}/Dockerfile".format(tmpdir))
         self.execute(auth, "podman build {0}".format(tmpdir))
 
-        # HACK due to https://github.com/containers/podman/issues/7022
-        b.reload()
-        b.enter_page("/podman")
-        b.wait_present(".listing-action")
-        b.wait_in_text("#containers-images", "registry")
-
         b.wait_not_in_text("#containers-images", "<none>:<none>")
         b.click(".listing-action button:contains('Show intermediate images')")
         b.wait_in_text("#containers-images", "<none>:<none>")


### PR DESCRIPTION
In https://github.com/containers/podman/pull/7202 a new event was
introduced. Listen on it as well.

This is not going to work out just now, but I am opening it now, so we won't forget. Once new podman (I guess 2.0.5 should get it) is out and in our VMs, we can nicely verify it with retrying tests in this PR.