### PR TITLE
test: Generalize cgroupsV2() for all rhel-8-* versions

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -80,7 +80,7 @@ class TestApplication(testlib.MachineCase):
         self.has_selinux = self.machine.image not in ["debian-testing", "ubuntu-stable"]
 
     def cgroupsV2(self):
-        return self.machine.image not in ["ubuntu-stable", "rhel-8-4"]
+        return self.machine.image != 'ubuntu-stable' and not self.machine.image.startswith('rhel-8')
 
     def execute(self, system, cmd):
         if system:


### PR DESCRIPTION
It looks like RHEL newer 8.y versions won't get cgroupsv2 either, so
generalize the check.