### PR TITLE
run: Make hostPort optional

### DIFF
--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -32,6 +32,13 @@ const PublishPort = ({ id, item, onChange, idx, removeitem, additem }) =>
     (
         <>
             <InputGroup className='ct-input-group-spacer-sm'>
+                <TextInput type='number'
+                           step={1}
+                           min={1}
+                           max={65535}
+                           placeholder={_("Host port (optional)")}
+                           value={item.hostPort || ''}
+                           onChange={value => onChange(idx, 'hostPort', value)} />
                 <TextInput id={id}
                            type='number'
                            step={1}
@@ -40,13 +47,6 @@ const PublishPort = ({ id, item, onChange, idx, removeitem, additem }) =>
                            placeholder={_("Container port")}
                            value={item.containerPort || ''}
                            onChange={value => onChange(idx, 'containerPort', value)} />
-                <TextInput type='number'
-                           step={1}
-                           min={1}
-                           max={65535}
-                           placeholder={_("Host port")}
-                           value={item.hostPort || ''}
-                           onChange={value => onChange(idx, 'hostPort', value)} />
                 <Select.Select extraClass='pf-c-form-control container-port-protocol'
                                initial={item.protocol}
                                onChange={value => onChange(idx, 'protocol', value)}>
@@ -264,8 +264,13 @@ export class ImageRunModal extends React.Component {
         createConfig.terminal = this.state.hasTTY;
         if (this.state.publish.length > 0)
             createConfig.portmappings = this.state.publish
-                    .filter(port => port.hostPort && port.containerPort)
-                    .map(port => { return { host_port: parseInt(port.hostPort), container_port: parseInt(port.containerPort), protocol: port.protocol } });
+                    .filter(port => port.containerPort)
+                    .map(port => {
+                        const pm = { container_port: parseInt(port.containerPort), protocol: port.protocol };
+                        if (port.hostPort !== null)
+                            pm.host_port = parseInt(port.hostPort);
+                        return pm;
+                    });
         if (this.state.env.length > 0) {
             const ports = {};
             this.state.env.forEach(item => { ports[item.envKey] = item.envValue });

--- a/test/check-application
+++ b/test/check-application
@@ -1145,18 +1145,17 @@ class TestApplication(testlib.MachineCase):
         b.set_input_text('#run-image-dialog-command', "sh -c 'for i in $(seq 20); do sleep 1; echo $i; done; sleep infinity'")
 
         # Configure published ports
-        b.set_input_text('.publish-port-form[data-key="0"] input:first-child', '5000')
-        b.set_input_text('.publish-port-form[data-key="0"] input:nth-child(2)', '6000')
+        b.set_input_text('.publish-port-form[data-key="0"] input:first-child', '6000')
+        b.set_input_text('.publish-port-form[data-key="0"] input:nth-child(2)', '5000')
         b.click('.publish-port-form[data-key="0"] .btn-add')
-        b.set_input_text('.publish-port-form[data-key="1"] input:first-child', '5001')
-        b.set_input_text('.publish-port-form[data-key="1"] input:nth-child(2)', '6001')
+        b.set_input_text('.publish-port-form[data-key="1"] input:first-child', '6001')
+        b.set_input_text('.publish-port-form[data-key="1"] input:nth-child(2)', '5001')
         b.set_val('.publish-port-form[data-key="1"] select', "udp")
         b.click('.publish-port-form[data-key="1"] .btn-add')
         b.set_input_text('.publish-port-form[data-key="2"] input:first-child', '7001')
         b.set_input_text('.publish-port-form[data-key="2"] input:nth-child(2)', '7001')
         b.click('.publish-port-form[data-key="2"] .btn-close')
         b.click('.publish-port-form[data-key="1"] .btn-add')
-        b.set_input_text('.publish-port-form[data-key="3"] input:first-child', '8001')
         b.set_input_text('.publish-port-form[data-key="3"] input:nth-child(2)', '8001')
 
         # Configure env
@@ -1229,7 +1228,7 @@ class TestApplication(testlib.MachineCase):
 
         b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Ports") + dd', '0.0.0.0:6000 \u2192 5000/tcp')
         b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Ports") + dd', '0.0.0.0:6001 \u2192 5001/udp')
-        b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Ports") + dd', '0.0.0.0:8001 \u2192 8001/tcp')
+        b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Ports") + dd', ' \u2192 8001/tcp')
         b.wait_not_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Ports") + dd', '0.0.0.0:7001 \u2192 7001/tcp')
         ports = self.execute(auth, "podman inspect --format '{{.NetworkSettings.Ports}}' busybox-with-tty")
 
@@ -1237,7 +1236,7 @@ class TestApplication(testlib.MachineCase):
 
         self.assertIn('5000/tcp:[{ 6000}]', ports)
         self.assertIn('5001/udp:[{ 6001}]', ports)
-        self.assertIn('8001/tcp:[{ 8001}]', ports)
+        self.assertIn('8001/tcp:[{ ', ports)
         self.assertNotIn('7001/tcp:[{ 7001}]', ports)
 
         env = self.execute(auth, "podman exec busybox-with-tty env")


### PR DESCRIPTION
Follow what CLI allows:
```
--publish, -p=ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort | containerPort
```

Does not yet supports IP addresses. (so just the last two cases)
Also changing order as it is like that everywhere including in our UI
where we show `IP:hostPort->ContainerPort/protocol`

Fixes #365