### PR TITLE
spec: Drop cockpit-system dependency

### DIFF
--- a/cockpit-podman.spec.in
+++ b/cockpit-podman.spec.in
@@ -28,7 +28,6 @@ BuildRequires:  libappstream-glib
 BuildRequires:  make
 
 Requires:       cockpit-bridge >= 138
-Requires:       cockpit-shell >= 138
 Requires:       podman >= 2.0.4
 
 %description

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -11,7 +11,6 @@ Architecture: all
 Multi-Arch: foreign
 Depends: ${misc:Depends},
          cockpit-bridge (>= 138),
-         cockpit-system (>= 138),
          podman (>= 2.0.4),
 Description: Cockpit component for Podman containers
  The Cockpit Web Console enables users to administer GNU/Linux servers using a

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -580,11 +580,13 @@ class Application extends React.Component {
                     <Button onClick={this.startService}>
                         {_("Start podman")}
                     </Button>
-                    <EmptyStateSecondaryActions>
-                        <Button variant="link" onClick={this.goToServicePage}>
-                            {_("Troubleshoot")}
-                        </Button>
-                    </EmptyStateSecondaryActions>
+                    { cockpit.manifests.system &&
+                        <EmptyStateSecondaryActions>
+                            <Button variant="link" onClick={this.goToServicePage}>
+                                {_("Troubleshoot")}
+                            </Button>
+                        </EmptyStateSecondaryActions>
+                    }
                 </EmptyState>);
         }
 

--- a/src/index.html
+++ b/src/index.html
@@ -27,6 +27,7 @@ along with this package; If not, see <http://www.gnu.org/licenses/>.
     <script type="text/javascript" src="../base1/cockpit.js"></script>
     <script type="text/javascript" src="po.js"></script>
     <script type="text/javascript" src="index.js"></script>
+    <script type="text/javascript" src="../manifests.js"></script>
 </head>
 
 <body class="pf-m-redhat-font">

--- a/test/check-application
+++ b/test/check-application
@@ -1093,6 +1093,19 @@ class TestApplication(testlib.MachineCase):
         is_active_user("active")
         is_enabled_user("enabled")
         is_enabled_system("disabled")
+        b.logout()
+
+        # no Troubleshoot action without cockpit-system package
+        disable_system()
+        disable_user()
+        self.restore_file("/usr/share/cockpit/systemd/manifest.json")
+        self.machine.execute("rm /usr/share/cockpit/systemd/manifest.json")
+        self.login_and_go("/podman")
+        b.wait_visible("#app .pf-c-empty-state button.pf-m-primary")
+        self.assertFalse(b.is_present("#app .pf-c-empty-state button.pf-m-link"))
+        # starting still works
+        b.click("#app .pf-c-empty-state button.pf-m-primary")
+        b.wait_visible("#containers-containers")
 
         self.allow_restart_journal_messages()
         self.allow_authorize_journal_messages()


### PR DESCRIPTION
cockpit-system is not strictly a requirement. In "remote ssh host" mode,
the Podman UI works just fine with just cockpit-{podman,bridge}.

----

It looks a little unfamiliar, but there is not actually anything wrong with this:

![cockpit-podman-only](https://user-images.githubusercontent.com/200109/106279611-fac97a80-623c-11eb-8010-773e9f7fc3a5.png)
