### PR TITLE
Update README: cockpit-docker no longer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 This is the [Cockpit](https://cockpit-project.org/) user interface for [podman
 containers](https://podman.io/).
 
-It is being actively developed and has not yet reached feature parity
-with [cockpit-docker](https://cockpit-project.org/guide/latest/feature-docker.html).
+It is being actively developed.
 For now you can do basic image and container tasks for both system and user containers.
 
 ## Technologies


### PR DESCRIPTION
cockpit-docker was dropped: cockpit-project/cockpit#14585