### PR TITLE
fmf: Drop rawhide version override

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -12,10 +12,6 @@ npm install chrome-remote-interface sizzle
 
 . /etc/os-release
 export TEST_OS="${ID}-${VERSION_ID/./-}"
-# HACK: upstream does not yet know about rawhide
-if [ "$TEST_OS" = "fedora-34" ]; then
-    export TEST_OS=fedora-33
-fi
 
 export TEST_AUDIT_NO_SELINUX=1
 


### PR DESCRIPTION
Our tests don't currently have special cases for fedora. If they ever do
get them again, let's add the rawhide version right away. They will be
gated by packit tests, and we just keep forgetting about this hack.