### PR TITLE
fmf: Update crun and podman packages

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -22,6 +22,9 @@ if ! rpm -q chromium; then
     dnf install -y chromium
 fi
 
+# HACK: ensure that critical components are up to date: https://github.com/psss/tmt/issues/682
+dnf update -y podman crun
+
 # HACK: systemd kills the services after 90s
 # See https://github.com/containers/podman/issues/8751
 sed -i 's/Type=notify/Type=exec/' /usr/lib/systemd/system/podman.service


### PR DESCRIPTION
The initial installation of podman on the Fedora 33 Testing Farm
instances somehow pulls in an old version 0.15.5:
https://github.com/psss/tmt/issues/682

As a quick workaround, ensure that podman and crun are the latest
version, so that criu support is available.

---

This fixes the recent [packit failures on f33](http://artifacts.dev.testing-farm.io/33fd92a3-0d95-4bee-a51b-3faa49fa07a9/).