### PR TITLE
po: Fix duplicate strings

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -521,11 +521,7 @@ msgstr "Pokračovat v chodu"
 msgid "Run"
 msgstr "Spustit"
 
-#: src/ImageRunModal.jsx:449
-msgid "Run image"
-msgstr "Spustit obraz"
-
-#: src/Images.jsx:124
+#: src/ImageRunModal.jsx:449 src/Images.jsx:124
 msgid "Run image"
 msgstr "Spustit obraz"
 

--- a/po/de.po
+++ b/po/de.po
@@ -566,12 +566,6 @@ msgstr "Starten"
 msgid "Run image"
 msgstr "Image starten"
 
-#: src/Images.jsx:124
-#, fuzzy
-#| msgid "Run image"
-msgid "Run image"
-msgstr "Image starten"
-
 #: src/util.js:9
 msgid "Running"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -571,12 +571,6 @@ msgstr "Ejecutar"
 msgid "Run image"
 msgstr "Ejecutar una imagen"
 
-#: src/Images.jsx:124
-#, fuzzy
-#| msgid "Run image"
-msgid "Run image"
-msgstr "Ejecutar una imagen"
-
 #: src/util.js:9
 msgid "Running"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -528,13 +528,14 @@ msgstr "Reprendre"
 msgid "Run"
 msgstr "Exécuter"
 
-#: src/ImageRunModal.jsx:449
+#: src/ImageRunModal.jsx:449 src/Images.jsx:124
+#, fuzzy
 msgid "Run image"
-msgstr "Exécuter image"
-
-#: src/Images.jsx:124
-msgid "Run image"
-msgstr "Exécuter l'image"
+msgstr ""
+"#-#-#-#-#  fr.po (PACKAGE_VERSION)  #-#-#-#-#\n"
+"Exécuter image\n"
+"#-#-#-#-#  fr.po (PACKAGE_VERSION)  #-#-#-#-#\n"
+"Exécuter l'image"
 
 #: src/util.js:10
 msgid "Running"

--- a/po/pl.po
+++ b/po/pl.po
@@ -526,11 +526,7 @@ msgstr "Wznów"
 msgid "Run"
 msgstr "Uruchom"
 
-#: src/ImageRunModal.jsx:449
-msgid "Run image"
-msgstr "Uruchom obraz"
-
-#: src/Images.jsx:124
+#: src/ImageRunModal.jsx:449 src/Images.jsx:124
 msgid "Run image"
 msgstr "Uruchom obraz"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -573,12 +573,6 @@ msgstr "Executar"
 msgid "Run image"
 msgstr "Executar imagem"
 
-#: src/Images.jsx:124
-#, fuzzy
-#| msgid "Run image"
-msgid "Run image"
-msgstr "Executar imagem"
-
 #: src/util.js:10
 msgid "Running"
 msgstr ""

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -526,11 +526,7 @@ msgstr "Retomar"
 msgid "Run"
 msgstr "Executar"
 
-#: src/ImageRunModal.jsx:449
-msgid "Run image"
-msgstr "Executar Imagem"
-
-#: src/Images.jsx:124
+#: src/ImageRunModal.jsx:449 src/Images.jsx:124
 msgid "Run image"
 msgstr "Executar Imagem"
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -537,12 +537,6 @@ msgstr "Spustiť"
 msgid "Run image"
 msgstr "Spustiť obraz"
 
-#: src/Images.jsx:124
-#, fuzzy
-#| msgid "Run image"
-msgid "Run image"
-msgstr "Spustiť obraz"
-
 #: src/util.js:9
 msgid "Running"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -524,13 +524,14 @@ msgstr "Sürdür"
 msgid "Run"
 msgstr "Çalıştır"
 
-#: src/ImageRunModal.jsx:449
+#: src/ImageRunModal.jsx:449 src/Images.jsx:124
+#, fuzzy
 msgid "Run image"
-msgstr "Kalıbı Çalıştır"
-
-#: src/Images.jsx:124
-msgid "Run image"
-msgstr "Kalıbı çalıştır"
+msgstr ""
+"#-#-#-#-#  tr.po (PACKAGE_VERSION)  #-#-#-#-#\n"
+"Kalıbı Çalıştır\n"
+"#-#-#-#-#  tr.po (PACKAGE_VERSION)  #-#-#-#-#\n"
+"Kalıbı çalıştır"
 
 #: src/util.js:9
 msgid "Running"

--- a/po/uk.po
+++ b/po/uk.po
@@ -529,11 +529,7 @@ msgstr "Продовжити"
 msgid "Run"
 msgstr "Запустити"
 
-#: src/ImageRunModal.jsx:449
-msgid "Run image"
-msgstr "Запустити образ"
-
-#: src/Images.jsx:124
+#: src/ImageRunModal.jsx:449 src/Images.jsx:124
 msgid "Run image"
 msgstr "Запустити образ"
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -553,12 +553,6 @@ msgstr "运行"
 msgid "Run image"
 msgstr "运行镜像"
 
-#: src/Images.jsx:124
-#, fuzzy
-#| msgid "Run image"
-msgid "Run image"
-msgstr "运行镜像"
-
 #: src/util.js:10
 msgid "Running"
 msgstr "正在运行"


### PR DESCRIPTION
Done with:
```
FILES=po/*.po
for f in $FILES; do msguniq -o $f $f; done
```

I did this in weblate repo but completely forgot to do it also in this
repo. See https://github.com/cockpit-project/cockpit-podman-weblate/commit/4147632b