### PR TITLE
Move to webpack 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "compression-webpack-plugin": "^6.0.0",
     "copy-webpack-plugin": "^6.1.0",
     "css-loader": "^5.2.0",
+    "css-minimizer-webpack-plugin": "^1.3.0",
     "eslint": "^7.10.0",
     "eslint-config-standard": "^16.0.0",
     "eslint-config-standard-jsx": "^10.0.0",
@@ -37,15 +38,14 @@
     "htmlparser": "^1.7.7",
     "jed": "^1.1.1",
     "mini-css-extract-plugin": "^0.11.0",
-    "optimize-css-assets-webpack-plugin": "^5.0.3",
     "po2json": "^1.0.0-alpha",
     "sizzle": "^2.3.3",
     "stdio": "^2.1.0",
-    "string-replace-loader": "^2.3.0",
+    "string-replace-loader": "^3.0.0",
     "svgo": "^1.3.0",
-    "terser-webpack-plugin": "^4.0.0",
-    "webpack": "^4.17.1",
-    "webpack-cli": "^3.1.0"
+    "terser-webpack-plugin": "^3.0.0",
+    "webpack": "^5.31.0",
+    "webpack-cli": "^4.6.0"
   },
   "dependencies": {
     "@patternfly/patternfly": "4.96.2",

--- a/packit.yaml
+++ b/packit.yaml
@@ -5,10 +5,15 @@ upstream_package_name: cockpit-podman
 downstream_package_name: cockpit-podman
 actions:
   post-upstream-clone: make cockpit-podman.spec
-  # reduce memory consumption of webpack in sandcastle container
+  # build in development mode; production mode uses too much memory for limited
+  # sandcastle containers; also reduce memory consumption of webpack
   # https://github.com/packit/sandcastle/pull/92
   # https://medium.com/the-node-js-collection/node-js-memory-management-in-container-environments-7eb8409a74e8
-  create-archive: make NODE_OPTIONS=--max-old-space-size=500 dist-gzip
+  create-archive:
+    - make NODE_ENV=development NODE_OPTIONS=--max-old-space-size=500
+    # dummy LICENSE.txt, as terser did not run
+    - touch dist/index.js.LICENSE.txt
+    - make dist-gzip
 jobs:
   - job: tests
     trigger: pull_request

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const childProcess = require('child_process');
 const copy = require("copy-webpack-plugin");
 const extract = require("mini-css-extract-plugin");
 const TerserJSPlugin = require('terser-webpack-plugin');
-const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const CompressionPlugin = require("compression-webpack-plugin");
 const ESLintPlugin = require('eslint-webpack-plugin');
 const CockpitPoPlugin = require("./src/lib/cockpit-po-plugin");
@@ -71,7 +71,7 @@ module.exports = {
 
     optimization: {
         minimize: production,
-        minimizer: [new TerserJSPlugin({}), new OptimizeCSSAssetsPlugin({})],
+        minimizer: [new TerserJSPlugin({}), new CssMinimizerPlugin()],
     },
 
     module: {


### PR DESCRIPTION
Mostly cherry-picked from recent starter-kit PRs. 

 - [x] prerequisite commits: PR #704
 - [x] Fix scrolling to "used by" container to not crash for stopped containers (regression in f1e7c9b1518dbb): PR #705
 - [x] Get rid of react-scrollable-anchor, which is dead and does not work any more with webpack 5: PR #707 
 - [x] fix terser-built LICENSE file