### PR TITLE
eslint: Enable no-var rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
                 "ignoredNodes": [ "JSXAttribute" ]
             }],
         "newline-per-chained-call": ["error", { "ignoreChainWithDepth": 2 }],
+        "no-var": "error",
         "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
         "prefer-promise-reject-errors": ["error", { "allowEmptyReject": true }],
         "react/jsx-indent": ["error", 4],


### PR DESCRIPTION
`var` has broken/unexpected scoping in JavaScript, and can lead to
subtle errors. It's preferable and safer to use `const` whenever
possible, and `let` where necessary.

There are no usages of `var` in our code nor the imported parts of
cockpit's pkg/lib right now, so just enable the rule to ensure that it
stays that way.

Cherry-picked from starter-kit commit 49a3d58e82.