### PR TITLE
Makefile: Don't parse rpm name from `spec.in`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TEST_OS = fedora-32
 endif
 export TEST_OS
 TARFILE=cockpit-$(PACKAGE_NAME)-$(VERSION).tar.gz
-RPMFILE=$(shell rpmspec -D"VERSION $(VERSION)" -q cockpit-podman.spec.in).rpm
+RPMFILE=$(shell rpmspec -D"VERSION $(VERSION)" -q `ls cockpit-podman.spec.in cockpit-podman.spec 2>/dev/null | head -n1`).rpm
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check if/when npm install ran
 NODE_MODULES_TEST=package-lock.json


### PR DESCRIPTION
This file is not shipped in tar file.

Oh wow, someone took picture of me while I was writing this patch:
![i-have-no-idea-what-im-doing](https://user-images.githubusercontent.com/12330670/98217339-aae35c00-1f4a-11eb-9c15-2879b6532298.jpg)

seriously, WDYT @martinpitt, does it make sense? The point it that if someone tries to build it from tar file it reports:
```
/usr/bin/make install DESTDIR=/home/jnovy/rpmbuild/BUILDROOT/cockpit-podman-25-2.el8.x86_64 'INSTALL=/usr/bin/install -p'
error: Unable to open cockpit-podman.spec.in: No such file or directory
```