### PR TITLE
Stop hardcoding library paths

### DIFF
--- a/src/ContainerLogs.jsx
+++ b/src/ContainerLogs.jsx
@@ -25,7 +25,7 @@ import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import cockpit from 'cockpit';
 import rest from './rest.js';
 import * as client from './client.js';
-import { EmptyStatePanel } from "../lib/cockpit-components-empty-state.jsx";
+import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
 import "./ContainerTerminal.css";
 

--- a/src/ContainerTerminal.jsx
+++ b/src/ContainerTerminal.jsx
@@ -24,7 +24,7 @@ import { Terminal } from "xterm";
 import { ErrorNotification } from './Notification.jsx';
 
 import * as client from './client.js';
-import { EmptyStatePanel } from "../lib/cockpit-components-empty-state.jsx";
+import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
 import "./ContainerTerminal.css";
 

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -8,8 +8,8 @@ import {
 import { TrashIcon } from '@patternfly/react-icons';
 
 import cockpit from 'cockpit';
-import { ListingTable } from "../lib/cockpit-components-table.jsx";
-import { ListingPanel } from '../lib/cockpit-components-listing-panel.jsx';
+import { ListingTable } from "cockpit-components-table.jsx";
+import { ListingPanel } from 'cockpit-components-listing-panel.jsx';
 import ContainerDetails from './ContainerDetails.jsx';
 import ContainerTerminal from './ContainerTerminal.jsx';
 import ContainerLogs from './ContainerLogs.jsx';

--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -8,7 +8,7 @@ import { CloseIcon, PlusIcon } from '@patternfly/react-icons';
 import * as dockerNames from 'docker-names';
 
 import { ErrorNotification } from './Notification.jsx';
-import { FileAutoComplete } from '../lib/cockpit-components-file-autocomplete.jsx';
+import { FileAutoComplete } from 'cockpit-components-file-autocomplete.jsx';
 import * as utils from './util.js';
 import * as client from './client.js';
 import cockpit from 'cockpit';

--- a/src/ImageSearchModal.jsx
+++ b/src/ImageSearchModal.jsx
@@ -5,7 +5,7 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
-import { EmptyStatePanel } from "../lib/cockpit-components-empty-state.jsx";
+import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 import { ErrorNotification } from './Notification.jsx';
 import cockpit from 'cockpit';
 import rest from './rest.js';

--- a/src/ImageUsedBy.jsx
+++ b/src/ImageUsedBy.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import cockpit from 'cockpit';
 import * as utils from './util.js';
-import { ListingTable } from "../lib/cockpit-components-table.jsx";
+import { ListingTable } from "cockpit-components-table.jsx";
 
 const _ = cockpit.gettext;
 

--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -7,8 +7,8 @@ import {
 import { PlayIcon, PlusIcon, TrashIcon } from '@patternfly/react-icons';
 
 import cockpit from 'cockpit';
-import { ListingTable } from "../lib/cockpit-components-table.jsx";
-import { ListingPanel } from '../lib/cockpit-components-listing-panel.jsx';
+import { ListingTable } from "cockpit-components-table.jsx";
+import { ListingPanel } from 'cockpit-components-listing-panel.jsx';
 import ImageDetails from './ImageDetails.jsx';
 import ImageUsedBy from './ImageUsedBy.jsx';
 import { ImageRunModal } from './ImageRunModal.jsx';

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -27,7 +27,7 @@ import {
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import cockpit from 'cockpit';
-import { superuser } from "../lib/superuser";
+import { superuser } from "superuser";
 import moment from "moment";
 import ContainerHeader from './ContainerHeader.jsx';
 import Containers from './Containers.jsx';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,6 +70,7 @@ try {
 module.exports = {
     mode: production ? 'production' : 'development',
     resolve: {
+        modules: [ nodedir, path.resolve(__dirname, 'lib') ],
         alias: { 'font-awesome': path.resolve(nodedir, 'font-awesome-sass/assets/stylesheets') },
     },
     resolveLoader: {


### PR DESCRIPTION
Just tell webpack to resolve modules in lib/ instead.

This is preparation for moving the library to src/lib for consistency
with starter-kit.