### PR TITLE
cockpituous: Rename Fedora rawhide branch

### DIFF
--- a/cockpituous-release
+++ b/cockpituous-release
@@ -17,7 +17,7 @@ job release-srpm -V
 # Authenticate for pushing into Fedora dist-git (works in Cockpituous release container)
 cat ~/.fedora-password | kinit cockpit@FEDORAPROJECT.ORG
 # Do fedora builds for the tag, using tarball
-job release-koji master
+job release-koji main
 job release-koji f32
 job release-koji f33
 job release-bodhi F32


### PR DESCRIPTION
Fedora "master" branches were renamed to "main".