### PR TITLE
cockpituous: Add Fedora 34 koji builds

### DIFF
--- a/cockpituous-release
+++ b/cockpituous-release
@@ -20,6 +20,7 @@ cat ~/.fedora-password | kinit cockpit@FEDORAPROJECT.ORG
 job release-koji rawhide
 job release-koji f32
 job release-koji f33
+job release-koji f34
 job release-bodhi F32
 job release-bodhi F33
 


### PR DESCRIPTION
Fedora 34 branches from Rawhide today:
https://fedorapeople.org/groups/schedule/f-34/f-34-all-tasks.html

bodhi will get enabled in two weeks, so don't add that yet.