### PR TITLE
spec: Add BuildRequires: make

### DIFF
--- a/cockpit-podman.spec.in
+++ b/cockpit-podman.spec.in
@@ -25,6 +25,7 @@ URL:            https://github.com/cockpit-project/cockpit-podman
 Source0:        https://github.com/cockpit-project/cockpit-podman/releases/download/%{version}/cockpit-podman-%{version}.tar.gz
 BuildArch:      noarch
 BuildRequires:  libappstream-glib
+BuildRequires:  make
 
 Requires:       cockpit-bridge >= 138
 Requires:       cockpit-shell >= 138


### PR DESCRIPTION
Taken from Troy Dawson's downstream commit:
https://src.fedoraproject.org/rpms/cockpit-podman/c/04f4a72c7033056690
due to removing `make` from the buildroot:
https://fedoraproject.org/wiki/Changes/Remove_make_from_BuildRoot