### PR TITLE
tests: Make it pass on rhel-8-3 and rhel-8-4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 231; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 234; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 

--- a/src/Notification.jsx
+++ b/src/Notification.jsx
@@ -23,7 +23,19 @@ import cockpit from 'cockpit';
 
 const _ = cockpit.gettext;
 
+let last_error = "";
+
+function log_error_if_changed(error) {
+    // Put the error in the browser log, for easier debugging and
+    // matching of known issues in the integration tests.
+    if (error != last_error) {
+        last_error = error;
+        console.error(error);
+    }
+}
+
 export const ErrorNotification = ({ errorMessage, errorDetail, onDismiss }) => {
+    log_error_if_changed(errorMessage + (errorDetail ? ": " + errorDetail : ""));
     return (
         <Alert isInline variant='danger' title={errorMessage}
             actionClose={onDismiss ? <AlertActionCloseButton onClose={onDismiss} /> : null}>

--- a/test/check-application
+++ b/test/check-application
@@ -69,7 +69,7 @@ class TestApplication(testlib.MachineCase):
         # But disable it globally so that "systemctl --user disable" does what we expect
         self.machine.execute("systemctl --global disable podman.socket")
 
-        self.addCleanup(self.machine.execute, "killall -9 podman")
+        self.addCleanup(self.machine.execute, "killall -9 podman || true")
 
         self.allow_journal_messages("/run.*/podman/podman: couldn't connect.*")
         self.allow_journal_messages(".*/run.*/podman/podman.*Connection reset by peer")
@@ -938,9 +938,13 @@ class TestApplication(testlib.MachineCase):
 
     @testlib.nondestructive
     def testCheckpointRestoreSystemCrun(self):
-        # With crun (CgroupsV2) checkpoint doesn't work yet
         b = self.browser
         m = self.machine
+
+        if not self.cgroupsV2() and self.has_criu:
+            return
+
+        # With crun (CgroupsV2) or without criu checkpoints don't work yet
 
         self.login_and_go("/podman", superuser=True)
         b.wait_present("#app")

--- a/test/check-application
+++ b/test/check-application
@@ -78,7 +78,7 @@ class TestApplication(testlib.MachineCase):
         self.has_selinux = self.machine.image not in ["debian-testing", "ubuntu-stable"]
 
     def cgroupsV2(self):
-        return self.machine.image not in ["debian-testing", "ubuntu-stable"]
+        return self.machine.image not in ["debian-testing", "ubuntu-stable", "rhel-8-3", "rhel-8-4"]
 
     def execute(self, system, cmd):
         if system:

--- a/test/check-application
+++ b/test/check-application
@@ -179,11 +179,16 @@ class TestApplication(testlib.MachineCase):
         b.wait_present("#containers-containers .container-name:contains('a')")
         b.wait_present("#containers-containers .container-name:contains('b')")
 
+        if self.system_before(231): # Changed in #14740
+            modal_sel = ".modal-dialog"
+        else:
+            modal_sel = ".pf-c-modal-box"
+
         # Drop privileges
         b.switch_to_top()
         b.click("#super-user-indicator button")
-        b.click(".pf-c-modal-box:contains('Switch to limited access') button:contains('Limit access')")
-        b.wait_not_present(".pf-c-modal-box:contains('Switch to limited access')")
+        b.click("%s:contains('Switch to limited access') button:contains('Limit access')" % modal_sel)
+        b.wait_not_present("%s:contains('Switch to limited access')" % modal_sel)
         b.wait_text("#super-user-indicator", "Limited access")
         b.switch_to_frame("cockpit1:localhost/podman")
 
@@ -209,10 +214,10 @@ class TestApplication(testlib.MachineCase):
         # Gain privileges
         b.switch_to_top()
         b.click("#super-user-indicator button")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
-        b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "foobar")
-        b.click(".pf-c-modal-box button:contains('Authenticate')")
-        b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
+        b.wait_in_text("%s:contains('Administrative access')" % modal_sel, "Please authenticate")
+        b.set_input_text("%s:contains('Administrative access') input" % modal_sel, "foobar")
+        b.click("%s button:contains('Authenticate')" % modal_sel)
+        b.wait_not_present("%s:contains('Administrative access')" % modal_sel)
         b.wait_text("#super-user-indicator", "Administrative access")
         b.switch_to_frame("cockpit1:localhost/podman")
 
@@ -248,8 +253,8 @@ class TestApplication(testlib.MachineCase):
 
         b.switch_to_top()
         b.click("#super-user-indicator button")
-        b.click(".pf-c-modal-box:contains('Switch to limited access') button:contains('Limit access')")
-        b.wait_not_present(".pf-c-modal-box:contains('Switch to limited access')")
+        b.click("%s:contains('Switch to limited access') button:contains('Limit access')" % modal_sel)
+        b.wait_not_present("%s:contains('Switch to limited access')" % modal_sel)
         b.wait_text("#super-user-indicator", "Limited access")
         b.switch_to_frame("cockpit1:localhost/podman")
 

--- a/test/check-application
+++ b/test/check-application
@@ -865,7 +865,8 @@ class TestApplication(testlib.MachineCase):
 
         # Set machine to cgroup1 and reboot; Debian uses hybrid mode and does not have grubby
         if not m.image.startswith("debian") and not m.image.startswith("ubuntu"):
-            self.execute(True, 'grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"; reboot')
+            self.execute(True, 'grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"')
+            self.machine.spawn("sleep 0.1 && reboot", "reboot")
             m.wait_reboot()
 
         self.login_and_go("/podman", superuser=True)


### PR DESCRIPTION
rhel-8-4:

- [x] Shell dialogs use old-style classes
- [x] synchronous reboot causes self.execute to fail.
- [x] cgroupv1 vs cgroupv2 stuff
- [x] Rootless podman doesn't work on rhel-8-4: https://bugzilla.redhat.com/show_bug.cgi?id=1903983

rhel-8-3:

- [x] Shell dialogs use old-style classes
- [x] synchronous reboot causes self.execute to fail.
- [x] cgroupv1 vs cgroupv2 stuff
- [x] TestApplication.testCheckpointRestoreSystemCrun can unexpectedly make snapshots 
