### PR TITLE
Don't show error message when we close connection during image search

### DIFF
--- a/src/ImageSearchModal.jsx
+++ b/src/ImageSearchModal.jsx
@@ -87,7 +87,7 @@ export class ImageSearchModal extends React.Component {
         };
         this.activeConnection.call(options)
                 .then(reply => {
-                    if (this._isMounted)
+                    if (reply && this._isMounted)
                         this.setState({ imageList: JSON.parse(reply) || [], searchInProgress: false, searchFinished: true, dialogError: "" });
                 })
                 .catch(ex => {


### PR DESCRIPTION
We close current search connection if the term has been updated in the
meantime. That results in getting empty reply that cannot be parsed as
valid JSON.

Fixes #595