### PR TITLE
test: Allow debian-testing to cgroupsV2

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -81,7 +81,7 @@ class TestApplication(testlib.MachineCase):
         self.has_selinux = self.machine.image not in ["debian-testing", "ubuntu-stable"]
 
     def cgroupsV2(self):
-        return self.machine.image not in ["debian-testing", "ubuntu-stable", "rhel-8-3", "rhel-8-4"]
+        return self.machine.image not in ["ubuntu-stable", "rhel-8-3", "rhel-8-4"]
 
     def execute(self, system, cmd):
         if system:


### PR DESCRIPTION
Fixes a failure in debian-testing image refresh:
https://github.com/cockpit-project/bots/pull/1544