### PR TITLE
Update terser-webpack-plugin

### DIFF
--- a/cockpit-podman.spec.in
+++ b/cockpit-podman.spec.in
@@ -45,7 +45,7 @@ appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/*
 
 %files
 %doc README.md
-%license LICENSE dist/index.js.LICENSE.txt
+%license LICENSE dist/index.js.LICENSE.txt.gz
 %{_datadir}/cockpit/*
 %{_datadir}/metainfo/*
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "stdio": "^2.1.0",
     "string-replace-loader": "^3.0.0",
     "svgo": "^1.3.0",
-    "terser-webpack-plugin": "^3.0.0",
+    "terser-webpack-plugin": "^5.1.3",
     "webpack": "^5.31.0",
     "webpack-cli": "^4.6.0"
   },

--- a/packit.yaml
+++ b/packit.yaml
@@ -12,7 +12,7 @@ actions:
   create-archive:
     - make NODE_ENV=development NODE_OPTIONS=--max-old-space-size=500
     # dummy LICENSE.txt, as terser did not run
-    - touch dist/index.js.LICENSE.txt
+    - touch dist/index.js.LICENSE.txt.gz
     - make dist-gzip
 jobs:
   - job: tests

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,7 +71,18 @@ module.exports = {
 
     optimization: {
         minimize: production,
-        minimizer: [new TerserJSPlugin({}), new CssMinimizerPlugin()],
+        minimizer: [
+            new TerserJSPlugin({
+                extractComments: {
+                    condition: true,
+                    filename: `[file].LICENSE.txt?query=[query]&filebase=[base]`,
+                    banner(licenseFile) {
+                        return `License information can be found in ${licenseFile}`;
+                    },
+                },
+            }),
+            new CssMinimizerPlugin()
+        ],
     },
 
     module: {


### PR DESCRIPTION
Commit e4a07a moved us back to terser 3.
However when tested against the latest available version from npm:
* dist was not much bigger 
  Master: index.js.gz (283 KiB)
  With new terser: index.js.gz (287 KiB)

* was able to extract LICENSE information with some config options

Unfortunately I don't seem to have full control on the LICENSE file
generated name, there is always gz suffix.

In addition the previous two major releases had a lot of bug fixes, so let's
follow their updates.
https://github.com/webpack-contrib/terser-webpack-plugin/releases