### PR TITLE
FMF/packit test improvements (backported from starter-kit), fix tests for firefox

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -20,3 +20,4 @@ jobs:
     metadata:
       targets:
       - fedora-all
+      - centos-stream-8

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -12,15 +12,12 @@ LOGS="$(pwd)/logs"
 mkdir -p "$LOGS"
 chmod a+w "$LOGS"
 
-# install browser; on RHEL, use chromium from epel
-# HACK: chromium-headless ought to be enough, but version 88 has a crash: https://bugs.chromium.org/p/chromium/issues/detail?id=1170634
-if ! rpm -q chromium; then
-    if grep -q 'ID=.*rhel' /etc/os-release; then
-        dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-        dnf config-manager --enable epel
-    fi
-    dnf install -y chromium
-fi
+# install firefox (available everywhere in Fedora and RHEL); install the package to pull in all the dependencies
+# we don't need the H.264 codec, and it is sometimes not available (rhbz#2005760)
+dnf install --disablerepo=fedora-cisco-openh264 -y firefox
+# install nightly for Chrome DevTools Protocol support
+curl --location 'https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US' | tar -C /usr/local/lib/ -xj
+ln -s /usr/local/lib/firefox/firefox /usr/local/bin/
 
 # HACK: ensure that critical components are up to date: https://github.com/psss/tmt/issues/682
 dnf update -y podman crun
@@ -66,7 +63,7 @@ loginctl disable-linger $(id -u admin)
 systemctl enable --now cockpit.socket podman.socket
 
 # Run tests as unprivileged user
-su - -c "env SOURCE=$SOURCE LOGS=$LOGS $TESTS/run-test.sh" runtest
+su - -c "env TEST_BROWSER=firefox SOURCE=$SOURCE LOGS=$LOGS $TESTS/run-test.sh" runtest
 
 RC=$(cat $LOGS/exitcode)
 exit ${RC:-1}

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -5,7 +5,7 @@ require:
   - cockpit-ws
   - cockpit-system
   - bzip2
-  - git
+  - git-core
   - libvirt-python3
   - make
   - npm

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -4,6 +4,7 @@ require:
   - cockpit-podman
   - cockpit-ws
   - cockpit-system
+  - bzip2
   - git
   - libvirt-python3
   - make

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -24,6 +24,10 @@ mv .git dot-git
 export TEST_OS="${ID}-${VERSION_ID/./-}"
 export TEST_AUDIT_NO_SELINUX=1
 
+if [ "$TEST_OS" = "centos-8" ]; then
+    TEST_OS=centos-8-stream
+fi
+
 EXCLUDES=""
 
 RC=0

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -4,15 +4,24 @@ set -eux
 # tests need cockpit's bots/ libraries and test infrastructure
 cd $SOURCE
 git init
+rm -f bots  # common local case: existing bots symlink
 make bots test/common
 
-# only install a subset to save time/space
-rm -f package-lock.json  # otherwise the command below installs *everything*, argh
-npm install chrome-remote-interface sizzle
+# support running from clean git tree
+if [ ! -d node_modules/chrome-remote-interface ]; then
+    # copy package.json temporarily otherwise npm might try to install the dependencies from it
+    rm -f package-lock.json  # otherwise the command below installs *everything*, argh
+    mv package.json .package.json
+    # only install a subset to save time/space
+    npm install chrome-remote-interface sizzle
+    mv .package.json package.json
+fi
+
+# disable detection of affected tests; testing takes too long as there is no parallelization
+mv .git dot-git
 
 . /etc/os-release
 export TEST_OS="${ID}-${VERSION_ID/./-}"
-
 export TEST_AUDIT_NO_SELINUX=1
 
 EXCLUDES=""

--- a/test/check-application
+++ b/test/check-application
@@ -1351,6 +1351,8 @@ class TestApplication(testlib.MachineCase):
 
         b.click("a:contains('Logs')")
         b.wait_text(".container-logs .xterm-accessibility-tree > div:nth-child(1)", "1")
+        # firefox optimizes these out when not visible
+        b.eval_js("document.querySelector('.container-logs .xterm-accessibility-tree').scrollIntoView()")
         b.wait_in_text(".container-logs .xterm-accessibility-tree", "6")
 
         b.click("a:contains('Console')")


### PR DESCRIPTION
See https://github.com/cockpit-project/starter-kit/pull/500

This should fix the FMF tests due to chromium crashes on F34/rawhide