### PR TITLE
Fix building PO template

### DIFF
--- a/po/html2po
+++ b/po/html2po
@@ -45,9 +45,9 @@ try {
 }
 
 var opts = stdio.getopt({
-    directory: { key: "d", args: 1, description: "Base directory for input files" },
+    directory: { key: "d", args: 1, description: "Base directory for input files", default: "." },
     output: { key: "o", args: 1, description: "Output file" },
-    from: { key: "f", args: 1, description: "File containing list of input files" },
+    from: { key: "f", args: 1, description: "File containing list of input files", default: "" },
 });
 
 if (!opts.from && opts.args.length < 1) {

--- a/po/manifest2po
+++ b/po/manifest2po
@@ -26,9 +26,9 @@ try {
 }
 
 var opts = stdio.getopt({
-    directory: { key: "d", args: 1, description: "Base directory for input files" },
+    directory: { key: "d", args: 1, description: "Base directory for input files", default: "." },
     output: { key: "o", args: 1, description: "Output file" },
-    from: { key: "f", args: 1, description: "File containing list of input files" },
+    from: { key: "f", args: 1, description: "File containing list of input files", default: "" },
 });
 
 if (!opts.from && opts.args.length < 1) {
@@ -70,11 +70,18 @@ function step() {
     if (path.basename(filename) != "manifest.json")
         return step();
 
-    fs.readFile(filename, { encoding: "utf-8"}, function(err, data) {
+    /* Qualify the filename if necessary */
+    var full = filename;
+    if (opts.directory)
+        full = path.join(opts.directory, filename);
+    fs.readFile(full, { encoding: "utf-8"}, function(err, data) {
         if (err)
             fatal(err.message);
 
-        process_manifest(JSON.parse(data));
+        // There are variables which when not substituted can cause JSON.parse to fail
+        //  Dummy replace them. None variable is going to be translated anyway
+        safe_data = data.replace(/\@.+?\@/gi, 1);
+        process_manifest(JSON.parse(safe_data));
 
         return step();
     });

--- a/po/po2json
+++ b/po/po2json
@@ -72,7 +72,7 @@ function prepareHeader(header) {
 /* Parse and process the po data */
 function parse() {
     filename = opts.args[0];
-    po2json.parseFile(opts.args[0], { "fuzzy": true }, function(err, jsonData) {
+    po2json.parseFile(opts.args[0], { "fuzzy": false }, function(err, jsonData) {
         var plurals, pos;
 
         if (err)

--- a/test/run
+++ b/test/run
@@ -2,3 +2,4 @@
 # This is the expected entry point for Cockpit CI; will be called without
 # arguments but with an appropriate $TEST_OS
 make check
+make po/podman.pot


### PR DESCRIPTION
The current version failed with

    Option "--directory" requires 1 arguments, but 0 were provided

In the current stdio npm module version, getopt() now requires a
`default:` attribute, otherwise it considers the options as required.

Also sync PO helpers with current cockpit.

Cherry-picked from cockpit-project/starter-kit commit cbedf06

Checked and .pot file is built correctly. When we land this we need to retry #550 