### PR TITLE
Disable all ways of closing dialogs while an operation is in progress

### DIFF
--- a/src/ContainerCheckpointModal.jsx
+++ b/src/ContainerCheckpointModal.jsx
@@ -24,8 +24,8 @@ class ContainerCheckpointModal extends React.Component {
     render() {
         return (
             <Modal isOpen={this.props.selectContainerCheckpointModal}
+                   showClose={false}
                    position="top" variant="medium"
-                   onClose={this.props.handleCheckpointContainerDeleteModal}
                    title={cockpit.format(_("Checkpoint container $0"), this.props.containerWillCheckpoint.Names)}
                    footer={<>
                        <Button variant="primary" isDisabled={this.props.checkpointInProgress}
@@ -33,7 +33,8 @@ class ContainerCheckpointModal extends React.Component {
                                onClick={() => this.props.handleCheckpointContainer(this.state)}>
                            {_("Checkpoint")}
                        </Button>
-                       <Button variant="link" onClick={this.props.handleCheckpointContainerDeleteModal}>
+                       <Button variant="link" isDisabled={this.props.checkpointInProgress}
+                               onClick={this.props.handleCheckpointContainerDeleteModal}>
                            {_("Cancel")}
                        </Button>
                    </>}

--- a/src/ContainerCommitModal.jsx
+++ b/src/ContainerCommitModal.jsx
@@ -216,13 +216,24 @@ class ContainerCommitModal extends React.Component {
 
         return (
             <Modal isOpen
+                   showClose={false}
                    position="top" variant="medium"
-                   onClose={this.props.onHide}
                    title={_("Commit image")}
                    footer={<>
                        {this.state.dialogError && <ErrorNotification errorMessage={this.state.dialogError} errorDetail={this.state.dialogErrorDetail} onDismiss={() => this.setState({ dialogError: undefined })} />}
-                       <Button variant="primary" className="btn-ctr-commit" isLoading={this.state.commitInProgress} isDisabled={this.state.commitInProgress} onClick={this.handleCommit}>{_("Commit")}</Button>
-                       <Button variant="link" className="btn-ctr-cancel-commit" onClick={this.props.onHide}>{_("Cancel")}</Button>
+                       <Button variant="primary"
+                               className="btn-ctr-commit"
+                               isLoading={this.state.commitInProgress}
+                               isDisabled={this.state.commitInProgress}
+                               onClick={this.handleCommit}>
+                           {_("Commit")}
+                       </Button>
+                       <Button variant="link"
+                               className="btn-ctr-cancel-commit"
+                               isDisabled={this.state.commitInProgress}
+                               onClick={this.props.onHide}>
+                           {_("Cancel")}
+                       </Button>
                    </>}
             >
                 {commitContent}

--- a/src/ContainerRemoveErrorModal.jsx
+++ b/src/ContainerRemoveErrorModal.jsx
@@ -9,8 +9,8 @@ const ContainerRemoveErrorModal = (props) => {
     const [inProgress, setInProgress] = useState(false);
     return (
         <Modal key={name} isOpen={props.setContainerRemoveErrorModal}
+               showClose={false}
                position="top" variant="medium"
-               onClose={props.handleCancelRemoveError}
                title={cockpit.format(_("Please confirm forced deletion of $0"), name)}
                footer={<>
                    <Button variant="danger" isDisabled={inProgress} isLoading={inProgress} className="btn-ctr-forcedelete"
@@ -18,7 +18,7 @@ const ContainerRemoveErrorModal = (props) => {
                    >
                        {_("Force delete")}
                    </Button>
-                   <Button variant="link" onClick={props.handleCancelRemoveError}>{_("Cancel")}</Button>
+                   <Button variant="link" isDisabled={inProgress} onClick={props.handleCancelRemoveError}>{_("Cancel")}</Button>
                </>}
         >
             {_("Container is currently running.")}

--- a/src/ContainerRestoreModal.jsx
+++ b/src/ContainerRestoreModal.jsx
@@ -26,8 +26,8 @@ class ContainerRestoreModal extends React.Component {
     render() {
         return (
             <Modal isOpen={this.props.selectContainerRestoreModal}
+                   showClose={false}
                    position="top" variant="medium"
-                   onClose={this.props.handleRestoreContainerDeleteModal}
                    title={cockpit.format(_("Restore container $0"), utils.truncate_id(this.props.containerWillCheckpoint.Id))}
                    footer={<>
                        <Button variant="primary" isDisabled={this.props.restoreInProgress}
@@ -35,7 +35,8 @@ class ContainerRestoreModal extends React.Component {
                                onClick={() => this.props.handleRestoreContainer(this.state)}>
                            {_("Restore")}
                        </Button>
-                       <Button variant="link" onClick={this.props.handleRestoreContainerDeleteModal}>
+                       <Button variant="link" isDisabled={this.props.restoreInProgress}
+                               onClick={this.props.handleRestoreContainerDeleteModal}>
                            {_("Cancel")}
                        </Button>
                    </>}


### PR DESCRIPTION
Fixes #504

Note: ideally we should be able to cancel the operations but podman does
not offer that, so let's just be safe with not allowing the users to
close the dialogs.