### PR TITLE
test: Disable podman.socket globally for the tests

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -63,6 +63,8 @@ class TestApplication(testlib.MachineCase):
         # Enable user service as well
         self.restore_dir("/home/admin/.local/share/containers")
         self.admin_s.execute("systemctl --now --user enable podman.socket")
+        # But disable it globally so that "systemctl --user disable" does what we expect
+        self.machine.execute("systemctl --global disable podman.socket")
         # HACK: user podman.service leaks a "podman pause" outside of the unit: https://github.com/containers/podman/issues/7180
         self.addCleanup(self.admin_s.execute, "pkill -u $USER -e podman; while pgrep -u $USER -a podman; do sleep 1; done")
 


### PR DESCRIPTION
Otherwise, "systemctl --user disable podman.socket" has no effect on
"systemctl --user is-enabled".