### PR TITLE
Bump cockpit test API and library to 243

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,14 +183,14 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 239; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 243; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 
 # checkout Cockpit's PF/React/build library; again this has no API stability guarantee, so check out a stable tag
 $(LIB_TEST):
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 239; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 243; \
 	    git checkout --force FETCH_HEAD -- pkg/lib; \
 	    git reset -- pkg/lib'
 	mv pkg/lib src/ && rmdir -p pkg

--- a/test/check-application
+++ b/test/check-application
@@ -129,9 +129,9 @@ class TestApplication(testlib.MachineCase):
                                    cmd=container["command"], state=container["state"], pod=podName)
         else:
             if self.browser.val("#containers-containers-filter") == "all":
-                self.browser.wait_in_text("#table-" + podName + " .ct-table-empty", "No containers in this pod")
+                self.browser.wait_in_text("#table-" + podName + " .pf-c-empty-state", "No containers in this pod")
             else:
-                self.browser.wait_in_text("#table-" + podName + " .ct-table-empty", "No running containers in this pod")
+                self.browser.wait_in_text("#table-" + podName + " .pf-c-empty-state", "No running containers in this pod")
 
     def performPodAction(self, podName, podOwner, action):
         b = self.browser
@@ -147,7 +147,7 @@ class TestApplication(testlib.MachineCase):
 
         self.login()
 
-        self.browser.wait_in_text("#containers-containers .ct-table-empty", "No running containers")
+        self.browser.wait_in_text("#containers-containers .pf-c-empty-state", "No running containers")
 
         # Run a pods as system
         self.machine.execute("podman pod create --infra=false --name pod-1")
@@ -1413,17 +1413,17 @@ class TestApplication(testlib.MachineCase):
 
         b.click('#containers-images tbody tr:contains("alpine:latest") td.pf-c-table__toggle button')
         b.click("#containers-images tbody tr:contains('alpine:latest') a:contains('Used by')")
-        b.wait_visible("#containers-images tbody tr:contains('alpine:latest') + tr .pf-c-empty-state:contains('No containers are using this image')")
+        b.wait_in_text("#containers-images tbody tr:contains('alpine:latest') + tr .pf-c-empty-state", 'No containers are using this image')
 
         b.set_input_text('#containers-filter', 'foobar')
-        b.wait_visible('#containers-containers tbody tr td:contains("No containers that match the current filter")')
-        b.wait_visible('#containers-images tbody tr td:contains("No images that match the current filter")')
+        b.wait_in_text('#containers-containers .pf-c-empty-state', 'No containers that match the current filter')
+        b.wait_in_text('#containers-images .pf-c-empty-state', 'No images that match the current filter')
         b.set_input_text('#containers-filter', '')
         self.execute(auth, "podman rmi -af")
-        b.wait_visible('#containers-containers tbody tr td:contains("No containers")')
+        b.wait_in_text('#containers-containers .pf-c-empty-state', 'No containers')
         b.set_val("#containers-containers-filter", "running")
-        b.wait_visible('#containers-containers tbody tr td:contains("No running containers")')
-        b.wait_visible('#containers-images tbody tr td:contains("No images")')
+        b.wait_in_text('#containers-containers .pf-c-empty-state', 'No running containers')
+        b.wait_in_text('#containers-images .pf-c-empty-state', 'No images')
 
     def check_content(self, type, present, not_present):
         b = self.browser

--- a/test/vm.install
+++ b/test/vm.install
@@ -49,6 +49,9 @@ if [ -d /var/tmp/debian ]; then
         systemctl disable docker.service
     fi
 
+    # tuned is installed for testing cockpit; but it causes funny bugs, and we are not testing this here
+    systemctl disable tuned
+
 # install rpms
 elif [ -e /var/tmp/*.rpm ]; then
     rpm -i --verbose /var/tmp/*.rpm


### PR DESCRIPTION
This fixes "DeprecationWarning: Compilation.assets will be frozen in future" as this now uses the updated cockpit-po-plugin.

I visually tested this build, and it looks ok to me (updated PF CSS and such).

I also added a more robust workaround for https://github.com/cockpit-project/bots/issues/1956 (which will solve this naughty).