### PR TITLE
Upgrade React to 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "date-fns": "2.25.0",
     "docker-names": "1.1.1",
     "prop-types": "15.7.2",
-    "react": "16.14.0",
-    "react-dom": "16.14.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "throttle-debounce": "2.3.0",
     "xterm": "4.14.1"
   }


### PR DESCRIPTION
For the redesign we want to use a footer with a button in a <Select>
with React 16 it's not possible to stop event propagation to not close
the footer when menuAppendTo is specified.

https://github.com/patternfly/patternfly-react/issues/6390