### PR TITLE
cockpituous: Release to Fedora 33

### DIFF
--- a/cockpituous-release
+++ b/cockpituous-release
@@ -20,8 +20,10 @@ cat ~/.fedora-password | kinit cockpit@FEDORAPROJECT.ORG
 job release-koji master
 job release-koji f31
 job release-koji f32
+job release-koji f33
 job release-bodhi F31
 job release-bodhi F32
+job release-bodhi F33
 
 # These are likely the first of your release targets; but run them after Fedora uploads,
 # so that failures there will fail the release early, before publishing on GitHub


### PR DESCRIPTION
Bodhi activation point is the [next Tuesday](https://fedorapeople.org/groups/schedule/f-33/f-33-key-tasks.html). We won't have another release in the meantime so lets not forget about it. I'll start preparing F33 image now so we can also test it.