### PR TITLE
Always fill the page with gray background

### DIFF
--- a/src/podman.scss
+++ b/src/podman.scss
@@ -14,7 +14,7 @@ body {
     flex-direction: column;
 
     @at-root #app {
-        min-height: 100%;
+        height: 100%;
     }
 }
 


### PR DESCRIPTION
This was not working in webkit browser. Now it works in webkit, firefox
and chrome.

Fixes #615
Closes #616

Webkit before:
![before](https://user-images.githubusercontent.com/12330670/102588741-389b9500-410e-11eb-8cae-50906e175afb.png)
Webkit after:
![after](https://user-images.githubusercontent.com/12330670/102588751-3c2f1c00-410e-11eb-88aa-fee970f027ca.png)
