### PR TITLE
Convert the "Download new image" button to a kebab menu

### DIFF
--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -8,7 +8,6 @@ import {
     KebabToggle,
     Text, TextVariants
 } from '@patternfly/react-core';
-import { PlusIcon } from '@patternfly/react-icons';
 
 import cockpit from 'cockpit';
 import { ListingTable } from "cockpit-components-table.jsx";
@@ -57,6 +56,10 @@ class Images extends React.Component {
                     this.setState({ imageDownloadInProgress: undefined });
                     this.props.onAddNotification({ type: 'danger', error, errorDetail });
                 });
+    }
+
+    onOpenNewImagesDialog = () => {
+        this.setState({ showSearchImageModal: true });
     }
 
     getUsedByText(image) {
@@ -148,14 +151,6 @@ class Images extends React.Component {
             emptyCaption = "Loading...";
         else if (this.props.textFilter.length > 0)
             emptyCaption = _("No images that match the current filter");
-        const getNewImageAction = [
-            <Button variant="secondary" key="get-new-image-action"
-                    onClick={() => this.setState({ showSearchImageModal: true })}
-                    className="pull-right"
-                    icon={<PlusIcon />}>
-                {_("Get new image")}
-            </Button>
-        ];
 
         const intermediateOpened = this.state.intermediateOpened;
 
@@ -254,7 +249,7 @@ class Images extends React.Component {
                             {imageTitleStats}
                         </Flex>
                     </CardTitle>
-                    <CardActions>{getNewImageAction}</CardActions>
+                    <CardActions><ImageOverActions handleDownloadNewImage={this.onOpenNewImagesDialog} /></CardActions>
                 </CardHeader>
                 <CardBody>
                     {filtered.length
@@ -280,6 +275,24 @@ class Images extends React.Component {
         );
     }
 }
+
+const ImageOverActions = ({ handleDownloadNewImage }) => {
+    const [isActionsKebabOpen, setIsActionsKebabOpen] = useState(false);
+
+    return (
+        <Dropdown toggle={<KebabToggle onToggle={() => setIsActionsKebabOpen(!isActionsKebabOpen)} id="image-actions-dropdown" />}
+                  isOpen={isActionsKebabOpen}
+                  isPlain
+                  position="right"
+                  dropdownItems={[
+                      <DropdownItem key="download-new-image"
+                                    component="button"
+                                    onClick={handleDownloadNewImage}>
+                          {_("Download new image")}
+                      </DropdownItem>,
+                  ]} />
+    );
+};
 
 const ImageActions = ({ image, onAddNotification, selinuxAvailable }) => {
     const [showRunImageModal, setShowImageRunModal] = useState(false);

--- a/test/check-application
+++ b/test/check-application
@@ -242,7 +242,9 @@ class TestApplication(testlib.MachineCase):
         b.wait_not_present("#containers-containers-owner")
 
         # Also user selection in image download should not be visible
-        b.click("button:contains(Get new image)")
+        b.click("#image-actions-dropdown")
+        b.click("button:contains(Download new image)")
+
         b.wait_visible('div.pf-c-modal-box header:contains("Search for an image")')
         b.wait_visible("div.pf-c-modal-box footer button:contains(Download):disabled")
         b.wait_not_present("#as-user")
@@ -276,7 +278,8 @@ class TestApplication(testlib.MachineCase):
         b.wait_visible("#containers-containers-owner")
 
         # Also user selection in image download should be visible
-        b.click("button:contains(Get new image)")
+        b.click("#image-actions-dropdown")
+        b.click("button:contains(Download new image)")
         b.wait_visible('div.pf-c-modal-box header:contains("Search for an image")')
         b.wait_visible("div.pf-c-modal-box footer button:contains(Download):disabled")
         b.wait_visible("#as-user")
@@ -668,7 +671,8 @@ class TestApplication(testlib.MachineCase):
 
             def openDialog(self):
                 # Open get new image modal
-                b.click("button:contains(Get new image)")
+                b.click("#image-actions-dropdown")
+                b.click("button:contains(Download new image)")
                 b.wait_visible('div.pf-c-modal-box header:contains("Search for an image")')
                 b.wait_visible("div.pf-c-modal-box footer button:contains(Download):disabled")
 
@@ -753,7 +757,8 @@ class TestApplication(testlib.MachineCase):
         self.login()
 
         # Test registries
-        b.click("button:contains(Get new image)")
+        b.click("#image-actions-dropdown")
+        b.click("button:contains(Download new image)")
         b.wait_visible('div.pf-c-modal-box header:contains("Search for an image")')
         # HACK: Sometimes the value is not shown fully. FIXME
         b.set_input_text("#search-image-dialog-name", "my-busybox", value_check=False)


### PR DESCRIPTION
The images group menu is now a kebab menu to accommodate space for "Prun
unused images" in the future.