### PR TITLE
test: Explicitly install runc on Debian testing

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -7,8 +7,8 @@ if [ -d /var/tmp/debian ]; then
     apt-get update
     eatmydata apt-get install -y cockpit-ws cockpit-system podman
 
-    # HACK: starting podman.service complains about missing crun: https://bugs.debian.org/961016
-    eatmydata apt-get install -y crun
+    # HACK: podman dependencies prefer crun, but config defaults to runc: https://bugs.debian.org/971253
+    eatmydata apt-get install -y runc
 
     # build source package
     cd /var/tmp


### PR DESCRIPTION
The podman package's dependencies now prefer crun, so the previous hack
for https://bugs.debian.org/961016 is obsolete (and that bug is closed).

However, podman *really* defaults to runc, so explicitly install it
for now until the default configuration or dependencies get fixed:
https://bugs.debian.org/971253

This was previously hidden because the debian-testing image contained
docker.io, which pulls in runc. But
https://github.com/cockpit-project/bots/pull/1262 removes docker.io, and
runc with it.