### PR TITLE
Run integration tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,29 @@
-dist: bionic
-sudo: false
-language: node_js
-node_js:
-  - "lts/*"
+dist: focal
+sudo: true
+language: minimal
+addons:
+  apt:
+    packages:
+      - appstream-util
+      - chromium-browser
+      - curl
+      - git
+      - libvirt-daemon-system
+      - npm
+      - python3-libvirt
+      - qemu-kvm
+      - qemu-utils
+      - rpm
+env:
+  - TEST_OS=fedora-33
 script:
-  - npm install
-  - npm run build
+  # HACK: /dev/kvm is root:kvm 0660 by default
+  - sudo chmod 666 /dev/kvm
+
+  # test PO template generation
+  - make po/podman.pot
+
+  # FIXME: build rpm inside VM; no installed rpms on Travis Ubuntu environment
+  - sed -i '/^BuildRequires:/d' *.spec.in
+
+  - TEST_JOBS=$(nproc) make check


### PR DESCRIPTION
Travis now offers /dev/kvm, and its machines are powerful enough to run
our browser integration tests, at least for small projects.

Building an RPM on the Ubuntu host environment is a bit tricky, as there
are no installed RPMs. Thus ignore the BuildRequires, and install
appstream-util explicitly. In the future, the rpm build should happen
inside the VM (like Cockpit does).

Add initial scenario for current Fedora.

Switch to the "minimal" environment to make the test easier to reproduce
locally and more explicit.