### PR TITLE
package.json: Lock @patternfly/react-styles version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "@patternfly/patternfly": "4.87.2",
     "@patternfly/react-core": "4.97.1",
+    "@patternfly/react-styles": "4.8.1",
     "@patternfly/react-table": "4.23.1",
     "docker-names": "1.1.1",
     "moment": "2.29.1",


### PR DESCRIPTION
It's part of patternfly-react, so we should update it in a controlled
fashion. Letting it auto-update freely often breaks the build.

Similar to https://github.com/cockpit-project/cockpit/commit/bbde4c01947

----

This avoids out-of-the-blue failures like [this one](https://logs.cockpit-project.org/logs/pull-1684-20210217-090606-38f52238-rhel-8-4-cockpit-project-cockpit-podman/log.html) in an image refresh.