### PR TITLE
test: Drop workaround for wrong Type= in podman.services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,10 +157,6 @@ $(VM_IMAGE): $(VM_DEP) bots
 	rm -f $(VM_IMAGE) $(VM_IMAGE).qcow2
 	bots/image-customize -v $(VM_PACKAGE) -s $(CURDIR)/test/vm.install $(TEST_OS)
 	$(RAWHIDE)
-	# HACK: systemd kills the services after 90s
-	# See https://github.com/containers/podman/issues/8751
-	bots/image-customize -r "sed -i 's/Type=notify/Type=exec/' /usr/lib/systemd/system/podman.service" -r "sed -i 's/Type=notify/Type=exec/' /usr/lib/systemd/user/podman.service" $(TEST_OS)
-
 
 # convenience target for the above
 vm: $(VM_IMAGE)

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -25,11 +25,6 @@ fi
 # HACK: ensure that critical components are up to date: https://github.com/psss/tmt/issues/682
 dnf update -y podman crun
 
-# HACK: systemd kills the services after 90s
-# See https://github.com/containers/podman/issues/8751
-sed -i 's/Type=notify/Type=exec/' /usr/lib/systemd/system/podman.service
-sed -i 's/Type=notify/Type=exec/' /usr/lib/systemd/user/podman.service
-
 # create user account for logging in
 if ! id admin 2>/dev/null; then
     useradd -c Administrator -G wheel admin


### PR DESCRIPTION
All supported operating systems have this fixed now.