### PR TITLE
tests: wait for image loading to finish before moving forward with downloading new images

### DIFF
--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -247,7 +247,7 @@ class Images extends React.Component {
         }
 
         return (
-            <Card id="containers-images" key="images" className="containers-images">
+            <Card id="containers-images" key="images" className="containers-images" data-updating={this.props.updatingImages}>
                 <CardHeader>
                     <CardTitle><Text component={TextVariants.h2}>{_("Images")}</Text></CardTitle>
                     <CardActions>{getNewImageAction}</CardActions>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -203,6 +203,7 @@ class Application extends React.Component {
     }
 
     updateImagesAfterEvent(system) {
+        this.setState({ updatingImages: true });
         client.getImages(system)
                 .then(reply => {
                     this.setState(prevState => {
@@ -219,12 +220,14 @@ class Application extends React.Component {
                         });
 
                         return {
+                            updatingImages: false,
                             images: copyImages,
                             [system ? "systemImagesLoaded" : "userImagesLoaded"]: true
                         };
                     });
                 })
                 .catch(ex => {
+                    this.setState({ updatingImages: false });
                     console.warn("Failed to do Update Images:", JSON.stringify(ex));
                 });
     }
@@ -642,6 +645,7 @@ class Application extends React.Component {
                 systemServiceAvailable={this.state.systemServiceAvailable}
                 registries={this.state.registries}
                 selinuxAvailable={this.state.selinuxAvailable}
+                updatingImages={this.state.updatingImages}
             />;
         const containerList =
             <Containers

--- a/test/check-application
+++ b/test/check-application
@@ -663,6 +663,7 @@ class TestApplication(testlib.MachineCase):
 
             def openDialog(self):
                 # Open get new image modal
+                b.wait_visible('#containers-images[data-updating=false]')
                 b.click("button:contains(Get new image)")
                 b.wait_visible('div.pf-c-modal-box header:contains("Search for an image")')
                 b.wait_visible("div.pf-c-modal-box footer button:contains(Download):disabled")


### PR DESCRIPTION
testDownloadImage was previously quite flaky as when multiple images were
pulled one after another the image list update events would overlap
resulting in a non-deterministic UI updating.