### PR TITLE
Fix error and success handling on image pull

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -256,7 +256,18 @@ export function pullImage(system, reference) {
             reference: reference,
         };
         podmanCall("libpod/images/pull", "POST", options, system)
-                .then(reply => resolve(JSON.parse(reply)))
+                .then(r => {
+                    // Need to check the last response if it contains error
+                    const responses = r.trim().split("\n");
+                    const response = JSON.parse(responses[responses.length - 1]);
+                    if (response.error) {
+                        response.message = response.error;
+                        reject(response);
+                    } else if (response.cause) // present for 400 and 500 errors
+                        reject(response);
+                    else
+                        resolve();
+                })
                 .catch(reject);
     });
 }

--- a/test/check-application
+++ b/test/check-application
@@ -676,6 +676,9 @@ class TestApplication(testlib.MachineCase):
                 b.wait_visible('#containers-images td[data-label="Name"]:contains("{0}")'.format(self.imageName))
                 checkImage(b, "localhost:5000/{0}:{1}".format(self.imageName, self.imageTag or "latest"), "system" if self.user == "system" else "admin")
 
+                # Confirm that no error has happened
+                b.wait_not_present('h4.pf-c-alert__title:contains("Failed to download image")')
+
                 # Find out this image ID
                 self.imageSha = execute(self.user == "system", "podman inspect --format '{{{{.Id}}}}' localhost:5000/{0}:{1}".format(self.imageName, self.imageTag or "latest")).strip()
 


### PR DESCRIPTION
   
    We have shown error on every pull because we tried to parse the whole
    response as one JSON, but in fact it is a group of JSONs. That meant we
    failed to notice the fact that we were not showing any useful error when
    downloading actually failed. (We always just shown that we could not
    parse the response)
    
    Fixes #640
