### PR TITLE
Stop explicitly installing cockpit-ws

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ VM_DEP=$(TARFILE) packaging/debian/rules packaging/debian/control
 VM_PACKAGE=--upload `pwd`/$(TARFILE):/var/tmp/ --upload `pwd`/packaging/debian:/var/tmp/
 else
 VM_DEP=$(RPMFILE)
-VM_PACKAGE=--install cockpit-ws --install `pwd`/$(RPMFILE)
+VM_PACKAGE=--upload `pwd`/$(RPMFILE):/var/tmp/
 endif
 
 ifeq ($(TEST_SCENARIO),rawhide)

--- a/test/vm.install
+++ b/test/vm.install
@@ -48,6 +48,10 @@ if [ -d /var/tmp/debian ]; then
     if systemctl is-enabled docker.service; then
         systemctl disable docker.service
     fi
+
+# install rpms
+elif [ -e /var/tmp/*.rpm ]; then
+    rpm -i --verbose /var/tmp/*.rpm
 fi
 
 systemctl enable cockpit.socket


### PR DESCRIPTION
It is already present on all our test images, and trying to
install/upgrade it again touches the network. That is often unreliable
and makes tests less reproducible.

For cockpit-podman.rpm itself, upload that and install it with rpm, so
that dnf does not try and update the package metadata. This is the same
approach as with the debs.

-----

Fixes annoying errors like [this one](https://logs.cockpit-project.org/logs/pull-712-20210422-022404-fe2ac86a-rhel-9-0/log.html). The same happened to cockpit-machines today, which I fixed in https://github.com/cockpit-project/cockpit-machines/pull/120 . This is exactly the same fix minus the `--no-network`, as we need networking for the container pulls.