### PR TITLE
Enable webpack watch progress

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "LGPL-2.1",
   "scripts": {
-    "watch": "webpack --watch",
+    "watch": "webpack --watch --progress",
     "build": "webpack",
     "eslint": "eslint --ext .jsx --ext .js src/ lib/",
     "eslint:fix": "eslint --fix --ext .jsx --ext .js src/ lib/"


### PR DESCRIPTION
Without that, `npm run watch` is entirely silent after the first build,
and does not give any feedback when a build starts, and even more
importantly, when it's done.

Cherry-picked from starter-kit commit 71a321cc28