### PR TITLE
test: Don't check if user or system service failed to start

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -110,7 +110,6 @@ class TestApplication(testlib.MachineCase):
                 b.wait_not_present("#overview div.pf-c-alert")
             except testlib.Error:
                 if system:
-                    b.wait_in_text("#overview div.pf-c-alert .pf-c-alert__title", "User Podman service is also available")
                     b.click("#overview div.pf-c-alert .pf-c-alert__action > button:contains(Start)")
                     b.wait_not_present("#overview div.pf-c-alert")
                 else:


### PR DESCRIPTION
It seems that this can hit system podman as well. Let's see how this behaves.