### PR TITLE
Fix crash on clicking on "Used by" for stopped containers

### DIFF
--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -43,7 +43,6 @@ class Containers extends React.Component {
             checkpointInProgress: false,
             restoreInProgress: false,
             width: 0,
-            filter: "running",
         };
         this.renderRow = this.renderRow.bind(this);
         this.onWindowResize = this.onWindowResize.bind(this);
@@ -59,7 +58,6 @@ class Containers extends React.Component {
         this.handleRestoreContainer = this.handleRestoreContainer.bind(this);
         this.handleCancelRemoveError = this.handleCancelRemoveError.bind(this);
         this.handleForceRemoveContainer = this.handleForceRemoveContainer.bind(this);
-        this.handleFilterChange = this.handleFilterChange.bind(this);
 
         window.addEventListener('resize', this.onWindowResize);
     }
@@ -70,10 +68,6 @@ class Containers extends React.Component {
 
     componentWillUnmount() {
         window.removeEventListener('resize', this.onWindowResize);
-    }
-
-    handleFilterChange (value) {
-        this.setState({ filter: value });
     }
 
     deleteContainer(container, event) {
@@ -339,11 +333,11 @@ class Containers extends React.Component {
             emptyCaption = _("Loading...");
         else if (this.props.textFilter.length > 0)
             emptyCaption = _("No containers that match the current filter");
-        else if (this.state.filter == "running")
+        else if (this.props.filter == "running")
             emptyCaption = _("No running containers");
 
         if (this.props.containers !== null && this.props.pods !== null) {
-            filtered = Object.keys(this.props.containers).filter(id => !(this.state.filter == "running") || this.props.containers[id].State == "running");
+            filtered = Object.keys(this.props.containers).filter(id => !(this.props.filter == "running") || this.props.containers[id].State == "running");
 
             if (this.props.userServiceAvailable && this.props.systemServiceAvailable && this.props.ownerFilter !== "all") {
                 filtered = filtered.filter(id => {
@@ -387,7 +381,7 @@ class Containers extends React.Component {
                 const lcf = this.props.textFilter.toLowerCase();
                 if (section != "no-pod") {
                     const pod = this.props.pods[section];
-                    if ((this.state.filter == "running" && pod.Status != "Running") ||
+                    if ((this.props.filter == "running" && pod.Status != "Running") ||
                         // If nor the pod name nor any container inside the pod fit the filter, hide the whole pod
                         (!partitionedContainers[section].length && pod.Name.toLowerCase().indexOf(lcf) < 0) ||
                         ((this.props.userServiceAvailable && this.props.systemServiceAvailable && this.props.ownerFilter !== "all") &&
@@ -445,7 +439,7 @@ class Containers extends React.Component {
                         {_("Show")}
                     </ToolbarItem>
                     <ToolbarItem>
-                        <FormSelect id="containers-containers-filter" value={this.state.filter} onChange={this.handleFilterChange}>
+                        <FormSelect id="containers-containers-filter" value={this.props.filter} onChange={this.props.handleFilterChange}>
                             <FormSelectOption value='running' label={_("Only running")} />
                             <FormSelectOption value='all' label={_("All")} />
                         </FormSelect>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -49,6 +49,7 @@ class Application extends React.Component {
             userImagesLoaded: false,
             systemImagesLoaded: false,
             containers: null,
+            containersFilter: "running",
             containersStats: {},
             containersDetails: {},
             userContainersLoaded: null,
@@ -635,6 +636,7 @@ class Application extends React.Component {
                 onAddNotification={this.onAddNotification}
                 textFilter={this.state.textFilter}
                 ownerFilter={this.state.ownerFilter}
+                showAll={ () => this.setState({ containersFilter: "all" }) }
                 user={this.state.currentUser}
                 userServiceAvailable={this.state.userServiceAvailable}
                 systemServiceAvailable={this.state.systemServiceAvailable}
@@ -649,6 +651,8 @@ class Application extends React.Component {
                 pods={this.state.systemPodsLoaded && this.state.userPodsLoaded ? this.state.pods : null}
                 containersStats={this.state.containersStats}
                 containersDetails={this.state.containersDetails}
+                filter={this.state.containersFilter}
+                handleFilterChange={ value => this.setState({ containersFilter: value }) }
                 textFilter={this.state.textFilter}
                 ownerFilter={this.state.ownerFilter}
                 user={this.state.currentUser}

--- a/test/check-application
+++ b/test/check-application
@@ -1390,10 +1390,20 @@ class TestApplication(testlib.MachineCase):
         b.click(".pf-m-expanded a:contains('Console')")
         b.wait_text(".pf-m-expanded .pf-c-title", "Container is not running")
 
+        self.filter_containers("running")
+        b.wait_not_in_text("#containers-containers", "busybox-without-publish")
+
         b.click('#containers-images tbody tr:contains("busybox:latest") td.pf-c-table__toggle button')
         b.click("#containers-images tbody tr:contains('busybox:latest') a:contains('Used by')")
-        b.wait_visible("#containers-images tbody tr:contains('busybox:latest') + tr div.ct-listing-panel-body tbody tr:contains('busybox-without-publish')")
-        b.wait_visible("#containers-images tbody tr:contains('busybox:latest') + tr div.ct-listing-panel-body tbody tr:contains('busybox-with-tty')")
+        # running container, just scrolls up
+        b.mousedown("#containers-images tbody tr:contains('busybox:latest') + tr div.ct-listing-panel-body tbody tr:contains('busybox-with-tty')")
+        # FIXME: scrolling does not actually work right now
+        # but should leave "Only running" alone
+        b.wait_val("#containers-containers-filter", "running")
+        # stopped container, switches to showing all containers
+        b.mousedown("#containers-images tbody tr:contains('busybox:latest') + tr div.ct-listing-panel-body tbody tr:contains('busybox-without-publish')")
+        b.wait_val("#containers-containers-filter", "all")
+        b.wait_in_text("#containers-containers", "busybox-without-publish")
 
         b.click('#containers-images tbody tr:contains("alpine:latest") td.pf-c-table__toggle button')
         b.click("#containers-images tbody tr:contains('alpine:latest') a:contains('Used by')")


### PR DESCRIPTION
This functionality was introduced in commit b5f8df880 and broken by
f1e7c9b1518 (and was previously not tested at all). Partially revert the
latter commit and move the "container filter" state back to Application,
so taht the `<Images>` component can use it. Supply a `showAll` property
to that, as it expects it.

Add an integration test which clicks on the "used by" containers and
cover both the running and the stopped case. The former does not really
do anything right now (that's another bug), but check that the latter
switches to "all containers" view and makes the stopped container
visible.