### PR TITLE
Maintenance updates, starter-kit backports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ test/common:
 # checkout Cockpit's PF/React/build library; again this has no API stability guarantee, so check out a stable tag
 $(LIB_TEST):
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 248; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 253; \
 	    git checkout --force FETCH_HEAD -- pkg/lib; \
 	    git reset -- pkg/lib'
 	mv pkg/lib src/ && rmdir -p pkg

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ $(TARFILE): $(WEBPACK_TEST) $(RPM_NAME).spec
 	touch dist/*
 	tar --xz -cf $(TARFILE) --transform 's,^,cockpit-$(PACKAGE_NAME)/,' \
 		--exclude $(RPM_NAME).spec.in --exclude node_modules \
-		$$(git ls-files) $(LIB_TEST) src/lib/ package-lock.json $(RPM_NAME).spec dist/
+		$$(git ls-files) src/lib/ package-lock.json $(RPM_NAME).spec dist/
 
 $(NODE_CACHE): $(NODE_MODULES_TEST)
 	tar --xz -cf $@ node_modules

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 5a51e051af99a75f016bde33067904049beddf74; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 253; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 

--- a/cockpit-podman.spec.in
+++ b/cockpit-podman.spec.in
@@ -22,7 +22,7 @@ Summary:        Cockpit component for Podman containers
 License:        LGPLv2+
 URL:            https://github.com/cockpit-project/cockpit-podman
 
-Source0:        https://github.com/cockpit-project/cockpit-podman/releases/download/%{version}/cockpit-podman-%{version}.tar.xz
+Source0:        https://github.com/cockpit-project/%{name}/releases/download/%{version}/%{name}-%{version}.tar.xz
 BuildArch:      noarch
 BuildRequires:  libappstream-glib
 BuildRequires:  make
@@ -34,7 +34,7 @@ Requires:       podman >= 2.0.4
 The Cockpit user interface for Podman containers.
 
 %prep
-%setup -q -n cockpit-podman
+%setup -q -n %{name}
 
 %build
 # Nothing to build


### PR DESCRIPTION
In particular for the [hardlink in release tarballs](https://github.com/cockpit-project/cockpit-machines/issues/379)