### PR TITLE
test: Generalize cgroupsv2 distro check

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -869,7 +869,7 @@ class TestApplication(testlib.MachineCase):
             return;
 
         # Only Fedora works with CGroupsV2
-        if m.image in ["fedora-32", "fedora-33"]:
+        if m.image.startswith('fedora'):
             return self._testCheckpointRestore()
 
         # On other systems just check that we get expected error messages


### PR DESCRIPTION
All supported Fedoras use cgroupsv2 now, and this was previously missing
fedora-34 (current rawhide).