### PR TITLE
Build node cache on release, move to xz release tarballs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *~
 *.retry
-*.tar.gz
+*.tar.xz
 *.rpm
 node_modules/
 dist/

--- a/Makefile
+++ b/Makefile
@@ -105,13 +105,11 @@ dist-gzip: $(TARFILE)
 # node_modules/ can be reconstructed if necessary)
 $(TARFILE): export NODE_ENV=production
 $(TARFILE): $(WEBPACK_TEST) $(RPM_NAME).spec
-	mv node_modules node_modules.release
 	touch -r package.json $(NODE_MODULES_TEST)
 	touch dist/*
 	tar czf $(TARFILE) --transform 's,^,cockpit-$(PACKAGE_NAME)/,' \
-		--exclude $(RPM_NAME).spec.in \
+		--exclude $(RPM_NAME).spec.in --exclude node_modules \
 		$$(git ls-files) $(LIB_TEST) src/lib/patternfly/*.scss package-lock.json $(RPM_NAME).spec dist/
-	mv node_modules.release node_modules
 
 srpm: $(TARFILE) $(RPM_NAME).spec
 	rpmbuild -bs \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ifeq ($(TEST_OS),)
 TEST_OS = fedora-34
 endif
 export TEST_OS
-TARFILE=cockpit-$(PACKAGE_NAME)-$(VERSION).tar.gz
+TARFILE=cockpit-$(PACKAGE_NAME)-$(VERSION).tar.xz
 NODE_CACHE=cockpit-$(PACKAGE_NAME)-node-$(VERSION).tar.xz
 RPMFILE=$(shell rpmspec -D"VERSION $(VERSION)" -q `ls cockpit-podman.spec.in cockpit-podman.spec 2>/dev/null | head -n1`).rpm
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
@@ -97,7 +97,7 @@ devel-install: $(WEBPACK_TEST)
 	mkdir -p ~/.local/share/cockpit
 	ln -s `pwd`/dist ~/.local/share/cockpit/$(PACKAGE_NAME)
 
-dist-gzip: $(TARFILE)
+dist: $(TARFILE)
 	@ls -1 $(TARFILE)
 
 # when building a distribution tarball, call webpack with a 'production' environment
@@ -108,7 +108,7 @@ $(TARFILE): export NODE_ENV=production
 $(TARFILE): $(WEBPACK_TEST) $(RPM_NAME).spec
 	touch -r package.json $(NODE_MODULES_TEST)
 	touch dist/*
-	tar czf $(TARFILE) --transform 's,^,cockpit-$(PACKAGE_NAME)/,' \
+	tar --xz -cf $(TARFILE) --transform 's,^,cockpit-$(PACKAGE_NAME)/,' \
 		--exclude $(RPM_NAME).spec.in --exclude node_modules \
 		$$(git ls-files) $(LIB_TEST) src/lib/ package-lock.json $(RPM_NAME).spec dist/
 
@@ -206,4 +206,4 @@ $(NODE_MODULES_TEST): package.json
 	env -u NODE_ENV npm install
 	env -u NODE_ENV npm prune
 
-.PHONY: all clean install devel-install dist-gzip node-cache srpm rpm check vm update-po
+.PHONY: all clean install devel-install dist node-cache srpm rpm check vm update-po

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ $(TARFILE): $(WEBPACK_TEST) $(RPM_NAME).spec
 	touch dist/*
 	tar czf $(TARFILE) --transform 's,^,cockpit-$(PACKAGE_NAME)/,' \
 		--exclude $(RPM_NAME).spec.in --exclude node_modules \
-		$$(git ls-files) $(LIB_TEST) src/lib/patternfly/*.scss package-lock.json $(RPM_NAME).spec dist/
+		$$(git ls-files) $(LIB_TEST) src/lib/ package-lock.json $(RPM_NAME).spec dist/
 
 srpm: $(TARFILE) $(RPM_NAME).spec
 	rpmbuild -bs \

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ TEST_OS = fedora-34
 endif
 export TEST_OS
 TARFILE=cockpit-$(PACKAGE_NAME)-$(VERSION).tar.gz
+NODE_CACHE=cockpit-$(PACKAGE_NAME)-node-$(VERSION).tar.xz
 RPMFILE=$(shell rpmspec -D"VERSION $(VERSION)" -q `ls cockpit-podman.spec.in cockpit-podman.spec 2>/dev/null | head -n1`).rpm
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check if/when npm install ran
@@ -111,6 +112,11 @@ $(TARFILE): $(WEBPACK_TEST) $(RPM_NAME).spec
 		--exclude $(RPM_NAME).spec.in --exclude node_modules \
 		$$(git ls-files) $(LIB_TEST) src/lib/ package-lock.json $(RPM_NAME).spec dist/
 
+$(NODE_CACHE): $(NODE_MODULES_TEST)
+	tar --xz -cf $@ node_modules
+
+node-cache: $(NODE_CACHE)
+
 srpm: $(TARFILE) $(RPM_NAME).spec
 	rpmbuild -bs \
 	  --define "_sourcedir `pwd`" \
@@ -200,4 +206,4 @@ $(NODE_MODULES_TEST): package.json
 	env -u NODE_ENV npm install
 	env -u NODE_ENV npm prune
 
-.PHONY: all clean install devel-install dist-gzip srpm rpm check vm update-po
+.PHONY: all clean install devel-install dist-gzip node-cache srpm rpm check vm update-po

--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,10 @@ download-po: $(WEBLATE_REPO)
 	sed -e 's/%{VERSION}/$(VERSION)/g' $< > $@
 
 $(WEBPACK_TEST): $(NODE_MODULES_TEST) $(LIB_TEST) $(shell find src/ -type f) package.json webpack.config.js
-	NODE_ENV=$(NODE_ENV) npm run build
+	NODE_ENV=$(NODE_ENV) node_modules/.bin/webpack
 
 watch:
-	NODE_ENV=$(NODE_ENV) npm run watch
+	NODE_ENV=$(NODE_ENV) node_modules/.bin/webpack --watch
 
 clean:
 	rm -rf dist/

--- a/cockpit-podman.spec.in
+++ b/cockpit-podman.spec.in
@@ -22,7 +22,7 @@ Summary:        Cockpit component for Podman containers
 License:        LGPLv2+
 URL:            https://github.com/cockpit-project/cockpit-podman
 
-Source0:        https://github.com/cockpit-project/cockpit-podman/releases/download/%{version}/cockpit-podman-%{version}.tar.gz
+Source0:        https://github.com/cockpit-project/cockpit-podman/releases/download/%{version}/cockpit-podman-%{version}.tar.xz
 BuildArch:      noarch
 BuildRequires:  libappstream-glib
 BuildRequires:  make

--- a/packit.yaml
+++ b/packit.yaml
@@ -13,7 +13,7 @@ actions:
     - make NODE_ENV=development NODE_OPTIONS=--max-old-space-size=500
     # dummy LICENSE.txt, as terser did not run
     - touch dist/index.js.LICENSE.txt.gz
-    - make dist-gzip
+    - make dist
 jobs:
   - job: tests
     trigger: pull_request

--- a/test/vm.install
+++ b/test/vm.install
@@ -21,10 +21,10 @@ if [ -d /var/tmp/debian ]; then
 
     # build source package
     cd /var/tmp
-    TAR=$(ls cockpit-podman-*.tar.gz)
+    TAR=$(ls cockpit-podman-*.tar.xz)
     VERSION="${TAR#cockpit-podman-}"
-    VERSION="${VERSION%.tar.gz}"
-    ln -s $TAR cockpit-podman_${VERSION}.orig.tar.gz
+    VERSION="${VERSION%.tar.xz}"
+    ln -s $TAR cockpit-podman_${VERSION}.orig.tar.xz
     tar xf "$TAR"
     cd cockpit-podman
     cp -r ../debian .


### PR DESCRIPTION
Ported most commits from https://github.com/cockpit-project/starter-kit/pull/488 , except for the one that actually rebuilds the webpack during RPM. We don't currently have pressure to do this for existing projects, and with the commits from these PRs (and thus having node cache tarballs available for releases), we could enable this quickly if/when needed.