### PR TITLE
Image create time moves to timestamp

### DIFF
--- a/src/ContainerDetails.jsx
+++ b/src/ContainerDetails.jsx
@@ -2,12 +2,11 @@ import React from 'react';
 import cockpit from 'cockpit';
 import * as utils from './util.js';
 
-const moment = require('moment');
 const _ = cockpit.gettext;
 
 const render_container_state = (container) => {
     if (container.State === "running") {
-        return cockpit.format(_("Up since $0"), moment(container.StartedAt * 1000).calendar());
+        return cockpit.format(_("Up since $0"), utils.localize_time(container.StartedAt));
     }
     return cockpit.format(_("Exited"));
 };
@@ -29,7 +28,7 @@ const ContainerDetails = ({ container, containerDetail }) => (
         <dt>{_("ID")}</dt>
         <dd>{container.Id}</dd>
         <dt>{_("Created")}</dt>
-        <dd>{moment(container.Created * 1000).calendar()}</dd>
+        <dd>{utils.localize_time(container.Created)}</dd>
         <dt>{_("Image")}</dt>
         <dd>{container.Image}</dd>
         <dt>{_("Command")}</dt>

--- a/src/ImageDetails.jsx
+++ b/src/ImageDetails.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import cockpit from 'cockpit';
 import * as utils from './util.js';
 
-const moment = require('moment');
 const _ = cockpit.gettext;
 
 const truncate_id = (id) => {
@@ -11,7 +10,6 @@ const truncate_id = (id) => {
 
 const ImageDetails = (props) => {
     const image = props.image;
-    const created = moment(image.Created, "YYYY-MM-DDTHH:mm:ss.SZ").calendar();
 
     return (
         <dl className='image-details'>
@@ -24,7 +22,7 @@ const ImageDetails = (props) => {
             <dt>{_("Command")}</dt>
             <dd>{image.Command ? utils.quote_cmdline(image.Command) : "" }</dd>
             <dt>{_("Created")}</dt>
-            <dd>{created}</dd>
+            <dd>{utils.localize_time(image.Created)}</dd>
             <dt>{_("Author")}</dt>
             <dd>{image.Author}</dd>
             <dt>{_("Ports")}</dt>

--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -12,10 +12,10 @@ import { ImageSearchModal } from './ImageSearchModal.jsx';
 import { ImageDeleteModal } from './ImageDeleteModal.jsx';
 import ImageRemoveErrorModal from './ImageRemoveErrorModal.jsx';
 import * as client from './client.js';
+import * as utils from './util.js';
 
 import './Images.css';
 
-const moment = require('moment');
 const _ = cockpit.gettext;
 
 class Images extends React.Component {
@@ -127,9 +127,10 @@ class Images extends React.Component {
                 </Button>
             </div>
         );
+
         const columns = [
             { title: image.RepoTags ? image.RepoTags[0] : "<none>:<none>", header: true },
-            moment(image.Created, "YYYY-MM-DDTHH:mm:ss.SZ").calendar(),
+            utils.localize_time(image.Created),
             cockpit.format_bytes(image.Size),
             image.isSystem ? _("system") : this.props.user.name,
             runImage,

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,6 @@
 import cockpit from 'cockpit';
 
+const moment = require('moment');
 const _ = cockpit.gettext;
 
 // https://github.com/containers/podman/blob/master/libpod/define/containerstate.go
@@ -13,6 +14,13 @@ export function truncate_id(id) {
         return "";
     }
     return id.substr(0, 12);
+}
+
+// On some places time is passed as timestamp and on some as string
+export function localize_time(time) {
+    if (Number.isInteger(time))
+        return moment(time * 1000).calendar();
+    return moment(time, "YYYY-MM-DDTHH:mm:ss.SZ").calendar();
 }
 
 export function format_memory_and_limit(usage, limit) {

--- a/test/check-application
+++ b/test/check-application
@@ -494,6 +494,8 @@ class TestApplication(testlib.MachineCase):
         b.wait_not_in_text("#containers-images", "<none>:<none>")
         b.click(".listing-action button:contains('Show intermediate images')")
         b.wait_in_text("#containers-images", "<none>:<none>")
+        b.wait_in_text("#containers-images tbody:last-child td:nth-child(3)", "Today at")
+
         b.click(".listing-action button:contains('Hide intermediate images')")
         b.wait_not_in_text("#containers-images", "<none>:<none>")
 
@@ -1140,6 +1142,8 @@ class TestApplication(testlib.MachineCase):
         b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Ports") + dd', '0.0.0.0:8001 \u2192 8001/tcp')
         b.wait_not_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Ports") + dd', '0.0.0.0:7001 \u2192 7001/tcp')
         ports = self.execute(auth, "podman inspect --format '{{.NetworkSettings.Ports}}' busybox-with-tty")
+
+        b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Created") + dd', 'Today at')
 
         self.assertIn('5000/tcp:[{ 6000}]', ports)
         self.assertIn('5001/udp:[{ 6001}]', ports)


### PR DESCRIPTION
This was introduced somewhere between 2.0.4 and 2.1.0.
Our `fedora-32/rawhide` already sees that, but not our other images.

I have to add there some condition so it works also with 2.0.4 but I want to spin tests once now to see it really is needed for rawhide.