### PR TITLE
Add container migration support

### DIFF
--- a/lib/machines.js
+++ b/lib/machines.js
@@ -1,0 +1,798 @@
+import $ from "jquery";
+import cockpit from "cockpit";
+
+var mod = { };
+
+var known_hosts_path = "/etc/ssh/ssh_known_hosts";
+/*
+ * We share the Machines state between multiple frames. Only
+ * one frame has the job of loading the state, usually index.js
+ * The Loader code below does all the loading.
+ *
+ * The data is stored in sessionStorage in a JSON object, like this
+ * {
+ *    content: name → info dict from bridge's /machines Machines property
+ *    content: name → info dict from bridge's /machines Machines property
+ *    overlay: extra data to augment and override on top of content
+ * }
+ *
+ * This uses sessionStorage rather than cockpit.sessionStorage
+ * because we don't ever want to write unprefixed keys.
+ */
+
+var key = cockpit.sessionStorage.prefixedKey("v2-machines.json");
+var session_prefix = cockpit.sessionStorage.prefixedKey("v1-session-machine");
+
+function generate_session_key(host) {
+    return session_prefix + "/" + host;
+}
+
+export function host_superuser_storage_key(host) {
+    if (!host)
+        host = cockpit.transport.host;
+
+    const local_key = window.localStorage.getItem("superuser-key");
+    if (host == "localhost")
+        return local_key;
+    else if (host.indexOf("@") >= 0)
+        return "superuser:" + host;
+    else if (local_key)
+        return local_key + "@" + host;
+    else
+        return null;
+}
+
+export function get_host_superuser_value(host) {
+    const key = host_superuser_storage_key(host);
+    if (key)
+        return window.localStorage.getItem(key);
+    else
+        return null;
+}
+
+function Machines() {
+    var self = this;
+
+    var flat = null;
+    self.ready = false;
+
+    /* parsed machine data */
+    var machines = { };
+
+    /* Data shared between Machines() instances */
+    var last = {
+        content: null,
+        overlay: {
+            localhost: {
+                visible: true,
+                manifests: cockpit.manifests
+            }
+        }
+    };
+
+    function storage(ev) {
+        if (ev.key === key && ev.storageArea === window.sessionStorage)
+            refresh(JSON.parse(ev.newValue || "null"));
+    }
+
+    window.addEventListener("storage", storage);
+
+    window.setTimeout(function() {
+        var value = window.sessionStorage.getItem(key);
+        if (!self.ready && value)
+            refresh(JSON.parse(value));
+    });
+
+    var timeout = null;
+
+    function sync(machine, values, overlay) {
+        var desired = $.extend({ }, values || { }, overlay || { });
+        var prop;
+        for (prop in desired) {
+            if (machine[prop] !== desired[prop])
+                machine[prop] = desired[prop];
+        }
+        for (prop in machine) {
+            if (machine[prop] !== desired[prop])
+                delete machine[prop];
+        }
+        return machine;
+    }
+
+    function refresh(shared, push) {
+        if (!shared)
+            return;
+
+        var emit_ready = !self.ready;
+
+        self.ready = true;
+        last = shared;
+        flat = null;
+
+        if (push && !timeout) {
+            timeout = window.setTimeout(function() {
+                timeout = null;
+                window.sessionStorage.setItem(key, JSON.stringify(last));
+            }, 10);
+        }
+
+        var host;
+        var hosts = { };
+        var content = shared.content || { };
+        var overlay = shared.overlay || { };
+        for (host in content)
+            hosts[host] = true;
+        for (host in overlay)
+            hosts[host] = true;
+
+        var events = [];
+
+        var machine, application;
+        for (host in hosts) {
+            var old_machine = machines[host] || { };
+            var old_conns = old_machine.connection_string;
+
+            /* Invert logic for color, always respect what's on disk */
+            if (content[host] && content[host].color && overlay[host])
+                delete overlay[host].color;
+
+            machine = sync(old_machine, content[host], overlay[host]);
+
+            /* Fill in defaults */
+            machine.key = host;
+            if (!machine.address)
+                machine.address = host;
+
+            machine.connection_string = self.generate_connection_string(machine.user,
+                                                                        machine.port,
+                                                                        machine.address);
+
+            if (!machine.label) {
+                if (host == "localhost" || host == "localhost.localdomain") {
+                    application = cockpit.transport.application();
+                    if (application.indexOf('cockpit+=') === 0)
+                        machine.label = application.replace('cockpit+=', '');
+                    else
+                        machine.label = window.location.hostname;
+                } else {
+                    machine.label = host;
+                }
+            }
+            if (!machine.avatar)
+                machine.avatar = "../shell/images/server-small.png";
+
+            events.push([host in machines ? "updated" : "added",
+                [machine, host, old_conns]]);
+            machines[host] = machine;
+        }
+
+        /* Remove any lost hosts */
+        for (host in machines) {
+            if (!(host in hosts)) {
+                machine = machines[host];
+                delete machines[host];
+                delete overlay[host];
+                events.push(["removed", [machine, host]]);
+            }
+        }
+
+        /* Fire off all events */
+        var i;
+        var sel = $(self);
+        var len = events.length;
+        for (i = 0; i < len; i++)
+            sel.triggerHandler(events[i][0], events[i][1]);
+        if (emit_ready)
+            $(self).triggerHandler("ready");
+    }
+
+    function update_session_machine(machine, host, values) {
+        /* We don't save the whole machine object */
+        var skey = generate_session_key(host);
+        var data = $.extend({}, machine, values);
+        window.sessionStorage.setItem(skey, JSON.stringify(data));
+        self.overlay(host, values);
+        return cockpit.when([]);
+    }
+
+    function update_saved_machine(host, values) {
+        // wrap values in variants for D-Bus call; at least values.port can
+        // be int or string, so stringify everything but the "visible" boolean
+        var values_variant = {};
+        for (var prop in values) {
+            if (values[prop] !== null) {
+                if (prop == "visible")
+                    values_variant[prop] = cockpit.variant('b', values[prop]);
+                else
+                    values_variant[prop] = cockpit.variant('s', values[prop].toString());
+            }
+        }
+
+        // FIXME: investigate re-using the proxy from Loader (runs in different frame/scope)
+        var bridge = cockpit.dbus(null, { bus: "internal", superuser: "try" });
+        var mod = bridge.call("/machines", "cockpit.Machines", "Update", ["99-webui.json", host, values_variant])
+                .fail(function(error) {
+                    console.error("failed to call cockpit.Machines.Update(): ", error);
+                });
+
+        return mod;
+    }
+
+    self.add_key = function(host_key) {
+        var known_hosts = cockpit.file(known_hosts_path, { superuser: "try" });
+        return known_hosts
+                .modify(function(data) {
+                    if (!data)
+                        data = "";
+
+                    return data + "\n" + host_key;
+                })
+                .always(function() {
+                    known_hosts.close();
+                });
+    };
+
+    self.add = function add(connection_string, color) {
+        var values = self.split_connection_string(connection_string);
+        var host = values.address;
+
+        values = $.extend({
+            visible: true,
+            color: color || self.unused_color(),
+        }, values);
+
+        var machine = self.lookup(host);
+        if (machine)
+            machine.on_disk = true;
+
+        return self.change(values.address, values);
+    };
+
+    self.unused_color = function unused_color() {
+        var i;
+        var len = mod.colors.length;
+        for (i = 0; i < len; i++) {
+            if (!color_in_use(mod.colors[i]))
+                return mod.colors[i];
+        }
+        return "gray";
+    };
+
+    function color_in_use(color) {
+        var key, machine;
+        var norm = mod.colors.parse(color);
+        for (key in machines) {
+            machine = machines[key];
+            if (machine.color && mod.colors.parse(machine.color) == norm)
+                return true;
+        }
+        return false;
+    }
+
+    function merge(item, values) {
+        for (var prop in values) {
+            if (values[prop] === null)
+                delete item[prop];
+            else
+                item[prop] = values[prop];
+        }
+    }
+
+    self.change = function change(host, values) {
+        var mod, hostnamed, call;
+        var machine = self.lookup(host);
+
+        if (values.label) {
+            var conn_to = host;
+            if (machine)
+                conn_to = machine.connection_string;
+
+            if (!machine || machine.label !== values.label) {
+                hostnamed = cockpit.dbus("org.freedesktop.hostname1", { host: conn_to, superuser: "try" });
+                call = hostnamed.call("/org/freedesktop/hostname1", "org.freedesktop.hostname1",
+                                      "SetPrettyHostname", [values.label, true])
+                        .always(function() {
+                            hostnamed.close();
+                        })
+                        .fail(function(ex) {
+                            console.warn("couldn't set pretty host name: " + ex);
+                        });
+            }
+        }
+
+        if (machine && !machine.on_disk)
+            mod = update_session_machine(machine, host, values);
+        else
+            mod = update_saved_machine(host, values);
+
+        if (call)
+            // Can't use Promise.all() here, because this promise is sometimes
+            // passed to the dialog() function from pkg/lib/patterns.js, which
+            // expects a promise with a progress() method
+            return cockpit.all([call, mod]);
+
+        return mod;
+    };
+
+    self.data = function data(content) {
+        var host;
+        var changes = {};
+
+        for (host in content) {
+            changes[host] = $.extend({ }, last.overlay[host] || { });
+            merge(changes[host], { on_disk: true });
+        }
+
+        /* It's a full reload, so data not
+         * present is no longer from disk
+         */
+        for (host in machines) {
+            if (content && !content[host]) {
+                changes[host] = $.extend({ }, last.overlay[host] || { });
+                merge(changes[host], { on_disk: null });
+            }
+        }
+
+        refresh({
+            content: content,
+            overlay: $.extend({ }, last.overlay, changes)
+        }, true);
+    };
+
+    self.overlay = function overlay(host, values) {
+        var changes = { };
+        changes[host] = $.extend({ }, last.overlay[host] || { });
+        merge(changes[host], values);
+        refresh({
+            content: last.content,
+            overlay: $.extend({ }, last.overlay, changes)
+        }, true);
+    };
+
+    Object.defineProperty(self, "list", {
+        enumerable: true,
+        get: function get() {
+            var key;
+            if (!flat) {
+                flat = [];
+                for (key in machines) {
+                    if (machines[key].visible)
+                        flat.push(machines[key]);
+                }
+                flat.sort(function(m1, m2) {
+                    return m1.label.localeCompare(m2.label);
+                });
+            }
+            return flat;
+        }
+    });
+
+    Object.defineProperty(self, "addresses", {
+        enumerable: true,
+        get: function get() {
+            return Object.keys(machines);
+        }
+    });
+
+    self.lookup = function lookup(address) {
+        var parts = self.split_connection_string(address);
+        return machines[parts.address || "localhost"] || null;
+    };
+
+    self.generate_connection_string = function (user, port, addr) {
+        var address = addr;
+        if (user)
+            address = user + "@" + address;
+
+        if (port)
+            address = address + ":" + port;
+
+        return address;
+    };
+
+    self.split_connection_string = function(conn_to) {
+        var parts = {};
+        var user_spot = -1;
+        var port_spot = -1;
+
+        if (conn_to) {
+            user_spot = conn_to.lastIndexOf('@');
+            port_spot = conn_to.lastIndexOf(':');
+        }
+
+        if (user_spot > 0) {
+            parts.user = conn_to.substring(0, user_spot);
+            conn_to = conn_to.substring(user_spot + 1);
+            port_spot = conn_to.lastIndexOf(':');
+        }
+
+        if (port_spot > -1) {
+            var port = parseInt(conn_to.substring(port_spot + 1), 10);
+            if (!isNaN(port)) {
+                parts.port = port;
+                conn_to = conn_to.substring(0, port_spot);
+            }
+        }
+
+        parts.address = conn_to;
+        return parts;
+    };
+
+    self.close = function close() {
+        window.removeEventListener("storage", storage);
+    };
+}
+
+function Loader(machines, session_only) {
+    var self = this;
+
+    /* Have we loaded from cockpit session */
+    var session_loaded = false;
+
+    /* echo channels to each machine */
+    var channels = { };
+
+    /* hostnamed proxies to each machine, if hostnamed available */
+    var proxies = { };
+
+    /* clients for the bridge D-Bus API */
+    var bridge_dbus = { };
+
+    function process_session_key(key, value) {
+        var host, values, machine;
+        var parts = key.split("/");
+        if (parts[0] == session_prefix &&
+            parts.length === 2) {
+            host = parts[1];
+            if (value) {
+                values = JSON.parse(value);
+                machine = machines.lookup(host);
+                if (!machine || !machine.on_disk)
+                    machines.overlay(host, values);
+                else if (!machine.visible)
+                    machines.change(host, { visible: true });
+                self.connect(host);
+            }
+        }
+    }
+
+    function load_from_session_storage() {
+        var i;
+        session_loaded = true;
+        for (i = 0; i < window.sessionStorage.length; i++) {
+            var k = window.sessionStorage.key(i);
+            process_session_key(k, window.sessionStorage.getItem(k));
+        }
+    }
+
+    function process_session_machines(ev) {
+        if (ev.storageArea === window.sessionStorage)
+            process_session_key(ev.key || "", ev.newValue);
+    }
+    window.addEventListener("storage", process_session_machines);
+
+    function state(host, value, problem) {
+        var values = { state: value, problem: problem };
+        if (value == "connected") {
+            values.restarting = false;
+        } else if (problem) {
+            values.manifests = null;
+            values.checksum = null;
+            if (problem == "authentication-failed" || problem == "authentication-not-supported")
+                values.restarting = false;
+        }
+        machines.overlay(host, values);
+    }
+
+    $(machines).on("added", updated);
+    $(machines).on("updated", updated);
+    $(machines).on("removed", removed);
+
+    function updated(ev, machine, host, old_conns) {
+        if (!machine) {
+            machine = machines.lookup(host);
+            if (!machine)
+                return;
+        }
+
+        var props = proxies[host];
+        if (!props || !props.valid)
+            props = { };
+
+        var overlay = { };
+
+        if (!machine.color)
+            overlay.color = machines.unused_color();
+
+        var label = props.PrettyHostname || props.StaticHostname;
+        if (label && label !== machine.label)
+            overlay.label = label;
+
+        var os = props.OperatingSystemPrettyName;
+        if (os && os != machine.os)
+            overlay.os = props.OperatingSystemPrettyName;
+
+        if (!$.isEmptyObject(overlay))
+            machines.overlay(host, overlay);
+
+        /* Don't automatically reconnect failed machines */
+        if (machine.visible) {
+            if (old_conns && machine.connection_string != old_conns) {
+                cockpit.kill(old_conns);
+                self.disconnect(host);
+                self.connect(host);
+            } else if (!machine.problem) {
+                self.connect(host);
+            }
+        } else {
+            self.disconnect(host);
+        }
+    }
+
+    function removed(ev, machine, host) {
+        self.disconnect(host);
+    }
+
+    self.connect = function connect(host) {
+        var machine = machines.lookup(host);
+        if (!machine)
+            return;
+
+        var channel = channels[host];
+        if (channel)
+            return;
+
+        var options = {
+            host: machine.connection_string,
+            payload: "echo",
+            "init-superuser": get_host_superuser_value(machine.connection_string)
+        };
+
+        if (!machine.on_disk && machine.host_key) {
+            options['temp-session'] = false; /* Compatibility option */
+            options.session = 'shared';
+            options['host-key'] = machine.host_key;
+        }
+
+        channel = cockpit.channel(options);
+        channels[host] = channel;
+
+        var local = host === "localhost";
+
+        /* Request is null, and message is true when connected */
+        var request = null;
+        var open = local;
+        var problem = null;
+
+        var url;
+        if (!machine.manifests) {
+            if (machine.checksum)
+                url = "../../" + machine.checksum + "/manifests.json";
+            else
+                url = "../../@" + encodeURI(machine.connection_string) + "/manifests.json";
+        }
+
+        function whirl() {
+            if (!request && open)
+                state(host, "connected", null);
+            else if (!problem)
+                state(host, "connecting", null);
+        }
+
+        /* Here we load the machine manifests, and expect them before going to "connected" */
+        function request_manifest() {
+            request = $.ajax({ url: url, dataType: "json", cache: true })
+                    .done(function(manifests) {
+                        var overlay = { manifests: manifests };
+                        var etag = request.getResponseHeader("ETag");
+                        if (etag) /* and remove quotes */
+                            overlay.checksum = etag.replace(/^"(.+)"$/, '$1');
+                        machines.overlay(host, overlay);
+                    })
+                    .fail(function(ex) {
+                        console.warn("failed to load manifests from " + machine.connection_string + ": " + ex);
+                    })
+                    .always(function() {
+                        request = null;
+                        whirl();
+                    });
+        }
+
+        /* Try to get change notifications via the internal
+           /packages D-Bus interface of the bridge.  Not all
+           bridges support this API, so we still get the first
+           version of the manifests via HTTP in request_manifest.
+        */
+
+        function watch_manifests() {
+            var dbus = cockpit.dbus(null, {
+                bus: "internal",
+                host: machine.connection_string
+            });
+            bridge_dbus[host] = dbus;
+            dbus.subscribe({
+                path: "/packages",
+                interface: "org.freedesktop.DBus.Properties",
+                member: "PropertiesChanged"
+            },
+                           function (path, iface, mamber, args) {
+                               if (args[0] == "cockpit.Packages") {
+                                   if (args[1].Manifests) {
+                                       var manifests = JSON.parse(args[1].Manifests.v);
+                                       machines.overlay(host, { manifests: manifests });
+                                   }
+                               }
+                           });
+
+            /* Tell the bridge to reload the packages, but only if
+               it hasn't just started.  Thus, nothing happens on
+               the first login, but if you reload the shell, we
+               will also reload the packages.
+            */
+            dbus.call("/packages", "cockpit.Packages", "ReloadHint", []);
+        }
+
+        function request_hostname() {
+            if (!machine.static_hostname) {
+                var proxy = cockpit.dbus("org.freedesktop.hostname1",
+                                         { host: machine.connection_string }).proxy();
+                proxies[host] = proxy;
+                proxy.wait(function() {
+                    $(proxy).on("changed", function() {
+                        updated(null, null, host);
+                    });
+                    updated(null, null, host);
+                });
+            }
+        }
+
+        /* Send a message to the server and get back a message once connected */
+        if (!local) {
+            channel.send("x");
+
+            $(channel)
+                    .on("message", function() {
+                        open = true;
+                        if (url)
+                            request_manifest();
+                        watch_manifests();
+                        request_hostname();
+                        whirl();
+                    })
+                    .on("close", function(ev, options) {
+                        var m = machines.lookup(host);
+                        open = false;
+                        // reset to clean state when removing machine (orderly disconnect), otherwise mark as failed
+                        if (!options.problem && m && !m.visible)
+                            state(host, null, null);
+                        else
+                            state(host, "failed", options.problem || "disconnected");
+                        if (m && m.restarting) {
+                            window.setTimeout(function() {
+                                self.connect(host);
+                            }, 10000);
+                        }
+                        self.disconnect(host);
+                    });
+        } else {
+            if (url)
+                request_manifest();
+            watch_manifests();
+            request_hostname();
+        }
+
+        /* In case already ready, for example when local */
+        whirl();
+    };
+
+    self.disconnect = function disconnect(host) {
+        if (host === "localhost")
+            return;
+
+        var channel = channels[host];
+        delete channels[host];
+        if (channel) {
+            channel.close();
+            $(channel).off();
+        }
+
+        var proxy = proxies[host];
+        delete proxies[host];
+        if (proxy) {
+            proxy.client.close();
+            $(proxy).off();
+        }
+
+        var dbus = bridge_dbus[host];
+        delete bridge_dbus[host];
+        if (dbus) {
+            dbus.close();
+        }
+    };
+
+    self.expect_restart = function expect_restart(host) {
+        var parts = machines.split_connection_string(host);
+        machines.overlay(parts.address, {
+            restarting: true,
+            problem: null
+        });
+    };
+
+    self.close = function close() {
+        $(machines).off("added", updated);
+        $(machines).off("changed", updated);
+        $(machines).off("removed", removed);
+        machines = null;
+
+        window.removeEventListener("storage", process_session_machines);
+        var hosts = Object.keys(channels);
+        hosts.forEach(self.disconnect);
+    };
+
+    if (!session_only) {
+        var proxy = cockpit.dbus(null, { bus: "internal" }).proxy("cockpit.Machines", "/machines");
+        $(proxy).on("changed", function(data) {
+            // unwrap variants from D-Bus call
+            var wrapped = proxy.Machines;
+            var data_unwrap = {};
+            var host_props;
+            for (var host in wrapped) {
+                host_props = {};
+                for (var prop in wrapped[host])
+                    host_props[prop] = wrapped[host][prop].v;
+                data_unwrap[host] = host_props;
+            }
+
+            machines.data(data_unwrap);
+            if (!session_loaded)
+                load_from_session_storage();
+        });
+    } else {
+        load_from_session_storage();
+        machines.data({});
+    }
+}
+
+mod.instance = function instance(loader) {
+    return new Machines();
+};
+
+mod.loader = function loader(machines, session_only) {
+    return new Loader(machines, session_only);
+};
+
+mod.colors = [
+    "#0099d3",
+    "#67d300",
+    "#d39e00",
+    "#d3007c",
+    "#00d39f",
+    "#00d1d3",
+    "#00618a",
+    "#4c8a00",
+    "#8a6600",
+    "#9b005b",
+    "#008a55",
+    "#008a8a",
+    "#00b9ff",
+    "#7dff00",
+    "#ffbe00",
+    "#ff0096",
+    "#00ffc0",
+    "#00fdff",
+    "#023448",
+    "#264802",
+    "#483602",
+    "#590034",
+    "#024830",
+    "#024848"
+];
+
+mod.colors.parse = function parse_color(input) {
+    var div = document.createElement('div');
+    div.style.color = input;
+    var style = window.getComputedStyle(div, null);
+    return style.getPropertyValue("color") || div.style.color;
+};
+
+export const machines = mod;

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@patternfly/react-core": "4.84.4",
     "@patternfly/react-table": "4.19.45",
     "docker-names": "1.1.1",
+    "jquery": "3.5.1",
     "moment": "2.29.1",
     "prop-types": "15.7.2",
     "react": "16.14.0",

--- a/src/ContainerMigrateModal.jsx
+++ b/src/ContainerMigrateModal.jsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { Modal } from 'patternfly-react';
+import { Button, Checkbox, Select, SelectOption } from '@patternfly/react-core';
+import cockpit from 'cockpit';
+
+const _ = cockpit.gettext;
+const targetHostPlaceholder = _("Choose target host...");
+
+class ContainerMigrateModal extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            targetHost: targetHostPlaceholder,
+            targetHostOpen: false,
+            keep: false,
+            leaveRunning: false,
+            tcpEstablished: false,
+            ignoreRootFS: false
+        };
+        this.handleChange = this.handleChange.bind(this);
+    }
+
+    handleChange(checked, event) {
+        if (event.target.type === "checkbox")
+            this.setState({ [event.target.name]: event.target.checked });
+    }
+
+    render() {
+        return (
+            <Modal show={this.props.selectContainerMigrateModal}>
+                <Modal.Header>
+                    <Modal.Title>
+                        {_("Migrate running container to another host")}
+                    </Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <div className="ct-form">
+                        <label className="control-label" htmlFor="migrate-dialog-container">
+                            {_("Container")}
+                        </label>
+                        <div id="migrate-dialog-container">{this.props.containerWillMigrate.Names}</div>
+
+                        <label className="control-label" htmlFor="migrate-dialog-target-host">
+                            {_("Target host")}
+                        </label>
+                        <Select id="migrate-dialog-target-host" isOpen={this.state.targetHostOpen}
+                                selections={this.state.targetHost}
+                                onToggle={targetHostOpen => this.setState({ targetHostOpen })}
+                                onSelect={(event, targetHost) => this.setState({ targetHost, targetHostOpen: false })}>
+                            {
+                                Object.keys(this.props.remoteHosts).map(host =>
+                                    <SelectOption value={this.props.remoteHosts[host]} key={host} />)
+                                        .concat([<SelectOption value={targetHostPlaceholder} key="_placeholder"
+                                                               isPlaceholder />])
+                            }
+                        </Select>
+
+                        <label className="control-label" htmlFor="migrate-dialog-keep">
+                            {_("Keep all temporary checkpoint files")}
+                        </label>
+                        <Checkbox id="migrate-dialog-keep" name="keep" isChecked={this.state.keep}
+                                  onChange={this.handleChange} />
+
+                        <label className="control-label" htmlFor="migrate-dialog-leaveRunning">
+                            {_("Leave running after migration")}
+                        </label>
+                        <Checkbox id="migrate-dialog-leaveRunning" name="leaveRunning"
+                                  isChecked={this.state.leaveRunning} onChange={this.handleChange} />
+
+                        <label className="control-label" htmlFor="migrate-dialog-tcpEstablished">
+                            {_("Preserve established TCP connections")}
+                        </label>
+                        <Checkbox id="migrate-dialog-tcpEstablished" name="tcpEstablished"
+                                  isChecked={this.state.tcpEstablished} onChange={this.handleChange} />
+
+                        <label className="control-label" htmlFor="migrate-dialog-ignoreRootFS">
+                            {_("Do not migrate root file-system changes")}
+                        </label>
+                        <Checkbox id="migrate-dialog-ignoreRootFS" name="ignoreRootFS"
+                                  isChecked={this.state.ignoreRootFS} onChange={this.handleChange} />
+
+                        <label className="control-label" htmlFor="migrate-dialog-ignoreStaticIP">
+                            {_("Ignore IP address if set statically")}
+                        </label>
+                        <Checkbox id="migrate-dialog-ignoreStaticIP" name="ignoreStaticIP"
+                                  isChecked={this.state.ignoreRootFS} onChange={this.handleChange} />
+
+                        <label className="control-label" htmlFor="migrate-dialog-ignoreStaticMAC">
+                            {_("Ignore MAC address if set statically")}
+                        </label>
+                        <Checkbox id="migrate-dialog-ignoreStaticMAC" name="ignoreStaticMAC"
+                                  isChecked={this.state.ignoreStaticMAC} onChange={this.handleChange} />
+                    </div>
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button variant="primary" isDisabled={this.props.migrateInProgress ||
+                                                          this.state.targetHost === targetHostPlaceholder}
+                            onClick={() => this.props.handleMigrateContainer(this.state, this.state.targetHost)}>
+                        {_("Migrate")}
+                    </Button>
+                    <Button variant="link" onClick={this.props.handleMigrateContainerDeleteModal}>
+                        {_("Cancel")}
+                    </Button>
+                    <label className="migration-progress">
+                        {this.props.migrationStateLabel}
+                    </label>
+                    {this.props.migrateInProgress && <div className="spinner spinner-sm pull-right" />}
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+}
+
+export default ContainerMigrateModal;

--- a/src/ContainerMigrateModal.jsx
+++ b/src/ContainerMigrateModal.jsx
@@ -1,23 +1,36 @@
 import React from 'react';
-import { Modal } from 'patternfly-react';
-import { Button, Checkbox, Select, SelectOption } from '@patternfly/react-core';
+import { Button, Checkbox, Modal, Select, SelectOption, TextInput } from '@patternfly/react-core';
 import cockpit from 'cockpit';
+import * as client from './client.js';
 
 const _ = cockpit.gettext;
-const targetHostPlaceholder = _("Choose target host...");
 
 class ContainerMigrateModal extends React.Component {
     constructor(props) {
         super(props);
+        this.targetHostPlaceholder = _("Choose target host...");
+        this.targetContainerPlaceholder = _("Create new container");
+        this.targetContainerLoading = _("Loading container list...");
+        this.targetContainerError = _("Error loading container list");
         this.state = {
-            targetHost: targetHostPlaceholder,
+            targetHost: this.targetHostPlaceholder,
             targetHostOpen: false,
+            targetContainer: this.targetContainerPlaceholder,
+            targetContainerList: [],
+            targetContainerOpen: false,
+            targetContainerLoading: false,
+            targetContainerError: false,
+            targetContainerName: "",
             keep: false,
             leaveRunning: false,
             tcpEstablished: false,
             ignoreRootFS: false
         };
         this.handleChange = this.handleChange.bind(this);
+        this.handleTargetHostSelect = this.handleTargetHostSelect.bind(this);
+        this.handleTargetContainerSelect = this.handleTargetContainerSelect.bind(this);
+        this.isTargetContainerDisabled = this.isTargetContainerDisabled.bind(this);
+        this.getContainerName = this.getContainerName.bind(this);
     }
 
     handleChange(checked, event) {
@@ -25,87 +38,182 @@ class ContainerMigrateModal extends React.Component {
             this.setState({ [event.target.name]: event.target.checked });
     }
 
+    handleTargetHostSelect(event, targetHost) {
+        this.setState({ targetHost, targetHostOpen: false });
+
+        if (targetHost !== this.targetHostPlaceholder) {
+            // Update target container list based on the host
+            this.setState({ targetContainerLoading: true, targetContainer: this.targetContainerLoading });
+            const modal = this;
+            client.getContainers(true, undefined, targetHost)
+                    .then(function (containers) {
+                        const newContainerList = [];
+                        for (const container of containers)
+                            newContainerList.push(container.Names[0]);
+                        modal.setState({
+                            targetContainerLoading: false,
+                            targetContainer: modal.targetContainerPlaceholder,
+                            targetContainerList: newContainerList
+                        });
+                    })
+                    .catch(function() {
+                        modal.setState({
+                            targetContainerLoading: false,
+                            targetContainerError: true,
+                            targetContainer: modal.targetContainerError,
+                            targetContainerList: []
+                        });
+                    });
+        } else {
+            this.setState({
+                targetContainer: this.targetContainerPlaceholder,
+                targetContainerList: [],
+                targetContainerLoading: false,
+                targetContainerError: false
+            });
+        }
+    }
+
+    handleTargetContainerSelect(event, targetContainer) {
+        this.setState({ targetContainer, targetContainerOpen: false });
+    }
+
+    isTargetContainerDisabled() {
+        return this.state.targetHost === this.targetHostPlaceholder || this.state.targetContainerLoading;
+    }
+
+    getContainerName() {
+        if (this.state.targetContainer === this.targetContainerError ||
+            this.state.targetContainer === this.targetContainerLoading)
+            return null;
+
+        if (this.state.targetContainer === this.targetContainerPlaceholder)
+            return this.state.targetContainerName;
+
+        return this.state.targetContainer;
+    }
+
     render() {
         return (
-            <Modal show={this.props.selectContainerMigrateModal}>
-                <Modal.Header>
-                    <Modal.Title>
-                        {_("Migrate running container to another host")}
-                    </Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
-                    <div className="ct-form">
-                        <label className="control-label" htmlFor="migrate-dialog-container">
-                            {_("Container")}
-                        </label>
-                        <div id="migrate-dialog-container">{this.props.containerWillMigrate.Names}</div>
-
-                        <label className="control-label" htmlFor="migrate-dialog-target-host">
-                            {_("Target host")}
-                        </label>
-                        <Select id="migrate-dialog-target-host" isOpen={this.state.targetHostOpen}
-                                selections={this.state.targetHost}
-                                onToggle={targetHostOpen => this.setState({ targetHostOpen })}
-                                onSelect={(event, targetHost) => this.setState({ targetHost, targetHostOpen: false })}>
-                            {
-                                Object.keys(this.props.remoteHosts).map(host =>
-                                    <SelectOption value={this.props.remoteHosts[host]} key={host} />)
-                                        .concat([<SelectOption value={targetHostPlaceholder} key="_placeholder"
-                                                               isPlaceholder />])
-                            }
-                        </Select>
-
-                        <label className="control-label" htmlFor="migrate-dialog-keep">
-                            {_("Keep all temporary checkpoint files")}
-                        </label>
-                        <Checkbox id="migrate-dialog-keep" name="keep" isChecked={this.state.keep}
-                                  onChange={this.handleChange} />
-
-                        <label className="control-label" htmlFor="migrate-dialog-leaveRunning">
-                            {_("Leave running after migration")}
-                        </label>
-                        <Checkbox id="migrate-dialog-leaveRunning" name="leaveRunning"
-                                  isChecked={this.state.leaveRunning} onChange={this.handleChange} />
-
-                        <label className="control-label" htmlFor="migrate-dialog-tcpEstablished">
-                            {_("Preserve established TCP connections")}
-                        </label>
-                        <Checkbox id="migrate-dialog-tcpEstablished" name="tcpEstablished"
-                                  isChecked={this.state.tcpEstablished} onChange={this.handleChange} />
-
-                        <label className="control-label" htmlFor="migrate-dialog-ignoreRootFS">
-                            {_("Do not migrate root file-system changes")}
-                        </label>
-                        <Checkbox id="migrate-dialog-ignoreRootFS" name="ignoreRootFS"
-                                  isChecked={this.state.ignoreRootFS} onChange={this.handleChange} />
-
-                        <label className="control-label" htmlFor="migrate-dialog-ignoreStaticIP">
-                            {_("Ignore IP address if set statically")}
-                        </label>
-                        <Checkbox id="migrate-dialog-ignoreStaticIP" name="ignoreStaticIP"
-                                  isChecked={this.state.ignoreRootFS} onChange={this.handleChange} />
-
-                        <label className="control-label" htmlFor="migrate-dialog-ignoreStaticMAC">
-                            {_("Ignore MAC address if set statically")}
-                        </label>
-                        <Checkbox id="migrate-dialog-ignoreStaticMAC" name="ignoreStaticMAC"
-                                  isChecked={this.state.ignoreStaticMAC} onChange={this.handleChange} />
-                    </div>
-                </Modal.Body>
-                <Modal.Footer>
-                    <Button variant="primary" isDisabled={this.props.migrateInProgress ||
-                                                          this.state.targetHost === targetHostPlaceholder}
-                            onClick={() => this.props.handleMigrateContainer(this.state, this.state.targetHost)}>
-                        {_("Migrate")}
-                    </Button>
-                    <Button variant="link" onClick={this.props.handleMigrateContainerDeleteModal}>
-                        {_("Cancel")}
-                    </Button>
-                    <label className="migration-progress">
-                        {this.props.migrationStateLabel}
+            <Modal isOpen={this.props.selectContainerMigrateModal}
+                   showClose={false}
+                   position="top" variant="medium"
+                   onClose={this.props.handleMigrateContainerDeleteModal}
+                   title={_("Migrate running container to another host")}
+                   footer={<>
+                       <Button variant="primary" isDisabled={this.props.migrateInProgress ||
+                                                             this.state.targetHost === this.targetHostPlaceholder ||
+                                                             this.state.targetContainer === this.targetContainerError}
+                               onClick={() => this.props.handleMigrateContainer(this.state, this.state.targetHost,
+                                                                                this.getContainerName())}>
+                           {_("Migrate")}
+                       </Button>
+                       <Button variant="link" isDisabled={this.props.migrateInProgress}
+                               onClick={this.props.handleMigrateContainerDeleteModal}>
+                           {_("Cancel")}
+                       </Button>
+                       <label className="migration-progress">
+                           {this.props.migrationStateLabel}
+                       </label>
+                       {this.props.migrateInProgress && <div className="spinner spinner-sm pull-right" />}
+                   </>}
+            >
+                <div className="ct-form">
+                    <label className="control-label" htmlFor="migrate-dialog-container">
+                        {_("Container")}
                     </label>
-                    {this.props.migrateInProgress && <div className="spinner spinner-sm pull-right" />}
-                </Modal.Footer>
+                    <div id="migrate-dialog-container">{this.props.containerWillMigrate.Names}</div>
+
+                    <label className="control-label" htmlFor="migrate-dialog-target-host">
+                        {_("Target host")}
+                    </label>
+                    <Select id="migrate-dialog-target-host" isOpen={this.state.targetHostOpen}
+                            selections={this.state.targetHost}
+                            onToggle={targetHostOpen => this.setState({ targetHostOpen })}
+                            onSelect={this.handleTargetHostSelect}>
+                        {
+                            Object.keys(this.props.remoteHosts).map(host =>
+                                <SelectOption value={this.props.remoteHosts[host]} key={host} />)
+                                    .concat([<SelectOption value={this.targetHostPlaceholder} key="_placeholder"
+                                                           isPlaceholder />])
+                        }
+                    </Select>
+
+                    <label className="control-label" htmlFor="migrate-dialog-target-container">
+                        {_("Target container")}
+                    </label>
+                    <Select id="migrate-dialog-target-container" isOpen={this.state.targetContainerOpen}
+                            selections={this.state.targetContainer} isDisabled={this.isTargetContainerDisabled()}
+                            onToggle={targetContainerOpen => this.setState({ targetContainerOpen })}
+                            onSelect={this.handleTargetContainerSelect}>
+                        {
+                            this.state.targetContainerList.map(container => <SelectOption value={container}
+                                                                                          key={container} />)
+                                    .concat([
+                                        <SelectOption value={this.targetContainerPlaceholder} key="_placeholder"
+                                                      isPlaceholder />,
+                                        this.state.targetContainerLoading
+                                            ? <SelectOption value={this.targetContainerLoading} key="_placeholder2"
+                                                            isPlaceholder />
+                                            : <></>,
+                                        this.state.targetContainerError
+                                            ? <SelectOption value={this.targetContainerError} key="_placeholder3"
+                                                            isPlaceholder />
+                                            : <></>
+                                    ])
+                        }
+                    </Select>
+
+                    {
+                        (this.state.targetContainer === this.targetContainerPlaceholder &&
+                         this.state.targetHost !== this.targetHostPlaceholder)
+                            ? <>
+                                <label className="control-label" htmlFor="migrate-container-target-name">
+                                    {_("Target container name")}
+                                </label>
+                                <TextInput id="migrate-container-target-name" text={this.state.targetContainerName}
+                                           onChange={targetContainerName =>
+                                               this.setState({ targetContainerName })} />
+                            </>
+                            : null
+                    }
+
+                    <label className="control-label" htmlFor="migrate-dialog-keep">
+                        {_("Keep all temporary checkpoint files")}
+                    </label>
+                    <Checkbox id="migrate-dialog-keep" name="keep" isChecked={this.state.keep}
+                              onChange={this.handleChange} />
+
+                    <label className="control-label" htmlFor="migrate-dialog-leaveRunning">
+                        {_("Leave running after migration")}
+                    </label>
+                    <Checkbox id="migrate-dialog-leaveRunning" name="leaveRunning"
+                              isChecked={this.state.leaveRunning} onChange={this.handleChange} />
+
+                    <label className="control-label" htmlFor="migrate-dialog-tcpEstablished">
+                        {_("Preserve established TCP connections")}
+                    </label>
+                    <Checkbox id="migrate-dialog-tcpEstablished" name="tcpEstablished"
+                              isChecked={this.state.tcpEstablished} onChange={this.handleChange} />
+
+                    <label className="control-label" htmlFor="migrate-dialog-ignoreRootFS">
+                        {_("Do not migrate root file-system changes")}
+                    </label>
+                    <Checkbox id="migrate-dialog-ignoreRootFS" name="ignoreRootFS"
+                              isChecked={this.state.ignoreRootFS} onChange={this.handleChange} />
+
+                    <label className="control-label" htmlFor="migrate-dialog-ignoreStaticIP">
+                        {_("Ignore IP address if set statically")}
+                    </label>
+                    <Checkbox id="migrate-dialog-ignoreStaticIP" name="ignoreStaticIP"
+                              isChecked={this.state.ignoreRootFS} onChange={this.handleChange} />
+
+                    <label className="control-label" htmlFor="migrate-dialog-ignoreStaticMAC">
+                        {_("Ignore MAC address if set statically")}
+                    </label>
+                    <Checkbox id="migrate-dialog-ignoreStaticMAC" name="ignoreStaticMAC"
+                              isChecked={this.state.ignoreStaticMAC} onChange={this.handleChange} />
+                </div>
             </Modal>
         );
     }

--- a/src/ContainerMigrateModal.jsx
+++ b/src/ContainerMigrateModal.jsx
@@ -155,11 +155,11 @@ class ContainerMigrateModal extends React.Component {
                                         this.state.targetContainerLoading
                                             ? <SelectOption value={this.targetContainerLoading} key="_placeholder2"
                                                             isPlaceholder />
-                                            : <></>,
+                                            : <React.Fragment key="null" />,
                                         this.state.targetContainerError
                                             ? <SelectOption value={this.targetContainerError} key="_placeholder3"
                                                             isPlaceholder />
-                                            : <></>
+                                            : <React.Fragment key="null2" />
                                     ])
                         }
                     </Select>

--- a/src/ContainerMigrateModal.jsx
+++ b/src/ContainerMigrateModal.jsx
@@ -1,5 +1,16 @@
 import React from 'react';
-import { Button, Checkbox, Modal, Select, SelectOption, TextInput } from '@patternfly/react-core';
+import {
+    Button,
+    Checkbox,
+    FormGroup,
+    Modal,
+    Radio,
+    Select,
+    SelectOption,
+    TextInput,
+    ValidatedOptions
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import cockpit from 'cockpit';
 import * as client from './client.js';
 
@@ -8,28 +19,41 @@ const _ = cockpit.gettext;
 class ContainerMigrateModal extends React.Component {
     constructor(props) {
         super(props);
-        this.targetHostPlaceholder = _("Choose target host...");
-        this.targetContainerPlaceholder = _("Create new container");
-        this.targetContainerLoading = _("Loading container list...");
-        this.targetContainerError = _("Error loading container list");
+        this.strings = {
+            targetHostPlaceholder: _("Choose target host..."),
+            targetHostInaccessible: _("Connection failed"),
+            targetContainerDefaultPlaceholder: _("Choose container..."),
+            targetContainerLoadingPlaceholder: _("Loading container list..."),
+            targetContainerErrorPlaceholder: _("Error loading container list"),
+            targetContainerNameErrorEmpty: _("Container name can't be empty"),
+            targetContainerNameErrorContainerExists: _("Container with that name already exists")
+        };
         this.state = {
-            targetHost: this.targetHostPlaceholder,
+            action: "new-container",
+            targetHost: this.strings.targetHostPlaceholder,
+            targetHostValidated: ValidatedOptions.default,
             targetHostOpen: false,
-            targetContainer: this.targetContainerPlaceholder,
+            targetContainer: null,
             targetContainerList: [],
             targetContainerOpen: false,
-            targetContainerLoading: false,
-            targetContainerError: false,
             targetContainerName: "",
+            targetContainerNameValidated: ValidatedOptions.default,
+            targetContainerNameError: null,
+            targetContainerPlaceholder: this.strings.targetContainerDefaultPlaceholder,
             keep: false,
             leaveRunning: false,
             tcpEstablished: false,
-            ignoreRootFS: false
+            ignoreRootFS: false,
+            ignoreStaticIP: false,
+            ignoreStaticMAC: false
         };
         this.handleChange = this.handleChange.bind(this);
+        this.handleActionSelect = this.handleActionSelect.bind(this);
         this.handleTargetHostSelect = this.handleTargetHostSelect.bind(this);
+        this.handleTargetContainerNameChange = this.handleTargetContainerNameChange.bind(this);
         this.handleTargetContainerSelect = this.handleTargetContainerSelect.bind(this);
         this.isTargetContainerDisabled = this.isTargetContainerDisabled.bind(this);
+        this.isMigrateButtonDisabled = this.isMigrateButtonDisabled.bind(this);
         this.getContainerName = this.getContainerName.bind(this);
     }
 
@@ -38,12 +62,27 @@ class ContainerMigrateModal extends React.Component {
             this.setState({ [event.target.name]: event.target.checked });
     }
 
+    handleActionSelect(checked, event) {
+        if (event.target.id === "migrate-dialog-action-new-container") {
+            this.setState({
+                action: "new-container"
+            });
+        } else if (event.target.id === "migrate-dialog-action-existing-container") {
+            this.setState({
+                action: "existing-container"
+            });
+        }
+    }
+
     handleTargetHostSelect(event, targetHost) {
         this.setState({ targetHost, targetHostOpen: false });
 
-        if (targetHost !== this.targetHostPlaceholder) {
+        if (targetHost !== this.strings.targetHostPlaceholder) {
             // Update target container list based on the host
-            this.setState({ targetContainerLoading: true, targetContainer: this.targetContainerLoading });
+            this.setState({
+                targetContainerPlaceholder: this.strings.targetContainerLoadingPlaceholder,
+                targetContainerList: []
+            });
             const modal = this;
             client.getContainers(true, undefined, targetHost)
                     .then(function (containers) {
@@ -51,27 +90,60 @@ class ContainerMigrateModal extends React.Component {
                         for (const container of containers)
                             newContainerList.push(container.Names[0]);
                         modal.setState({
-                            targetContainerLoading: false,
-                            targetContainer: modal.targetContainerPlaceholder,
+                            targetHostValidated: ValidatedOptions.default,
+                            targetContainerPlaceholder: modal.strings.targetContainerDefaultPlaceholder,
+                            targetContainer: modal.strings.targetContainerPlaceholder,
                             targetContainerList: newContainerList
                         });
+
+                        // Update target container name field
+                        modal.handleTargetContainerNameChange(modal.state.targetContainerName);
                     })
-                    .catch(function() {
+                    .catch(function(error) {
+                        console.warn(`Couldn't connect to remote host: ${JSON.stringify(error)}`);
                         modal.setState({
-                            targetContainerLoading: false,
-                            targetContainerError: true,
-                            targetContainer: modal.targetContainerError,
+                            targetHostValidated: ValidatedOptions.error,
+                            targetContainerPlaceholder: modal.strings.targetContainerErrorPlaceholder,
+                            targetContainer: modal.strings.targetContainerError,
                             targetContainerList: []
                         });
                     });
         } else {
             this.setState({
-                targetContainer: this.targetContainerPlaceholder,
+                targetHostValidated: ValidatedOptions.default,
+                targetContainer: this.strings.targetContainerDefaultPlaceholder,
                 targetContainerList: [],
                 targetContainerLoading: false,
                 targetContainerError: false
             });
+
+            // Update target container name field
+            this.handleTargetContainerNameChange(this.state.targetContainerName);
         }
+    }
+
+    handleTargetContainerNameChange(targetContainerName) {
+        this.setState(state => {
+            const newState = { targetContainerName };
+
+            if (state.targetHost === this.strings.targetHostPlaceholder) {
+                newState.targetContainerNameValidated = ValidatedOptions.default;
+                newState.targetContainerNameError = null;
+            } else if (targetContainerName === "") {
+                newState.targetContainerNameValidated = ValidatedOptions.error;
+                newState.targetContainerNameError = this.strings.targetContainerNameErrorEmpty;
+            } else {
+                if (state.targetContainerList.includes(targetContainerName)) {
+                    newState.targetContainerNameValidated = ValidatedOptions.error;
+                    newState.targetContainerNameError = this.strings.targetContainerNameErrorContainerExists;
+                } else {
+                    newState.targetContainerNameValidated = ValidatedOptions.success;
+                    newState.targetContainerNameError = null;
+                }
+            }
+
+            return newState;
+        });
     }
 
     handleTargetContainerSelect(event, targetContainer) {
@@ -79,15 +151,22 @@ class ContainerMigrateModal extends React.Component {
     }
 
     isTargetContainerDisabled() {
-        return this.state.targetHost === this.targetHostPlaceholder || this.state.targetContainerLoading;
+        return this.state.targetHost === this.strings.targetHostPlaceholder || this.state.targetContainerLoading;
+    }
+
+    isMigrateButtonDisabled() {
+        return this.props.migrateInProgress || this.state.targetHost === this.strings.targetHostPlaceholder ||
+               this.state.targetContainerPlaceholder === this.strings.targetContainerErrorPlaceholder ||
+               (this.state.action === "new-container" &&
+                this.state.targetContainerNameValidated !== ValidatedOptions.success);
     }
 
     getContainerName() {
-        if (this.state.targetContainer === this.targetContainerError ||
-            this.state.targetContainer === this.targetContainerLoading)
+        if (this.state.targetContainer === this.strings.targetContainerErrorPlaceholder ||
+            this.state.targetContainer === this.strings.targetContainerLoadingPlaceholder)
             return null;
 
-        if (this.state.targetContainer === this.targetContainerPlaceholder)
+        if (this.state.action === "new-container")
             return this.state.targetContainerName;
 
         return this.state.targetContainer;
@@ -99,11 +178,9 @@ class ContainerMigrateModal extends React.Component {
                    showClose={false}
                    position="top" variant="medium"
                    onClose={this.props.handleMigrateContainerDeleteModal}
-                   title={_("Migrate running container to another host")}
+                   title={_(`Migrate container ${this.props.containerWillMigrate.Names} to another host`)}
                    footer={<>
-                       <Button variant="primary" isDisabled={this.props.migrateInProgress ||
-                                                             this.state.targetHost === this.targetHostPlaceholder ||
-                                                             this.state.targetContainer === this.targetContainerError}
+                       <Button variant="primary" isDisabled={this.isMigrateButtonDisabled()}
                                onClick={() => this.props.handleMigrateContainer(this.state, this.state.targetHost,
                                                                                 this.getContainerName())}>
                            {_("Migrate")}
@@ -119,100 +196,83 @@ class ContainerMigrateModal extends React.Component {
                    </>}
             >
                 <div className="ct-form">
-                    <label className="control-label" htmlFor="migrate-dialog-container">
-                        {_("Container")}
+                    <label className="control-label" htmlFor="migrate-dialog-action">
+                        {_("Action")}
                     </label>
-                    <div id="migrate-dialog-container">{this.props.containerWillMigrate.Names}</div>
+                    <div id="migrate-dialog-action">
+                        <Radio id="migrate-dialog-action-new-container"
+                               isChecked={this.state.action === "new-container"} name="action"
+                               onChange={this.handleActionSelect} label={_("Create new container")} />
+                        <Radio id="migrate-dialog-action-existing-container"
+                               isChecked={this.state.action === "existing-container"} name="action"
+                               onChange={this.handleActionSelect} label={_("Restore into existing container")} />
+                    </div>
 
-                    <label className="control-label" htmlFor="migrate-dialog-target-host">
+                    <label className="control-label" htmlFor="migrate-dialog-target-host-form-group">
                         {_("Target host")}
                     </label>
-                    <Select id="migrate-dialog-target-host" isOpen={this.state.targetHostOpen}
-                            selections={this.state.targetHost}
-                            onToggle={targetHostOpen => this.setState({ targetHostOpen })}
-                            onSelect={this.handleTargetHostSelect}>
-                        {
-                            Object.keys(this.props.remoteHosts).map(host =>
-                                <SelectOption value={this.props.remoteHosts[host]} key={host} />)
-                                    .concat([<SelectOption value={this.targetHostPlaceholder} key="_placeholder"
-                                                           isPlaceholder />])
-                        }
-                    </Select>
+                    <FormGroup id="migrate-dialog-target-host-form-group" validated={this.state.targetHostValidated}
+                               helperTextInvalid={this.strings.targetHostInaccessible}
+                               helperTextInvalidIcon={<ExclamationCircleIcon />}>
+                        <Select id="migrate-dialog-target-host" isOpen={this.state.targetHostOpen}
+                                selections={this.state.targetHost}
+                                onToggle={targetHostOpen => this.setState({ targetHostOpen })}
+                                onSelect={this.handleTargetHostSelect}>
+                            {
+                                Object.keys(this.props.remoteHosts).map(host =>
+                                    <SelectOption value={this.props.remoteHosts[host]} key={host} />)
+                                        .concat([<SelectOption value={this.strings.targetHostPlaceholder}
+                                                               key="_placeholder" isPlaceholder />])
+                            }
+                        </Select>
+                    </FormGroup>
 
                     <label className="control-label" htmlFor="migrate-dialog-target-container">
                         {_("Target container")}
                     </label>
-                    <Select id="migrate-dialog-target-container" isOpen={this.state.targetContainerOpen}
-                            selections={this.state.targetContainer} isDisabled={this.isTargetContainerDisabled()}
-                            onToggle={targetContainerOpen => this.setState({ targetContainerOpen })}
-                            onSelect={this.handleTargetContainerSelect}>
-                        {
-                            this.state.targetContainerList.map(container => <SelectOption value={container}
-                                                                                          key={container} />)
-                                    .concat([
-                                        <SelectOption value={this.targetContainerPlaceholder} key="_placeholder"
-                                                      isPlaceholder />,
-                                        this.state.targetContainerLoading
-                                            ? <SelectOption value={this.targetContainerLoading} key="_placeholder2"
-                                                            isPlaceholder />
-                                            : <React.Fragment key="null" />,
-                                        this.state.targetContainerError
-                                            ? <SelectOption value={this.targetContainerError} key="_placeholder3"
-                                                            isPlaceholder />
-                                            : <React.Fragment key="null2" />
-                                    ])
-                        }
-                    </Select>
-
-                    {
-                        (this.state.targetContainer === this.targetContainerPlaceholder &&
-                         this.state.targetHost !== this.targetHostPlaceholder)
-                            ? <>
-                                <label className="control-label" htmlFor="migrate-container-target-name">
-                                    {_("Target container name")}
-                                </label>
-                                <TextInput id="migrate-container-target-name" text={this.state.targetContainerName}
-                                           onChange={targetContainerName =>
-                                               this.setState({ targetContainerName })} />
-                            </>
-                            : null
-                    }
+                    {this.state.action === "new-container"
+                        ? <FormGroup id="migrate-dialog-target-container"
+                                     validated={this.state.targetContainerNameValidated}
+                                     helperTextInvalid={this.state.targetContainerNameError}
+                                     helperTextInvalidIcon={<ExclamationCircleIcon />}>
+                            <TextInput id="migrate-container-target-name" text={this.state.targetContainerName}
+                                       onChange={this.handleTargetContainerNameChange}
+                                       validated={this.state.targetContainerNameValidated} />
+                        </FormGroup> : <Select id="migrate-dialog-target-container" isOpen={this.state.targetContainerOpen}
+                                  typeAheadAriaLabel={this.state.targetContainerPlaceholder}
+                                  placeholderText={this.state.targetContainerPlaceholder}
+                                  selections={this.state.targetContainer} isDisabled={this.isTargetContainerDisabled()}
+                                  onToggle={targetContainerOpen => this.setState({ targetContainerOpen })}
+                                  onSelect={this.handleTargetContainerSelect}>
+                            {
+                                this.state.targetContainerList.map(container => <SelectOption value={container}
+                                                                                              key={container} />)
+                            }
+                        </Select>}
 
                     <label className="control-label" htmlFor="migrate-dialog-keep">
-                        {_("Keep all temporary checkpoint files")}
+                        {_("Options")}
                     </label>
-                    <Checkbox id="migrate-dialog-keep" name="keep" isChecked={this.state.keep}
-                              onChange={this.handleChange} />
-
-                    <label className="control-label" htmlFor="migrate-dialog-leaveRunning">
-                        {_("Leave running after migration")}
-                    </label>
-                    <Checkbox id="migrate-dialog-leaveRunning" name="leaveRunning"
-                              isChecked={this.state.leaveRunning} onChange={this.handleChange} />
-
-                    <label className="control-label" htmlFor="migrate-dialog-tcpEstablished">
-                        {_("Preserve established TCP connections")}
-                    </label>
-                    <Checkbox id="migrate-dialog-tcpEstablished" name="tcpEstablished"
-                              isChecked={this.state.tcpEstablished} onChange={this.handleChange} />
-
-                    <label className="control-label" htmlFor="migrate-dialog-ignoreRootFS">
-                        {_("Do not migrate root file-system changes")}
-                    </label>
-                    <Checkbox id="migrate-dialog-ignoreRootFS" name="ignoreRootFS"
-                              isChecked={this.state.ignoreRootFS} onChange={this.handleChange} />
-
-                    <label className="control-label" htmlFor="migrate-dialog-ignoreStaticIP">
-                        {_("Ignore IP address if set statically")}
-                    </label>
-                    <Checkbox id="migrate-dialog-ignoreStaticIP" name="ignoreStaticIP"
-                              isChecked={this.state.ignoreRootFS} onChange={this.handleChange} />
-
-                    <label className="control-label" htmlFor="migrate-dialog-ignoreStaticMAC">
-                        {_("Ignore MAC address if set statically")}
-                    </label>
-                    <Checkbox id="migrate-dialog-ignoreStaticMAC" name="ignoreStaticMAC"
-                              isChecked={this.state.ignoreStaticMAC} onChange={this.handleChange} />
+                    <div id="migrate-dialog-options">
+                        <Checkbox id="migrate-dialog-keep" name="keep" isChecked={this.state.keep}
+                                  label={_("Keep all temporary checkpoint files")}
+                                  onChange={this.handleChange} />
+                        <Checkbox id="migrate-dialog-leaveRunning" name="leaveRunning"
+                                  label={_("Leave running after migration")}
+                                  isChecked={this.state.leaveRunning} onChange={this.handleChange} />
+                        <Checkbox id="migrate-dialog-tcpEstablished" name="tcpEstablished"
+                                  label={_("Preserve established TCP connections")}
+                                  isChecked={this.state.tcpEstablished} onChange={this.handleChange} />
+                        <Checkbox id="migrate-dialog-ignoreRootFS" name="ignoreRootFS"
+                                  label={_("Do not migrate root file-system changes")}
+                                  isChecked={this.state.ignoreRootFS} onChange={this.handleChange} />
+                        <Checkbox id="migrate-dialog-ignoreStaticIP" name="ignoreStaticIP"
+                                  label={_("Ignore IP address if set statically")}
+                                  isChecked={this.state.ignoreStaticIP} onChange={this.handleChange} />
+                        <Checkbox id="migrate-dialog-ignoreStaticMAC" name="ignoreStaticMAC"
+                                  label={_("Ignore MAC address if set statically")}
+                                  isChecked={this.state.ignoreStaticMAC} onChange={this.handleChange} />
+                    </div>
                 </div>
             </Modal>
         );

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -104,8 +104,8 @@ class Containers extends React.Component {
         });
     }
 
-    migrateContainer(container) {
-        this.state.remoteHosts = utils.getRemoteHosts();
+    async migrateContainer(container) {
+        this.state.remoteHosts = await utils.getRemoteHosts();
 
         this.setState({
             containerWillMigrate: container,
@@ -311,7 +311,7 @@ class Containers extends React.Component {
                 });
     }
 
-    handleMigrateContainer(args, targetHost) {
+    handleMigrateContainer(args, targetHost, targetContainer) {
         const container = this.state.containerWillMigrate;
         this.setState({ migrateInProgress: true });
 
@@ -335,7 +335,7 @@ class Containers extends React.Component {
             containerImport: () => this.setState({ migrationStateLabel: _("Importing container...") })
         };
 
-        client.migrateContainer(container.isSystem, container.Id, newArgs, targetHost, callbacks)
+        client.migrateContainer(container.isSystem, container.Id, targetContainer, newArgs, targetHost, callbacks)
                 .catch(ex => {
                     const error = cockpit.format(_("Failed to migrate container $0"), container.Names);
                     this.props.onAddNotification({ type: 'danger', error, errorDetail: ex.message ? ex.message : JSON.stringify(ex) });

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -244,7 +244,7 @@ class Containers extends React.Component {
             if (container.isSystem)
                 kebabMenuActions.push({ label: _("Migrate"), onActivate: () => this.migrateContainer(container) });
             if (kebabMenuActions.length !== 0)
-                actions.push(<DropDown isKebab actions={kebabMenuActions} />);
+                actions.push(<DropDown key={_(container.Id) + "kebab"} isKebab actions={kebabMenuActions} />);
         }
 
         return {

--- a/src/Dropdown.jsx
+++ b/src/Dropdown.jsx
@@ -4,9 +4,10 @@ import {
     DropdownToggle,
     DropdownToggleAction,
     DropdownItem,
+    KebabToggle,
 } from '@patternfly/react-core';
 
-export const DropDown = ({ actions }) => {
+export const DropDown = ({ actions, isKebab }) => {
     const [isOpen, setIsOpen] = useState(false);
     const dropdownItems = actions
             .map(button => {
@@ -22,18 +23,20 @@ export const DropDown = ({ actions }) => {
             onSelect={() => setIsOpen(!isOpen)}
             id={actions[0].label + "-dropdown"}
             toggle={
-                <DropdownToggle
-                    splitButtonItems={[
-                        <DropdownToggleAction key="default-action" onClick={actions[0].onActivate}>
-                            {actions[0].label}
-                        </DropdownToggleAction>
-                    ]}
-                    splitButtonVariant="action"
-                    onToggle={open => setIsOpen(open)}
-                />
+                isKebab ? <KebabToggle onToggle={open => setIsOpen(open)} splitButtonVariant="action" />
+                    : <DropdownToggle
+                          splitButtonItems={[
+                              <DropdownToggleAction key="default-action" onClick={actions[0].onActivate}>
+                                  {actions[0].label}
+                              </DropdownToggleAction>
+                          ]}
+                          splitButtonVariant="action"
+                          onToggle={open => setIsOpen(open)}
+                    />
             }
             isOpen={isOpen}
             dropdownItems={dropdownItems}
+            isPlain={isKebab}
         />
     );
 };

--- a/src/Dropdown.jsx
+++ b/src/Dropdown.jsx
@@ -23,7 +23,7 @@ export const DropDown = ({ actions, isKebab }) => {
             onSelect={() => setIsOpen(!isOpen)}
             id={actions[0].label + "-dropdown"}
             toggle={
-                isKebab ? <KebabToggle onToggle={open => setIsOpen(open)} splitButtonVariant="action" />
+                isKebab ? <KebabToggle onToggle={open => setIsOpen(open)} />
                     : <DropdownToggle
                           splitButtonItems={[
                               <DropdownToggleAction key="default-action" onClick={actions[0].onActivate}>

--- a/src/client.js
+++ b/src/client.js
@@ -1,3 +1,4 @@
+import cockpit from "cockpit";
 import rest from './rest.js';
 
 const PODMAN_SYSTEM_ADDRESS = "/run/podman/podman.sock";
@@ -13,7 +14,7 @@ export function getAddress(system) {
     return "";
 }
 
-function podmanCall(name, method, args, system, body) {
+function podmanCall(name, method, args, system, host, body) {
     const options = {
         method: method,
         path: VERSION + name,
@@ -21,10 +22,10 @@ function podmanCall(name, method, args, system, body) {
         params: args,
     };
 
-    return rest.call(getAddress(system), system, options);
+    return rest.call(getAddress(system), system, options, host);
 }
 
-function podmanMonitor(name, method, args, callback, system) {
+function podmanMonitor(name, method, args, callback, system, host) {
     const options = {
         method: method,
         path: VERSION + name,
@@ -32,114 +33,366 @@ function podmanMonitor(name, method, args, callback, system) {
         params: args,
     };
 
-    const connection = rest.connect(getAddress(system), system);
+    const connection = rest.connect(getAddress(system), system, host);
     return connection.monitor(options, callback, system);
 }
 
-export function streamEvents(system, callback) {
+function podmanTransfer(name, method, args, system, target, host) {
+    const options = {
+        method: method,
+        path: VERSION + name,
+        body: "",
+        params: args,
+        redirect: target,
+        binary: true,
+    };
+
+    return rest.call(getAddress(system), system, options, host);
+}
+
+export function streamEvents(system, callback, host) {
     return new Promise((resolve, reject) => {
-        podmanMonitor("libpod/events", "GET", {}, callback, system)
+        podmanMonitor("libpod/events", "GET", {}, callback, system, host)
                 .then(reply => resolve(JSON.parse(reply)))
                 .catch(reject);
     });
 }
 
-export function getInfo(system) {
+export function getInfo(system, host) {
     return new Promise((resolve, reject) => {
-        podmanCall("libpod/info", "GET", {}, system)
+        podmanCall("libpod/info", "GET", {}, system, host)
                 .then(reply => resolve(JSON.parse(reply)))
                 .catch(reject);
     });
 }
 
-export function getContainers(system, id) {
+export function getContainers(system, id, host) {
     return new Promise((resolve, reject) => {
         const options = { all: true };
         if (id)
             options.filters = JSON.stringify({ id: [id] });
 
-        podmanCall("libpod/containers/json", "GET", options, system)
+        podmanCall("libpod/containers/json", "GET", options, system, host)
                 .then(reply => resolve(JSON.parse(reply)))
                 .catch(reject);
     });
 }
 
-export function getContainerStats(system, id, callback) {
+export function getContainerStats(system, id, callback, host) {
     return new Promise((resolve, reject) => {
         const options = {
             stream: true,
         };
-        podmanMonitor("libpod/containers/" + id + "/stats", "GET", options, callback, system)
+        podmanMonitor("libpod/containers/" + id + "/stats", "GET", options, callback, system, host)
                 .then(resolve, reject);
     });
 }
 
-export function inspectContainer(system, id) {
+export function inspectContainer(system, id, host) {
     return new Promise((resolve, reject) => {
         const options = {
             size: false // set true to display filesystem usage
         };
-        podmanCall("libpod/containers/" + id + "/json", "GET", options, system)
+        podmanCall("libpod/containers/" + id + "/json", "GET", options, system, host)
                 .then(reply => resolve(JSON.parse(reply)))
                 .catch(reject);
     });
 }
 
-export function delContainer(system, id, force) {
+export function delContainer(system, id, force, host) {
     return new Promise((resolve, reject) => {
         const options = {
             force: force,
         };
-        podmanCall("libpod/containers/" + id, "DELETE", options, system)
+        podmanCall("libpod/containers/" + id, "DELETE", options, system, host)
                 .then(resolve)
                 .catch(reject);
     });
 }
 
-export function createContainer(system, config) {
+export function createContainer(system, config, host) {
     return new Promise((resolve, reject) => {
-        podmanCall("libpod/containers/create", "POST", {}, system, JSON.stringify(config))
+        podmanCall("libpod/containers/create", "POST", {}, system, host, JSON.stringify(config))
                 .then(reply => resolve(JSON.parse(reply)))
                 .catch(reject);
     });
 }
 
-export function commitContainer(system, commitData) {
+export function commitContainer(system, commitData, host) {
     return new Promise((resolve, reject) => {
-        podmanCall("libpod/commit", "POST", commitData, system)
+        podmanCall("libpod/commit", "POST", commitData, system, host)
                 .then(resolve)
                 .catch(reject);
     });
 }
 
-export function postContainer(system, action, id, args) {
+export async function migrateContainer(system, id, args, targetHost, callbacks, host) {
+    if (!system) {
+        throw new Error(`${id}: migrating non-system container unsupported`);
+    }
+
+    callbacks = Object.assign({
+        imageInspect: () => {},
+        imageExport: () => {},
+        imageImport: () => {},
+        imageTagging: () => {},
+        containerInspect: () => {},
+        containerExport: () => {},
+        containerCreate: () => {},
+        containerImport: () => {}
+    }, callbacks);
+
+    // Make sure Podman system service is present and active on target host
+    const systemd = cockpit.dbus("org.freedesktop.systemd1", { bus: "system" });
+    await systemd.wait();
+    const podmanSocketPath = await systemd.call("/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager",
+                                                "GetUnit", ["podman.socket"]);
+    const podmanSocket = systemd.proxy("org.freedesktop.systemd1.Unit", podmanSocketPath[0]);
+    await podmanSocket.wait();
+    if (podmanSocket.ActiveState !== "active")
+        throw new Error("Podman system service not active on target host");
+
+    // Make sure the image the container uses is present on the target host
+    const containerInfo = await inspectContainer(system, id, host);
+    try {
+        callbacks.imageInspect();
+        await inspectImage(system, containerInfo.Image, targetHost);
+    } catch (error) {
+        if (error.status === 404) {
+            // Image not found - try to copy it to the target host
+            callbacks.imageExport();
+            const imageFile = (await cockpit.script("mktemp -p /var/tmp", { host: targetHost })).slice(0, -1);
+            const imageSaveChannel = cockpit.channel({
+                payload: "fsreplace1",
+                path: imageFile,
+                binary: true,
+                host: targetHost
+            });
+            await imageSaveChannel.wait();
+            await exportImage(system, containerInfo.Image, { format: "docker-archive", compress: true }, host,
+                              imageSaveChannel.id);
+            imageSaveChannel.control({ command: "done" });
+            await new Promise(resolve => imageSaveChannel.addEventListener("close", resolve));
+
+            callbacks.imageImport();
+            try {
+                let imageLoadChannelData = null;
+                let imageLoadChannelResponse = null;
+
+                const imageFileSize = await cockpit.script(`stat --printf="%s" "${imageFile}"`, { host: targetHost });
+                const imageLoadChannel = cockpit.channel({
+                    payload: "http-stream2",
+                    unix: "/run/podman/podman.sock",
+                    method: "POST",
+                    path: VERSION + "libpod/images/load",
+                    binary: true,
+                    "body-length": parseInt(imageFileSize),
+                    superuser: "require",
+                    host: targetHost
+                });
+                imageLoadChannel.addEventListener("message", function (e, data) {
+                    imageLoadChannelData = data;
+                });
+                imageLoadChannel.addEventListener("control", function (e, options) {
+                    if (options.command === "response")
+                        imageLoadChannelResponse = options;
+                });
+                await imageLoadChannel.wait();
+                const imageReadChannel = cockpit.channel({
+                    payload: "fsread1",
+                    path: imageFile,
+                    max_read_size: 107374182400,
+                    redirect: imageLoadChannel.id,
+                    binary: true,
+                    host: targetHost
+                });
+                await imageReadChannel.wait();
+                await new Promise(resolve =>
+                    imageReadChannel.addEventListener("control", function (e, options) {
+                        if (options.command === "done")
+                            resolve();
+                    })
+                );
+                imageLoadChannel.control({ command: "done" });
+                await new Promise((resolve, reject) =>
+                    imageLoadChannel.addEventListener("close", function (e, options) {
+                        if (options.problem)
+                            reject(new Error(options.problem));
+                        else if (imageLoadChannelResponse.status >= 200 && imageLoadChannelResponse.status <= 299)
+                            resolve();
+                        else
+                            reject(new Error(String.fromCharCode.apply(null, imageLoadChannelData)));
+                    })
+                );
+            } finally {
+                await cockpit.script(`rm "${imageFile}"`, { host: targetHost });
+            }
+
+            // Inspect the old image and try to tag the new one to match it
+            callbacks.imageTagging();
+            const oldImageInfo = await inspectImage(system, containerInfo.Image, host);
+            for (const tag of oldImageInfo.RepoTags) {
+                const i = tag.lastIndexOf(":");
+                try {
+                    await tagImage(system, containerInfo.Image, tag.substring(0, i), tag.substring(i + 1, tag.length),
+                                   targetHost);
+                } catch (error) {
+                    // Ignore
+                }
+            }
+        } else {
+            throw error;
+        }
+    }
+
+    let containerCreated = false;
+    try {
+        callbacks.containerInspect();
+        await inspectContainer(system, containerInfo.Name, targetHost);
+    } catch (error) {
+        if (error.status === 404) {
+            callbacks.containerCreate();
+            const dummyConfig = {
+                name: containerInfo.Name,
+                image: containerInfo.Image,
+                terminal: true,
+                command: containerInfo.Args
+            };
+            await createContainer(system, dummyConfig, targetHost);
+            containerCreated = true;
+        } else {
+            throw error;
+        }
+    }
+
+    // Checkpoint the selected container
+    callbacks.containerExport();
+    const containerFile = (await cockpit.script("mktemp -p /var/tmp", { host: targetHost })).slice(0, -1);
+    const containerSaveChannel = cockpit.channel({
+        payload: "fsreplace1",
+        path: containerFile,
+        binary: true,
+        host: targetHost
+    });
+    await containerSaveChannel.wait();
+    const checkpointArgs = {
+        keep: args.keep,
+        leaveRunning: args.leaveRunning,
+        tcpEstablished: args.tcpEstablished,
+        ignoreRootFS: args.ignoreRootFS,
+        ignoreStaticIP: args.ignoreStaticIP,
+        ignoreStaticMAC: args.ignoreStaticMAC
+    };
+    await exportContainer(system, id, checkpointArgs, host, containerSaveChannel.id);
+    containerSaveChannel.control({ command: "done" });
+    await new Promise(resolve => containerSaveChannel.addEventListener("close", resolve));
+
+    // Restore it into the created dummy container
+    callbacks.containerImport();
+    try {
+        let containerImportChannelData = null;
+        let containerImportChannelResponse = null;
+        const containerFileSize = await cockpit.script(`stat --printf="%s" "${containerFile}"`, { host: targetHost });
+
+        const containerImportChannel = cockpit.channel({
+            payload: "http-stream2",
+            unix: "/run/podman/podman.sock",
+            method: "POST",
+            path: VERSION + `libpod/containers/${containerInfo.Name}/restore?import=true&keep=${args.keep}&` +
+                `tcpEstablished=${args.tcpEstablished}&leaveRunning=${args.leaveRunning}&` +
+                `ignoreRootFS=${args.ignoreRootFS}`,
+            binary: true,
+            "body-length": parseInt(containerFileSize),
+            superuser: "require",
+            host: targetHost
+        });
+        containerImportChannel.addEventListener("message", function (e, data) {
+            containerImportChannelData = data;
+        });
+        containerImportChannel.addEventListener("control", function (e, options) {
+            if (options.command === "response")
+                containerImportChannelResponse = options;
+        });
+        await containerImportChannel.wait();
+        const containerReadChannel = cockpit.channel({
+            payload: "fsread1",
+            path: containerFile,
+            max_read_size: 107374182400,
+            redirect: containerImportChannel.id,
+            binary: true,
+            host: targetHost
+        });
+        await containerReadChannel.wait();
+        await new Promise(resolve => containerReadChannel.addEventListener("control", function (e, options) {
+            if (options.command === "done")
+                resolve();
+        }));
+        containerImportChannel.control({ command: "done" });
+        await new Promise((resolve, reject) =>
+            containerImportChannel.addEventListener("close", function (e, options) {
+                if (options.problem)
+                    reject(new Error(options.problem));
+                else if (containerImportChannelResponse.status >= 200 && containerImportChannelResponse.status <= 299)
+                    resolve();
+                else
+                    reject(new Error(String.fromCharCode.apply(null, containerImportChannelData)));
+            })
+        );
+    } catch (e) {
+        if (containerCreated)
+            await delContainer(system, containerInfo.Name, true, targetHost);
+        throw e;
+    } finally {
+        await cockpit.script(`rm "${containerFile}"`, { host: targetHost });
+    }
+}
+
+export function postContainer(system, action, id, args, host) {
     return new Promise((resolve, reject) => {
-        podmanCall("libpod/containers/" + id + "/" + action, "POST", args, system)
+        podmanCall("libpod/containers/" + id + "/" + action, "POST", args, system, host)
                 .then(resolve)
                 .catch(reject);
     });
 }
 
-export function postPod(system, action, id, args) {
+export function exportContainer(system, id, options, host, targetChannel) {
+    const newArgs = Object.assign({}, options);
+    newArgs.export = true;
+
     return new Promise((resolve, reject) => {
-        podmanCall("libpod/pods/" + id + "/" + action, "POST", args, system)
+        if (targetChannel === undefined) {
+            podmanCall("libpod/containers/" + id + "/checkpoint", "POST", newArgs, system, host)
+                    .then(resolve)
+                    .catch(reject);
+        } else {
+            podmanTransfer("libpod/containers/" + id + "/checkpoint", "POST", newArgs, system,
+                           targetChannel, host)
+                    .then(resolve)
+                    .catch(reject);
+        }
+    });
+}
+
+export function postPod(system, action, id, args, host) {
+    return new Promise((resolve, reject) => {
+        podmanCall("libpod/pods/" + id + "/" + action, "POST", args, system, host)
                 .then(resolve)
                 .catch(reject);
     });
 }
 
-export function delPod(system, id, force) {
+export function delPod(system, id, force, host) {
     return new Promise((resolve, reject) => {
         const options = {
             force: force,
         };
-        podmanCall("libpod/pods/" + id, "DELETE", options, system)
+        podmanCall("libpod/pods/" + id, "DELETE", options, system, host)
                 .then(resolve)
                 .catch(reject);
     });
 }
 
-export function execContainer(system, id) {
+export function execContainer(system, id, host) {
     const args = {
         AttachStderr: true,
         AttachStdout: true,
@@ -149,13 +402,13 @@ export function execContainer(system, id) {
     };
 
     return new Promise((resolve, reject) => {
-        podmanCall("libpod/containers/" + id + "/exec", "POST", {}, system, JSON.stringify(args))
+        podmanCall("libpod/containers/" + id + "/exec", "POST", {}, system, host, JSON.stringify(args))
                 .then(reply => resolve(JSON.parse(reply)))
                 .catch(reject);
     });
 }
 
-export function resizeContainersTTY(system, id, exec, width, height) {
+export function resizeContainersTTY(system, id, exec, width, height, host) {
     const args = {
         h: height,
         w: width,
@@ -166,7 +419,7 @@ export function resizeContainersTTY(system, id, exec, width, height) {
         point = "exec/";
 
     return new Promise((resolve, reject) => {
-        podmanCall("libpod/" + point + id + "/resize", "POST", args, system)
+        podmanCall("libpod/" + point + id + "/resize", "POST", args, system, host)
                 .then(resolve)
                 .catch(reject);
     });
@@ -185,7 +438,7 @@ function parseImageInfo(info) {
     return image;
 }
 
-export function getImages(system, id) {
+export function getImages(system, id, host) {
     return new Promise((resolve, reject) => {
         const options = {};
         if (id)
@@ -198,7 +451,7 @@ export function getImages(system, id) {
 
                     for (const image of immages || []) {
                         images[image.Id] = image;
-                        promises.push(podmanCall("libpod/images/" + image.Id + "/json", "GET", {}, system));
+                        promises.push(podmanCall("libpod/images/" + image.Id + "/json", "GET", {}, system, host));
                     }
 
                     Promise.all(promises)
@@ -216,46 +469,58 @@ export function getImages(system, id) {
     });
 }
 
-export function getPods(system, id) {
+export function getPods(system, id, host) {
     return new Promise((resolve, reject) => {
         const options = {};
         if (id)
             options.filters = JSON.stringify({ id: [id] });
-        podmanCall("libpod/pods/json", "GET", options, system)
+        podmanCall("libpod/pods/json", "GET", options, system, host)
                 .then(reply => resolve(JSON.parse(reply)))
                 .catch(reject);
     });
 }
 
-export function delImage(system, id, force) {
+export function delImage(system, id, force, host) {
     return new Promise((resolve, reject) => {
         const options = {
             force: force,
         };
-        podmanCall("libpod/images/" + id, "DELETE", options, system)
+        podmanCall("libpod/images/" + id, "DELETE", options, system, host)
                 .then(reply => resolve(JSON.parse(reply)))
                 .catch(reject);
     });
 }
 
-export function untagImage(system, id, repo, tag) {
+export function tagImage(system, id, repo, tag, host) {
     return new Promise((resolve, reject) => {
         const options = {
             repo: repo,
             tag: tag
         };
-        podmanCall("libpod/images/" + id + "/untag", "POST", options, system)
+        podmanCall("libpod/images/" + id + "/tag", "POST", options, system, host)
                 .then(resolve)
                 .catch(reject);
     });
 }
 
-export function pullImage(system, reference) {
+export function untagImage(system, id, repo, tag, host) {
+    return new Promise((resolve, reject) => {
+        const options = {
+            repo: repo,
+            tag: tag
+        };
+        podmanCall("libpod/images/" + id + "/untag", "POST", options, system, host)
+                .then(resolve)
+                .catch(reject);
+    });
+}
+
+export function pullImage(system, reference, host) {
     return new Promise((resolve, reject) => {
         const options = {
             reference: reference,
         };
-        podmanCall("libpod/images/pull", "POST", options, system)
+        podmanCall("libpod/images/pull", "POST", options, system, host)
                 .then(r => {
                     // Need to check the last response if it contains error
                     const responses = r.trim().split("\n");
@@ -269,5 +534,27 @@ export function pullImage(system, reference) {
                         resolve();
                 })
                 .catch(reject);
+    });
+}
+
+export function inspectImage(system, id, host) {
+    return new Promise((resolve, reject) => {
+        podmanCall("libpod/images/" + id + "/json", "GET", {}, system, host)
+                .then(reply => resolve(JSON.parse(reply)))
+                .catch(reject);
+    });
+}
+
+export function exportImage(system, id, options, host, targetChannel) {
+    return new Promise((resolve, reject) => {
+        if (targetChannel === undefined) {
+            podmanCall("libpod/images/" + id + "/get", "GET", options, system, host)
+                    .then(resolve)
+                    .catch(reject);
+        } else {
+            podmanTransfer("libpod/images/" + id + "/get", "GET", options, system, targetChannel, host)
+                    .then(resolve)
+                    .catch(reject);
+        }
     });
 }

--- a/src/rest.js
+++ b/src/rest.js
@@ -13,9 +13,9 @@ function manage_error(reject, error, content) {
     reject(c);
 }
 
-function connect(address, system) {
+function connect(address, system, host) {
     /* This doesn't create a channel until a request */
-    const http = cockpit.http(address, { superuser: system ? "require" : null });
+    const http = cockpit.http(address, { superuser: system ? "require" : null, host });
     const connection = {};
 
     connection.monitor = function(options, callback, system, return_raw) {
@@ -56,8 +56,8 @@ function connect(address, system) {
  * Connects to the podman service, performs a single call, and closes the
  * connection.
  */
-async function call (address, system, parameters) {
-    const connection = connect(address, system);
+async function call (address, system, parameters, host) {
+    const connection = connect(address, system, host);
     const result = await connection.call(parameters);
     connection.close();
     return result;

--- a/src/util.js
+++ b/src/util.js
@@ -172,3 +172,39 @@ export function compare_versions(a, b) {
 
     return a_ints.length - b_ints.length;
 }
+
+/*
+ * Gets a dictionary of remote hosts with hosts as keys and addresses as values.
+ */
+export function getRemoteHosts() {
+    const result = {};
+
+    // The Cockpit host may be the SSH address, while the connected host in v2-machines.json is never that
+    const currentAddress = cockpit.transport.host;
+    const currentHost = currentAddress.includes("@") ? currentAddress.split("@")[1] : currentAddress;
+
+    const hosts = JSON.parse(cockpit.sessionStorage.getItem("v2-machines.json"));
+
+    // Get connected (i.e. usable) hosts from the overlay
+    for (const host in hosts.overlay) {
+        if (Object.hasOwnProperty.call(hosts.overlay, [host]) && hosts.overlay[host].state === "connected" &&
+            host !== currentHost) {
+            result[host] = host;
+        }
+    }
+
+    // Look for SSH addresses in the overlay
+    for (const address in hosts.overlay) {
+        if (!address.includes("@"))
+            continue;
+
+        const host = address.split("@")[1];
+        if (result[host] === undefined)
+            continue;
+
+        // Replace host with address
+        result[host] = address;
+    }
+
+    return result;
+}

--- a/test/check-application
+++ b/test/check-application
@@ -5,6 +5,7 @@
 
 import os
 import sys
+import time
 from distutils.version import StrictVersion
 import unittest
 
@@ -15,6 +16,7 @@ sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
 
 import testlib
 from machine_core import ssh_connection
+from machine_core.constants import TEST_OS_DEFAULT
 
 REGISTRIES_CONF="""
 [registries.search]
@@ -33,6 +35,14 @@ def checkImage(browser, name, owner):
                 return true;
         return false;
         })""", name, owner)
+
+
+def switch_to_cgroups_v2(machine):
+    # Set machine to cgroup1 and reboot; Debian uses hybrid mode and does not have grubby
+    if not machine.image.startswith("debian") and not machine.image.startswith("ubuntu"):
+        machine.execute('grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"; reboot')
+        machine.wait_reboot()
+
 
 class TestApplication(testlib.MachineCase):
 
@@ -903,9 +913,7 @@ class TestApplication(testlib.MachineCase):
 
         # Set machine to cgroup1 and reboot; Debian uses hybrid mode and does not have grubby
         if not m.image.startswith("debian") and not m.image.startswith("ubuntu"):
-            self.execute(True, 'grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"')
-            self.machine.spawn("sleep 0.1 && reboot", "reboot")
-            m.wait_reboot()
+            switch_to_cgroups_v2(m)
 
         self._testCheckpointRestore()
 
@@ -1426,6 +1434,542 @@ class TestApplication(testlib.MachineCase):
         b = self.browser
         b.click(".pf-c-modal-box footer button:contains(%s)" % text)
         b.wait_not_present(".pf-c-modal-box footer button:contains(%s)" % text)
+
+
+class TestContainerMigration(testlib.MachineCase):
+    provision = {
+        "machine1": {"address": "10.111.113.1/20"},
+        "machine2": {"address": "10.111.113.2/20"},
+    }
+
+    def start_machine_troubleshoot(self, new=False, known_host=False, password=None):
+        b = self.browser
+        b.wait_visible("#machine-troubleshoot")
+        b.click('#machine-troubleshoot')
+        b.wait_popup('troubleshoot-dialog')
+        if new:
+            b.click('#troubleshoot-dialog .modal-footer button:contains(Add)')
+            if not known_host:
+                b.wait_in_text('#troubleshoot-dialog', "Fingerprint")
+                b.click('#troubleshoot-dialog .modal-footer button:contains(Connect)')
+        if password:
+            b.wait_in_text('#troubleshoot-dialog', "Unable to log in")
+            b.set_val('#login-custom-password', password)
+            b.click('#troubleshoot-dialog .modal-footer button:contains(Log in)')
+
+    def add_machine(self, address, known_host=False, password="foobar"):
+        b = self.browser
+        b.switch_to_top()
+        b.go("/@%s" % address)
+        self.start_machine_troubleshoot(new=True, known_host=known_host, password=password)
+        b.wait_popdown('troubleshoot-dialog')
+        b.enter_page("/system", host=address)
+
+    def remove_machine(self, address):
+        b = self.browser
+        b.switch_to_top()
+        b.click(".ct-switcher .ct-nav-toggle")
+        b.click(".view-hosts button:contains(Edit hosts)")
+        b.click(".view-hosts a:contains({}) + div button.pf-m-danger".format(address))
+
+    def setup_ssh_auth(self):
+        self.machine.execute("d=/home/admin/.ssh; mkdir -p $d; chown admin:admin $d; chmod 700 $d")
+        self.machine.execute("test -f /home/admin/.ssh/id_rsa || ssh-keygen -f /home/admin/.ssh/id_rsa -t rsa -N ''")
+        self.machine.execute("chown admin:admin /home/admin/.ssh/id_rsa*")
+        pubkey = self.machine.execute("cat /home/admin/.ssh/id_rsa.pub")
+
+        for m in self.machines:
+            self.machines[m].execute("d=/home/admin/.ssh; mkdir -p $d; chown admin:admin $d; chmod 700 $d")
+            self.machines[m].write("/home/admin/.ssh/authorized_keys", pubkey)
+            self.machines[m].execute("chown admin:admin /home/admin/.ssh/authorized_keys")
+
+    def setUp(self):
+        super().setUp()
+        self.machine.execute("hostnamectl set-hostname machine1")
+        self.machine2 = self.machines['machine2']
+        self.machine2.execute("hostnamectl set-hostname machine2")
+
+        # Disable preloading on all machines ("machine1" is done in testlib.py)
+        # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
+        # In these tests we actually switch between machines in quick succession which can make things even worse
+        if self.machine.image == TEST_OS_DEFAULT:
+            self.machines["machine2"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
+            self.machines["machine2"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
+
+        self.setup_ssh_auth()
+
+        for m in self.machines:
+            self.machine = self.machines[m]
+
+            self.machine.execute("systemctl stop podman.service; systemctl --now enable podman.socket")
+
+            # backup/restore pristine podman state, so that tests can run on existing testbeds
+            self.restore_dir("/var/lib/containers", reboot_safe=True)
+
+            self.addCleanup(self.machine.execute, "systemctl stop podman.service")
+
+            # HACK: sometimes podman leaks mounts
+            self.addCleanup(self.machine.execute, "podman rm --force --all && "
+                                                  "findmnt --list -otarget | grep /var/lib/containers/. | xargs -r umount || true")
+        self.machine = self.machines["machine1"]
+
+        self.has_criu = self.machine.image not in ["debian-testing", "ubuntu-stable"]
+        self.has_selinux = self.machine.image not in ["debian-testing", "ubuntu-stable"]
+
+    def enable_administrative_access(self, machine, password="foobar"):
+        b = self.browser
+        b.go("/@{}".format(machine))
+        b.click("button:contains(Turn on administrative access)")
+        b.set_input_text("#pf-modal-part-2 form input", password)
+        b.click("button:contains(Authenticate)")
+        b.wait_not_present("button:contains(Authenticate)")
+
+    def start_podman_service(self, machine):
+        b = self.browser
+        b.go("/@{}/podman".format(machine))
+        b.enter_page("/podman", machine)
+        b.click("button:contains(Start podman)")
+        b.wait_present("#app")
+
+    def open_migrate_dialog(self, container, container_open=False):
+        b = self.browser
+        b.wait_present("#containers-containers tr:contains({})".format(container))
+        if not container_open:
+            b.click("#containers-containers tr:contains({}) .pf-c-table__toggle-icon".format(container))
+        b.click("#containers-containers tr:contains({}) + tr #Migrate-dropdown button".format(container))
+        b.click("#containers-containers tr:contains({}) + tr #Migrate-dropdown .pf-c-dropdown__menu-item:contains(Migrate)".format(container))
+
+    def select_new_container_action(self):
+        b = self.browser
+        b.click("#migrate-dialog-action-new-container")
+
+    def select_existing_container_action(self):
+        b = self.browser
+        b.click("#migrate-dialog-action-existing-container")
+
+    def select_target_host(self, machine):
+        b = self.browser
+        b.wait_present(".pf-c-modal-box .pf-c-select .pf-c-select__toggle")
+        b.click("#migrate-dialog-target-host-form-group .pf-c-select__toggle")
+        b.click("#migrate-dialog-target-host-form-group .pf-c-select__menu .pf-c-select__menu-item:contains({})".format(machine))
+
+    def select_target_container(self, container):
+        b = self.browser
+        b.wait_present(".pf-c-modal-box .pf-c-select .pf-c-select__toggle")
+        b.click("#migrate-dialog-target .pf-c-select__toggle")
+        b.click("#migrate-dialog-target .pf-c-select__menu .pf-c-select__menu-item:contains({})".format(container))
+
+    def wait_target_container_present(self, container):
+        b = self.browser
+        b.click("#migrate-dialog-target .pf-c-select__toggle")
+        b.wait_present("#migrate-dialog-target .pf-c-select__menu-item:contains({})".format(container))
+        b.click("#migrate-dialog-target .pf-c-select__toggle")
+
+    def set_new_target_container_name(self, container):
+        b = self.browser
+        b.set_input_text("#migrate-container-target-name", container)
+
+    def set_migrate_options(self, keep=False, leave_running=False, preserve_tcp=False, ignore_root_changes=False,
+                            ignore_ip=False, ignore_mac=False):
+        b = self.browser
+        b.set_checked("#migrate-dialog-keep", keep)
+        b.set_checked("#migrate-dialog-leaveRunning", leave_running)
+        b.set_checked("#migrate-dialog-tcpEstablished", preserve_tcp)
+        b.set_checked("#migrate-dialog-ignoreRootFS", ignore_root_changes)
+        b.set_checked("#migrate-dialog-ignoreStaticIP", ignore_ip)
+        b.set_checked("#migrate-dialog-ignoreStaticMAC", ignore_mac)
+
+    def wait_for_migration_state(self, state):
+        b = self.browser
+        b.wait_present("label.migration-progress:contains({})".format(state))
+
+    def testMigrateIntoNewContainer(self):
+        """
+        Tests migration into a newly created container, along with copying the underlying image
+        """
+        b = self.browser
+        m1 = self.machine
+        m2 = self.machine2
+
+        for m in [m1, m2]:
+            switch_to_cgroups_v2(m)
+
+        self.login_and_go(None, superuser=True)
+        self.add_machine("10.111.113.2", password=None)
+        self.enable_administrative_access("10.111.113.2")
+        self.start_podman_service("10.111.113.2")
+
+        b.go("/podman")
+        b.enter_page("/podman")
+        b.wait_present("#app")
+
+        # Run a container
+        m1.execute("podman run -dit --name swamped-crate busybox sh")
+        b.wait(lambda: m1.execute("podman ps --all | grep -e swamped-crate"))
+
+        # Remove image on second machine for testing its copying during the migration
+        m2.execute("podman rmi busybox:latest")
+
+        # Open the migration dialog
+        self.open_migrate_dialog("swamped-crate")
+
+        # Select the second machine
+        self.select_target_host("10.111.113.2")
+
+        # Name the target container and set options
+        self.select_new_container_action()
+        self.set_new_target_container_name("swamped-crate-2")
+        self.set_migrate_options()
+
+        # Migrate the container
+        b.click("button:contains(Migrate)")
+        b.wait_not_present("button:contains(Migrate)")
+
+        # Check if container present and running on other host
+        m2.execute("podman ps | grep -e swamped-crate-2")
+
+    def testMigrateIntoExistingContainer(self):
+        """
+        Tests migration into an existing container, along with checking the container state
+        """
+        b = self.browser
+        m1 = self.machine
+        m2 = self.machine2
+
+        for m in [m1, m2]:
+            switch_to_cgroups_v2(m)
+
+        self.login_and_go(None, superuser=True)
+        self.add_machine("10.111.113.2", password=None)
+        self.enable_administrative_access("10.111.113.2")
+        self.start_podman_service("10.111.113.2")
+
+        b.go("/podman")
+        b.enter_page("/podman")
+        b.wait_present("#app")
+
+        # Run a container with a process that will block on writing into a pipe
+        m1.execute("podman run -dit --name swamped-crate alpine sh")
+        m1.execute("podman exec swamped-crate mkfifo /tmp/fifo")
+        m1.execute("podman exec -d swamped-crate sh -c 'echo hello > /tmp/fifo'")
+        b.wait(lambda: m1.execute("podman ps | grep -e swamped-crate"))
+
+        # Run a container on the other host and stop it
+        m2.execute("podman run -dit --name swamped-crate alpine sh")
+        b.wait(lambda: m2.execute("podman ps --all | grep -e swamped-crate"))
+        m2.execute("podman stop swamped-crate")
+
+        # Open the migration dialog
+        self.open_migrate_dialog("swamped-crate")
+
+        # Select the second machine
+        self.select_target_host("10.111.113.2")
+
+        # Select the target container and set options
+        self.select_existing_container_action()
+        self.select_target_container("swamped-crate")
+        self.set_migrate_options(preserve_tcp=True)
+
+        # Migrate the container
+        b.click("button:contains(Migrate)")
+        b.wait_not_present("button:contains(Migrate)")
+
+        # Check if container present and running on other host
+        m2.execute("podman ps | grep -e swamped-crate")
+
+        # Read from the pipe created above and check the content
+        m2.execute("podman exec -d swamped-crate sh -c '[ \"$(</tmp/fifo)\" = \"hello\"'")
+
+    def testMigrateFromRemoteHost(self):
+        """
+        Tests container migration from the second machine to the first.
+        """
+        b = self.browser
+        m1 = self.machine
+        m2 = self.machine2
+
+        for m in [m1, m2]:
+            switch_to_cgroups_v2(m)
+
+        self.login_and_go(None, superuser=True)
+        self.add_machine("10.111.113.2", password=None)
+        self.enable_administrative_access("10.111.113.2")
+        self.start_podman_service("10.111.113.2")
+
+        b.go("/@10.111.113.2/podman")
+        b.wait_present("#app")
+
+        # Run a container
+        m2.execute("podman run -dit --name swamped-crate busybox sh")
+        b.wait(lambda: m2.execute("podman ps --all | grep -e swamped-crate"))
+
+        # Open the migration dialog
+        self.open_migrate_dialog("swamped-crate")
+
+        # Select the second machine
+        # Note: the first machine is rather confusingly referred to as "localhost" here
+        self.select_target_host("localhost")
+
+        # Name the target container and set options
+        self.select_new_container_action()
+        self.set_new_target_container_name("swamped-crate-2")
+        self.set_migrate_options()
+
+        # Migrate the container
+        b.click("button:contains(Migrate)")
+        b.wait_not_present("button:contains(Migrate)")
+
+        # Check if container present and running on other host
+        m1.execute("podman ps | grep -e swamped-crate-2")
+
+    def testMigrateDialogSelectTargetContainerLimitedAccess(self):
+        """
+        Tests migration with limited (i.e. non-root) access to the other machine.
+        This should result in a meaningful error message.
+        """
+        b = self.browser
+        m1 = self.machine
+
+        self.login_and_go(None, superuser=True)
+        self.add_machine("10.111.113.2", password=None)
+
+        b.go("/podman")
+        b.enter_page("/podman")
+        b.wait_present("#app")
+
+        # Run a container
+        m1.execute("podman run -dit --name swamped-crate busybox sh")
+        b.wait(lambda: m1.execute("podman ps --all | grep -e swamped-crate"))
+
+        # Open the migration dialog
+        self.open_migrate_dialog("swamped-crate")
+
+        # Show the container list
+        self.select_existing_container_action()
+
+        # Select the second machine
+        self.select_target_host("10.111.113.2")
+
+        # Cockpit doesn't have administrative access to the second machine - check error messages
+        b.wait_present(".pf-m-error:contains(Connection failed)")
+        b.wait_present(".pf-c-select__toggle:contains(Error loading container list)")
+        b.wait_present(".pf-c-modal-box button:contains(Migrate):disabled")
+
+    def testMigrateUsingCrun(self):
+        """
+        Tests migration into a newly created container using the crun runtime.
+        This should result in a meaningful error message.
+        """
+        b = self.browser
+        m1 = self.machine
+        m2 = self.machine2
+
+        self.login_and_go(None, superuser=True)
+        self.add_machine("10.111.113.2", password=None)
+        self.enable_administrative_access("10.111.113.2")
+        self.start_podman_service("10.111.113.2")
+
+        b.go("/podman")
+        b.enter_page("/podman")
+        b.wait_present("#app")
+
+        # Run a container
+        m1.execute("podman run -dit --name swamped-crate busybox sh")
+        b.wait(lambda: m1.execute("podman ps --all | grep -e swamped-crate"))
+
+        # Open the migration dialog
+        self.open_migrate_dialog("swamped-crate")
+
+        # Select the second machine
+        self.select_target_host("10.111.113.2")
+
+        # Name the target container and set options
+        self.set_new_target_container_name("swamped-crate-2")
+        self.set_migrate_options()
+
+        # Migrate the container
+        b.click("button:contains(Migrate)")
+        b.wait_not_present("button:contains(Migrate)")
+
+        # Check if the error was correctly displayed
+        b.wait_present(":contains(Configured runtime does not support checkpoint/restore)")
+
+    def testMigrateDialogHostRefresh(self):
+        """Tests refreshing of the remote host list when re-opening the migration dialog"""
+        b = self.browser
+        m1 = self.machine
+        m2 = self.machine2
+
+        self.login_and_go(None, superuser=True)
+
+        b.go("/podman")
+        b.enter_page("/podman")
+        b.wait_present("#app")
+
+        # Run a container
+        m1.execute("podman run -dit --name swamped-crate busybox sh")
+        b.wait(lambda: m1.execute("podman ps --all | grep -e swamped-crate"))
+
+        # Open the migration dialog, check if the target host placeholder is present, and close it
+        self.open_migrate_dialog("swamped-crate")
+        b.wait_present(".pf-c-modal-box :contains(Choose target host...)")
+        b.click("button:contains(Cancel)")
+
+        # Add the remote host to Cockpit
+        self.add_machine("10.111.113.2", password=None)
+        self.enable_administrative_access("10.111.113.2")
+        self.start_podman_service("10.111.113.2")
+
+        # Open the migration dialog again and check if the host list is present and container name checking is enabled
+        b.go("/podman")
+        b.enter_page("/podman")
+        b.wait_present("#app")
+
+        self.open_migrate_dialog("swamped-crate", container_open=True)
+        b.wait_present("#migrate-dialog-target-host-form-group :contains(10.111.113.2)")
+        b.wait_present(".pf-m-error:contains(Container name can't be empty)")
+        b.click("button:contains(Cancel)")
+
+        # Remove the remote host from Cockpit
+        self.remove_machine("machine2")
+        time.sleep(5)
+
+        # Open the migration dialog again and check if the placeholder is back
+        b.go("/podman")
+        b.enter_page("/podman")
+        b.wait_present("#app")
+
+        self.open_migrate_dialog("swamped-crate", container_open=True)
+        b.wait_present(".pf-c-modal-box :contains(Choose target host...)")
+        b.click("button:contains(Cancel)")
+
+    def testMigrateDialogSwitchActionPreservesTargetContainer(self):
+        """
+        Tests if changing the action from create new container to use existing container preserves the target container
+        (both the text field container and the selection in the select element).
+        """
+        b = self.browser
+        m1 = self.machine
+        m2 = self.machine2
+
+        self.login_and_go(None, superuser=True)
+        self.add_machine("10.111.113.2", password=None)
+        self.enable_administrative_access("10.111.113.2")
+        self.start_podman_service("10.111.113.2")
+
+        b.go("/podman")
+        b.enter_page("/podman")
+        b.wait_present("#app")
+
+        # Run a container
+        m1.execute("podman run -dit --name swamped-crate busybox sh")
+        b.wait(lambda: m1.execute("podman ps --all | grep -e swamped-crate"))
+
+        # Create a test container to migrate to (and another one to test the select value preservation)
+        for name in ["target-test", "target-test-2"]:
+            m2.execute("podman run -dit --name {} busybox sh".format(name))
+            b.wait(lambda: m2.execute("podman ps --all | grep -e {}".format(name)))
+            m2.execute("podman stop {}".format(name))
+
+        # Open the migration dialog and fill out container name
+        self.open_migrate_dialog("swamped-crate")
+        self.set_new_target_container_name("target-test-3")
+
+        # Switch action to existing container and select the second container on the target host
+        self.select_existing_container_action()
+        self.select_target_container("target-test-2")
+
+        # Switch back and check if the container name was preserved
+        self.select_new_container_action()
+        b.wait_val(".pf-c-modal-box #migrate-container-target-name", "target-test-3")
+
+        # Switch to existing container once again and check the selection
+        self.select_existing_container_action()
+        b.wait_present(".pf-c-modal-box :contains(target-test-2)")
+
+    def testMigrateContainerListUpdate(self):
+        """
+        Tests if closing and opening the window refreshes the container list. Also tests if container preselection
+        works correctly.
+        """
+        b = self.browser
+        m1 = self.machine
+        m2 = self.machine2
+
+        self.login_and_go(None, superuser=True)
+        self.add_machine("10.111.113.2", password=None)
+        self.enable_administrative_access("10.111.113.2")
+        self.start_podman_service("10.111.113.2")
+
+        b.go("/podman")
+        b.enter_page("/podman")
+        b.wait_present("#app")
+
+        # Run a container
+        m1.execute("podman run -dit --name swamped-crate busybox sh")
+        b.wait(lambda: m1.execute("podman ps --all | grep -e swamped-crate"))
+
+        # Run a container on the other host
+        m2.execute("podman run -dit --name swamped-crate busybox sh")
+        b.wait(lambda: m2.execute("podman ps --all | grep -e swamped-crate"))
+
+        # Open the migration modal and check if swamped-crate is preselected.
+        self.open_migrate_dialog("swamped-crate")
+        self.select_existing_container_action()
+        b.wait_present(".pf-c-modal-box #migrate-dialog-target :contains(swamped-crate)")
+
+        # swamped-crate should also be invalid for a new container
+        self.select_new_container_action()
+        self.set_new_target_container_name("swamped-crate")
+        b.wait_present(".pf-c-modal-box #migrate-dialog-target .pf-m-error:contains(Container with that name already exists)")
+        b.wait_present(".pf-c-modal-box button:contains(Migrate):disabled")
+
+        # Remove container on other host
+        m2.execute("podman rm -f swamped-crate")
+
+        # Re-open migration modal and check if the container list is updated (i.e. placeholder visible in the select)
+        b.click("button:contains(Cancel)")
+        self.open_migrate_dialog("swamped-crate", container_open=True)
+        self.select_existing_container_action()
+        b.wait_present(".pf-c-modal-box #migrate-dialog-target :contains(Choose container...)")
+
+        # swamped-care should now be a valid name
+        self.select_new_container_action()
+        b.wait_present(".pf-c-modal-box #migrate-container-target-name")
+        b.wait_not_present(".pf-c-modal-box #migrate-dialog-target .pf-m-error")
+
+    def testMigratePodmanServiceNotRunning(self):
+        """
+        Tests attempting to migrate container onto a host with the Podman service stopped.
+        This should result in a specific error message being displayed.
+        """
+        b = self.browser
+        m1 = self.machine
+        m2 = self.machine2
+
+        self.login_and_go(None, superuser=True)
+        self.add_machine("10.111.113.2", password=None)
+        self.enable_administrative_access("10.111.113.2")
+        self.start_podman_service("10.111.113.2")
+
+        b.go("/podman")
+        b.enter_page("/podman")
+        b.wait_present("#app")
+
+        # Run a container
+        m1.execute("podman run -dit --name swamped-crate busybox sh")
+        b.wait(lambda: m1.execute("podman ps --all | grep -e swamped-crate"))
+
+        # Stop Podman service on second machine
+        m2.execute("systemctl stop podman.service podman.socket")
+
+        # Open the migration modal and check if a connection error is displayed when "existing container" action is
+        # selected
+        self.open_migrate_dialog("swamped-crate")
+        self.select_existing_container_action()
+        b.wait_present(".pf-m-error:contains(Connection failed)")
+        b.wait_present(".pf-c-select__toggle:contains(Error loading container list)")
+        b.wait_present(".pf-c-modal-box button:contains(Migrate):disabled")
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
This requires a few changes in client.js, namely specifiying a host
where the operation is executed with each Podman command.

---

This patch introduces a graphical interface for [CRIU Podman container migration](https://criu.org/Podman#Container_Live_Migration), making use of cockpit-bridge sessions on the source and target hosts to transfer the data.

- Shows the state of the migration process using a label (see picture below)
- Supports transferring the image if not present on the target host
- Requires cockpit-project/cockpit#14641 to work and cockpit-project/cockpit#14849 to handle larger images/checkpoints (currently both open, first one likely close to merging)
- Uses raw channel API a lot, because the higher level cockpit.js API doesn't fit well with channel redirects
- Uses Cockpit session storage data to get the list of available host to migrate to
- I implemented the kebab menu using the PatternFly Dropdown component (as in the adjecent dropdown buttons) - the kebab icon's position looks a little bit off (see picture below)
- There are currently no tests - I'm working on them (a multi-machine setup is required for that, which is a little bit tricky)
- Export phases don't report errors correctly (error message is absent, because it gets saved into the checkpoint/image file) - this will probably be fixed with the tests, since it will be likely needed there

![Screenshot_20201214_123611](https://user-images.githubusercontent.com/1266171/102077186-31704080-3e09-11eb-915c-4b6527b4bbc7.png)
![Screenshot_20201214_123632](https://user-images.githubusercontent.com/1266171/102077194-32a16d80-3e09-11eb-9f31-943651062a45.png)
![Screenshot_20201214_123653](https://user-images.githubusercontent.com/1266171/102077197-346b3100-3e09-11eb-9d0b-9442d1133ad3.png)
![Screenshot_20201214_123711](https://user-images.githubusercontent.com/1266171/102077200-359c5e00-3e09-11eb-9132-677f105d391a.png)
![Screenshot_20201214_123738](https://user-images.githubusercontent.com/1266171/102077204-36cd8b00-3e09-11eb-9e9c-fd61da3109ff.png)


