### PR TITLE
livetest: fix cloning of repo

### DIFF
--- a/.github/workflows/livetest.yml
+++ b/.github/workflows/livetest.yml
@@ -46,11 +46,28 @@ jobs:
           sudo apt update
           sudo apt install -y cockpit-system cockpit-ws podman nodejs npm sassc make
 
-      - name: Clone repository
-        uses: actions/checkout@v2
+      - uses: actions/github-script@v3
+        id: get-pr
         with:
-          # need this to also fetch tags
+          script: |
+            const request = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            }
+            core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
+            try {
+              const result = await github.pulls.get(request)
+              return result.data
+            } catch (err) {
+              core.setFailed(`Request failed with error ${err}`)
+            }
+
+      - uses: actions/checkout@v2
+        with:
+          repository: ${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}
           fetch-depth: 0
+          ref: ${{ fromJSON(steps.get-pr.outputs.result).head.ref }}
 
       - name: Compile and install the project
         run: make && sudo make install


### PR DESCRIPTION
Previously it was checking out origin/master not the PR's branch.