### PR TITLE
cockpituous: Run release in a GitHub workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: release
+on:
+  push:
+    tags:
+      # this is a glob, not a regexp
+      - '[0-9]*'
+jobs:
+  cockpituous:
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/cockpit/release
+    steps:
+      - name: Set up configuration and secrets
+        run: |
+          # override GitHub's bind mount from host, we don't want anything from there and it interferes with ssh
+          export HOME=$(getent passwd $(id -u) | cut -f6 -d:)
+
+          echo '${{ secrets.SSH_KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+          echo '${{ secrets.FEDPKG_SSH_PUBLIC }}' > ~/.ssh/id_rsa.pub
+          echo '${{ secrets.FEDPKG_SSH_PRIVATE }}' > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          echo 'cockpit' > ~/.config/bodhi-user
+          echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
+          echo '${{ secrets.COPR_TOKEN }}' > ~/.config/copr
+          echo '${{ secrets.COCKPIT_FEDORA_PASSWORD }}' > ~/.fedora-password
+
+      - name: Run cockpituous
+        run: |
+          # override GitHub's bind mount from host, we don't want anything from there and it interferes with ssh
+          export HOME=$(getent passwd $(id -u) | cut -f6 -d:)
+          cd /build
+          release-runner -r https://github.com/$GITHUB_REPOSITORY -t $(basename $GITHUB_REF) ./cockpituous-release

--- a/README.md
+++ b/README.md
@@ -13,3 +13,17 @@ For now you can do basic image and container tasks for both system and user cont
 
  - This project is based on the [Cockpit Starter Kit](https://github.com/cockpit-project/starter-kit).
    See [Starter Kit Intro](http://cockpit-project.org/blog/cockpit-starter-kit.html) for details.
+
+# Automated release
+
+Releases are automated using [Cockpituous release](https://github.com/cockpit-project/cockpituous/tree/master/release)
+which aims to fully automate project releases to GitHub, Fedora, Ubuntu, COPR, Docker
+Hub, and other places. The intention is that the only manual step for releasing
+a project is to create a signed tag for the version number.
+
+The release steps are controlled by the
+[cockpituous-release](./cockpituous-release) script.
+
+Pushing the release tag triggers the [release.yml](.github/workflows/release.yml)
+[GitHub action](https://github.com/features/actions) workflow. This uses the
+[cockpit-project organization secrets](https://github.com/organizations/cockpit-project/settings/secrets).


### PR DESCRIPTION
Enter the new world of GitHub actions [1]/GitLab pipelines [2]. This
simplifies our end of the infrastructure considerably:

 * No need any more to set up webhooks, all the relevant configuration
   is right in the workflow file.

 * Does not need any infrastructure on our side any more, and thus works
   for third-party projects. They just need to set up their own secrets.

 * Gets rid of our webhook's special case for releases, which spawns an
   OpenShift Job (which means we can replace that webhook code with
   something more generic). Structually, spawning a Job is exactly like
   running an action/pipeline.

 * GitHub automatically provides a temporary `GITHUB_TOKEN` with
   sufficient write access to the project to publish a release, so we
   don't need to carry around that secret.

[1] https://github.com/features/actions
[2] https://docs.gitlab.com/ee/ci/pipelines/

Closes #153

 - [x] Disable release webhook