### PR TITLE
Drop sass-resources-loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ test/common:
 
 lib/patternfly/_fonts.scss:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 231; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 234; \
 	    mkdir -p pkg/lib/patternfly && git add pkg/lib/patternfly; \
 	    git checkout --force FETCH_HEAD -- pkg/lib/patternfly; \
 	    git reset -- pkg/lib/patternfly'

--- a/lib/_global-variables.scss
+++ b/lib/_global-variables.scss
@@ -1,3 +1,11 @@
+@import "@patternfly/patternfly/base/patternfly-variables.scss";
+
+/* Bootstrap scss compilation will complain if these are not set
+ * https://github.com/twbs/bootstrap/issues/23982
+ */
+$grid-gutter-width: 30px;
+$font-size-base: 1;
+
 /*
  * PatternFly 4 adapting the lists too early.
  * When PF4 has a breakpoint of 768px width, it's actually 1108 for us, as the sidebar is 340px.

--- a/lib/cockpit-components-file-autocomplete.jsx
+++ b/lib/cockpit-components-file-autocomplete.jsx
@@ -178,7 +178,8 @@ export class FileAutoComplete extends React.Component {
                 }}
                 onToggle={this.onToggle}
                 onClear={this.clearSelection}
-                isOpen={this.state.isOpen}>
+                isOpen={this.state.isOpen}
+                menuAppendTo="parent">
                 {this.state.displayFiles.map((option, index) => (
                     <SelectOption key={option.path}
                                   className={option.type}

--- a/lib/cockpit-components-table.jsx
+++ b/lib/cockpit-components-table.jsx
@@ -120,8 +120,11 @@ export class ListingTable extends React.Component {
                 res.title = column;
             } else {
                 res.title = column.title;
+                res.cellTransforms = [];
                 if (column.header)
-                    res.cellTransforms = [headerCol()];
+                    res.cellTransforms.push(headerCol());
+                if (column.cellTransforms)
+                    res.cellTransforms = res.cellTransforms.concat(column.cellTransforms);
                 if (column.transforms)
                     res.transforms = column.transforms;
                 if (column.sortable)

--- a/lib/cockpit-components-table.scss
+++ b/lib/cockpit-components-table.scss
@@ -1,5 +1,6 @@
-@import "~@patternfly/patternfly/components/Table/table.scss";
-@import "~@patternfly/patternfly/components/Table/table-grid.scss";
+@import "@patternfly/patternfly/base/patternfly-variables.scss";
+@import "@patternfly/patternfly/components/Table/table.scss";
+@import "@patternfly/patternfly/components/Table/table-grid.scss";
 
 .ct-table {
     // Reverse out the default padding for table bodies,
@@ -115,22 +116,6 @@
         // Similar to PF4, but with a translate to bump the expanded icon down 3 pixels,
         // to better align the expanded form
         transform: translateY(3px) rotate(var(--pf-c-table__toggle--c-button--m-expanded__toggle-icon--Rotate));
-    }
-
-    // Shrink buttons down a little
-    td:not(.pf-c-table__toggle) {
-        > .pf-c-button,
-        > .pf-c-input-group > .pf-c-button,
-        > .btn-group > .pf-c-button {
-            padding: 0.25rem 0.75rem;
-        }
-
-        > .pf-m-link {
-            &:only-child {
-                width: 100%;
-                text-align: left;
-            }
-        }
     }
 
     // Remove excess PF4 nested compact paddings

--- a/lib/ct-card.scss
+++ b/lib/ct-card.scss
@@ -26,5 +26,21 @@
 }
 
 .ct-card.pf-c-card .pf-c-card__header {
-  padding: var(--pf-global--spacer--md) var(--pf-global--spacer--md) var(--pf-global--spacer--sm) var(--pf-global--spacer--lg);
+  padding: var(--pf-global--spacer--md);
+}
+
+.ct-cards-grid {
+    --ct-grid-columns: 2;
+    --pf-l-gallery--GridTemplateColumns: repeat(var(--ct-grid-columns), 1fr);
+
+    > .pf-c-card:not(.ct-card-info) {
+        // Extend all non-info cards to be full width;
+        // let ct-card-info fit 1 column of the grid
+        grid-column: 1 / -1;
+    }
+
+    @media screen and (max-width: $pf-global--breakpoint--lg) {
+        // Shrink to 1 column when space is constrained
+        --ct-grid-columns: 1;
+    }
 }

--- a/lib/page.scss
+++ b/lib/page.scss
@@ -1,5 +1,7 @@
+@import "./_global-variables.scss";
+@import "@patternfly/patternfly/base/patternfly-themes.scss";
 @import "./patternfly/patternfly-4-overrides.scss";
-@import "../node_modules/@patternfly/patternfly/components/Page/page.scss";
+@import "@patternfly/patternfly/components/Page/page.scss";
 
 a {
     cursor: pointer;
@@ -155,10 +157,14 @@ a.disabled:hover {
 
 .dialog-wait-ct {
     margin-top: 3px;
+    /* Right align footer idle messages after the buttons */
+    margin-left: auto;
 }
 
 .dialog-wait-ct .spinner {
     display: inline-block;
+    /* Add spacing betweem possible messages and the spinner */
+    margin-left: var(--pf-global--spacer--md);
 }
 
 .dialog-wait-ct span {
@@ -174,7 +180,7 @@ a.disabled:hover {
 }
 
 /* HACK: https://github.com/patternfly/patternfly/issues/255 */
-input[type=number] {
+input[type=number]:not(.pf-c-form-control) {
   padding: 0 0 0 5px;
 }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "po2json": "^1.0.0-alpha",
     "sass-loader": "^10.0.2",
-    "sass-resources-loader": "^2.0.1",
     "sizzle": "^2.3.3",
     "stdio": "^2.1.0",
     "string-replace-loader": "^2.3.0",

--- a/src/podman.scss
+++ b/src/podman.scss
@@ -1,3 +1,4 @@
+@import '../lib/page.scss';
 @import '../lib/ct-card.scss';
 
 #app .pf-l-gallery {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -191,6 +191,7 @@ module.exports = {
                         options: {
                             sourceMap: true,
                             sassOptions: {
+                                includePaths: [ path.resolve(nodedir) ],
                                 outputStyle: 'compressed',
                             }
                         }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -196,17 +196,6 @@ module.exports = {
                             }
                         }
                     },
-                    {
-                        loader: 'sass-resources-loader',
-                            // Make PF4 variables globably accessible to be used by the components scss
-                            options: {
-                                resources: [
-                                    path.resolve(libdir, './_global-variables.scss'),
-                                    path.resolve(nodedir, './@patternfly/patternfly/base/patternfly-themes.scss'),
-                                    path.resolve(nodedir, './@patternfly/patternfly/base/patternfly-variables.scs'),
-                                ],
-                            },
-                    },
                 ]
             },
         ]


### PR DESCRIPTION
Explicitly include the required PF variables definitions into components
instead. This lessens the already gross duplication in the built
index.css (1200 → 950 kB in debug mode). It also makes separate
compilation and reuse easier, and paves the way for using sassc (which
doesn't support global resources).

Also drop the `~` prefix from cockpit-components-table.scss imports.
It's not necessary for sass-loader, and does not work with sassc.

 - [x] Do this in cockpit first, where these files got copied from: https://github.com/cockpit-project/cockpit/pull/15042