### PR TITLE
feat: Network options for run images

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -260,3 +260,11 @@ export function pullImage(system, reference) {
                 .catch(reject);
     });
 }
+
+export function getNetworks(system) {
+    return new Promise((resolve, reject) => {
+        podmanCall("libpod/networks/json", "GET", {}, system)
+                .then(reply => resolve(JSON.parse(reply)))
+                .catch(reject);
+    });
+}

--- a/src/podman.scss
+++ b/src/podman.scss
@@ -249,3 +249,7 @@ input.pf-c-form-control[type=number] {
 .invisible {
   visibility: hidden;
 }
+
+.hidden {
+  display: none !important;
+}


### PR DESCRIPTION
Add network options in "Run image" dialog, as screenshot:
![image](https://user-images.githubusercontent.com/841969/103033529-92cca800-459d-11eb-83fc-1bbebb7a185b.png)

Add two options:

* **Network Namespace Mode**: for selecting `--network` option in podman CLI/`netns.nsmode` in podman API, which allows `bridge`/`none`/`host` and `slirp4netns` (if detected in `podman info`) in rootful mode (system flag), or `none`/`slirp4netns` (if detected in `podman info`) in rootless mode
* **CNI Networks**: for selecting CNI networks using in bridge mode, which will listing CNI networks from `/libpod/networks/json` (`podman network ls` in CLI). Without choosing this option, podman will use default network.

also solved #176

More TODOs for the network feature:

* support more ns modes and options, like `container:id`, `ns:path`, etc.
* support shows IP infos from multiple networks (from `NetworkSettings.Networks`)