### PR TITLE
Redesign create container modal

### DIFF
--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -233,7 +233,7 @@ export class ImageRunModal extends React.Component {
             publish: [],
             image: props.image,
             memory: 512,
-            cpuShares: "",
+            cpuShares: 1024,
             memoryConfigure: false,
             cpuSharesConfigure: false,
             memoryUnit: 'MiB',
@@ -262,7 +262,7 @@ export class ImageRunModal extends React.Component {
             resourceLimit.memory = { limit: memorySize };
             createConfig.resource_limits = resourceLimit;
         }
-        if (this.state.cpuSharesConfigure && this.state.cpuShares !== "") {
+        if (this.state.cpuSharesConfigure && this.state.cpuShares !== 0) {
             resourceLimit.cpu = { shares: this.state.cpuShares };
             createConfig.resource_limits = resourceLimit;
         }
@@ -417,7 +417,7 @@ export class ImageRunModal extends React.Component {
                                         min={2}
                                         max={262144}
                                         isReadOnly={!this.state.cpuSharesConfigure}
-                                        onChange={value => this.onValueChanged('cpuShares', value === "" ? "" : parseInt(value))} />
+                                        onChange={value => this.onValueChanged('cpuShares', parseInt(value))} />
                                 </InputGroup>
                             </FormGroup>}
 

--- a/src/ImageRunModal.scss
+++ b/src/ImageRunModal.scss
@@ -1,0 +1,17 @@
+@import '@patternfly/patternfly/layouts/Grid/grid.css';
+
+// Limit the max-width more the override in podman.scss which is 40%, this is a
+// temporary workaround until the "Integration" tab has been redesigned to no
+// longer require a 40% max-width.
+.ct-input-group-spacer-sm.pf-c-input-group.modal-run-limiter {
+
+  // Avoid inputs taking up more space then required.
+  > input[type=number].pf-c-form-control:not(.pf-c-select__toggle-typeahead) {
+     max-width: 6rem;
+  }
+
+  // Avoid the memory dropdown to take more space then required.
+  > select.pf-c-form-control:not(.pf-c-select__toggle-typeahead) {
+     max-width: 5rem;
+  }
+}

--- a/src/podman.scss
+++ b/src/podman.scss
@@ -92,10 +92,6 @@
     }
 }
 
-input.pf-c-form-control[type=number] {
-  max-width: 20%;
-}
-
 .invisible {
   visibility: hidden;
 }

--- a/test/check-application
+++ b/test/check-application
@@ -1197,7 +1197,7 @@ class TestApplication(testlib.MachineCase):
         if auth:
             b.set_checked("#run-image-dialog-cpu-priority-checkbox", True)
             b.wait_visible("#run-image-dialog-cpu-priority-checkbox:checked")
-            b.wait_visible('#run-image-dialog-cpu-priority input[value=""]')
+            b.wait_visible('#run-image-dialog-cpu-priority input[value="1024"]')
             b.set_input_text("#run-image-dialog-cpu-priority input[type=number]", "512")
         else:
             b.wait_not_present("#run-image-dialog-cpu-priority-checkbox")

--- a/test/check-application
+++ b/test/check-application
@@ -1208,6 +1208,9 @@ class TestApplication(testlib.MachineCase):
         # Set up command line
         b.set_input_text('#run-image-dialog-command', "sh -c 'for i in $(seq 20); do sleep 1; echo $i; done; sleep infinity'")
 
+        # Switch to Integration tab
+        b.click("#pf-tab-1-create-image-dialog-tab-integration")
+
         # Configure published ports
         b.set_input_text('.publish-port-form[data-key="0"] input[aria-label="Host port (optional)"]', '6000')
         b.set_input_text('.publish-port-form[data-key="0"] input[aria-label="Container port"]', '5000')
@@ -1448,7 +1451,7 @@ class TestApplication(testlib.MachineCase):
         b.set_input_text("#run-image-dialog-name", container_name)
 
         # Uncheck start container after creation
-        b.click("#start-after-creation")
+        b.click("#run-image-dialog-start-after-creation")
         b.click('.pf-c-modal-box__footer button:contains("Create")')
         b.wait_not_present("div.pf-c-modal-box")
 


### PR DESCRIPTION
First step of converting the create container modal to the new re-design, converting the form into two tabs, details and integration. The source/image/tag fields have been redesign fields have been left out for now

Some minor tweaks are applied to set the default value of CPU shares, tweak width of input fields (so they don't take up the full width).

@garrett  we now show as if the default memory limit is 512 MiB, while the default is to take up all available memory.
@garrett you mentioned the "Start after creation" checkbox has no label, how can we add a label without duplicating text?

## Details

@KKoukiou is there an issue way to adjust the name label to take up less width so it aligns more with the [design](https://github.com/cockpit-project/cockpit/discussions/16059).

![image](https://user-images.githubusercontent.com/67428/132663099-ef1844d6-d713-497c-9f5d-dde6be5a9740.png)

## Integration
![image](https://user-images.githubusercontent.com/67428/132663635-27f990e9-eb17-4047-b578-d0f100f53e16.png)
