### PR TITLE
Run npm-update in a GitHub workflow

### DIFF
--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -1,0 +1,25 @@
+name: npm-update
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  # can be run manually on https://github.com/cockpit-project/cockpit-podman/actions
+  workflow_dispatch:
+jobs:
+  npm-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up dependencies
+        run: sudo apt-get install -y npm make
+
+      - name: Set up configuration and secrets
+        run: |
+          printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
+          echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
+
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Run npm-update bot
+        run: |
+          make bots
+          bots/npm-update

--- a/.tasks
+++ b/.tasks
@@ -9,6 +9,5 @@ fi
 
 if [ $chance -gt 9 ]; then
     # Open issues for things that need doing on a regular basis
-    bots/npm-trigger
     bots/po-trigger
 fi

--- a/README.md
+++ b/README.md
@@ -27,3 +27,11 @@ The release steps are controlled by the
 Pushing the release tag triggers the [release.yml](.github/workflows/release.yml)
 [GitHub action](https://github.com/features/actions) workflow. This uses the
 [cockpit-project organization secrets](https://github.com/organizations/cockpit-project/settings/secrets).
+
+# Automated maintenance
+
+It is important to keep your [NPM modules](./package.json) up to date, to keep
+up with security updates and bug fixes. This is done with the
+[npm-update bot script](https://github.com/cockpit-project/bots/blob/master/npm-update)
+which is run weekly or upon [manual request](https://github.com/cockpit-project/starter-kit/actions) through the
+[npm-update.yml](.github/workflows/npm-update.yml) [GitHub action](https://github.com/features/actions).


### PR DESCRIPTION
This avoids a lot of moving parts in our infrastructure (webhook,
npm-trigger roundtrip, tasks container) and does not need *any* secret
other than the automatically provided GitHub token.

Adopted from starter-kit: https://github.com/cockpit-project/starter-kit/pull/384