### PR TITLE
test: Copy system podman images to admin user

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -68,14 +68,11 @@ mkdir -p /root/.ssh
 curl https://raw.githubusercontent.com/cockpit-project/bots/master/machine/identity.pub  >> /root/.ssh/authorized_keys
 chmod 600 /root/.ssh/authorized_keys
 
-# pull images for user podman tests; podman insists on user session
+# copy images for user podman tests; podman insists on user session
 loginctl enable-linger $(id -u admin)
-sudo -i -u admin bash << EOF
-podman rmi --all
-podman pull quay.io/libpod/busybox
-podman pull quay.io/libpod/alpine
-podman pull quay.io/cockpit/registry:2
-EOF
+for img in quay.io/libpod/busybox quay.io/libpod/alpine quay.io/cockpit/registry:2; do
+    podman save  $img | sudo -i -u admin podman load
+done
 loginctl disable-linger $(id -u admin)
 
 # HACK: See https://github.com/cockpit-project/cockpit/issues/14133

--- a/test/vm.install
+++ b/test/vm.install
@@ -71,7 +71,6 @@ chmod 600 /root/.ssh/authorized_keys
 # pull images for user podman tests; podman insists on user session
 loginctl enable-linger $(id -u admin)
 sudo -i -u admin bash << EOF
-systemctl --user disable --now systemd-tmpfiles-clean.timer
 podman rmi --all
 podman pull quay.io/libpod/busybox
 podman pull quay.io/libpod/alpine
@@ -84,3 +83,4 @@ mkdir -p /usr/share/cockpit/packagekit
 
 # 15minutes after boot tmp files are removed and podman stores some tmp lock files
 systemctl disable --now systemd-tmpfiles-clean.timer
+systemctl --global disable systemd-tmpfiles-clean.timer


### PR DESCRIPTION
This avoids pulling the images twice, redudes pull limit stress, and
ensures that the images are identical.

----

I'll also update our Fedora/Debian images to pre-pull these container images and pre-install cockpit and podman; then `make vm` should be completely offline and also much faster.