### PR TITLE
packaging: Move Debian watch file to xz compressed tarballs

### DIFF
--- a/packaging/debian/watch
+++ b/packaging/debian/watch
@@ -1,2 +1,2 @@
 version=4
-https://github.com/cockpit-project/cockpit-podman/releases/ .*/cockpit-podman-([\d\.]+)\.tar\.gz
+https://github.com/cockpit-project/cockpit-podman/releases/ .*/cockpit-podman-([\d\.]+)\.tar\.xz


### PR DESCRIPTION
This was forgotten in commit 0225c84a8661.

---

Now it works again:
```
❱❱❱ uscan --report
uscan: Newest version of cockpit-podman on remote site is 35, local version is 34
uscan:  => Newer package available from:
        => https://github.com/cockpit-project/cockpit-podman/releases/download/35/cockpit-podman-35.tar.xz
```