### PR TITLE
.gitignore: add ./bots/vm-run temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ test/common/
 test/images/
 *.pot
 POTFILES*
-tmp/weblate-repo
+tmp/


### PR DESCRIPTION
Ignore the temporary qcow2 image from vm-run.