### PR TITLE
cockpituous: bodhi for Fedora 34, drop Fedora 32

### DIFF
--- a/cockpituous-release
+++ b/cockpituous-release
@@ -18,11 +18,10 @@ job release-srpm -V
 cat ~/.fedora-password | kinit cockpit@FEDORAPROJECT.ORG
 # Do fedora builds for the tag, using tarball
 job release-koji rawhide
-job release-koji f32
 job release-koji f33
 job release-koji f34
-job release-bodhi F32
 job release-bodhi F33
+job release-bodhi F34
 
 # These are likely the first of your release targets; but run them after Fedora uploads,
 # so that failures there will fail the release early, before publishing on GitHub

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.6.0",
-    "@babel/preset-env": "^7.6.0",
+    "@babel/preset-env": "7.12.17",
     "@babel/preset-react": "^7.0.0",
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.0",


### PR DESCRIPTION
bodhi activation for Fedora 34 is today [1]. Drop Fedora 32 instead,
which is soon EOL.

[1] https://fedorapeople.org/groups/schedule/f-34/f-34-key-tasks.html