### PR TITLE
cockpituous: Stop releasing to Fedora 31

### DIFF
--- a/cockpituous-release
+++ b/cockpituous-release
@@ -18,10 +18,8 @@ job release-srpm -V
 cat ~/.fedora-password | kinit cockpit@FEDORAPROJECT.ORG
 # Do fedora builds for the tag, using tarball
 job release-koji master
-job release-koji f31
 job release-koji f32
 job release-koji f33
-job release-bodhi F31
 job release-bodhi F32
 job release-bodhi F33
 


### PR DESCRIPTION
Fedora 33 is branched now, let's not support too many releases in
parallel.