### PR TITLE
fmf: Install/update critical dependencies earlier

### DIFF
--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -2,5 +2,10 @@ summary:
     Run all tests
 discover:
     how: fmf
+# HACK: ensure that critical components are up to date
+# https://github.com/psss/tmt/issues/682 and https://bugzilla.redhat.com/show_bug.cgi?id=1946975
+prepare:
+    how: shell
+    script: dnf install -y podman crun
 execute:
     how: tmt

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -22,9 +22,6 @@ if ! rpm -q chromium; then
     dnf install -y chromium
 fi
 
-# HACK: ensure that critical components are up to date: https://github.com/psss/tmt/issues/682
-dnf update -y podman crun
-
 # HACK: systemd kills the services after 90s
 # See https://github.com/containers/podman/issues/8751
 sed -i 's/Type=notify/Type=exec/' /usr/lib/systemd/system/podman.service


### PR DESCRIPTION
Updating them in the test script is too late, as now the "prepare" step
runs into a file conflict: https://bugzilla.redhat.com/show_bug.cgi?id=1900000

Introduce an explicit prepare: step which installs current podman/crun
before the test/browser/main.fmf's "require:" preparation. This avoids
the weird dependency resolution in dnf and is also closer to the planned
fix/workaround in tmt to update the testbed as a first step.