### PR TITLE
Add script to (re-)generate GitHub deploy keys

### DIFF
--- a/.github/deploy-keys.sh
+++ b/.github/deploy-keys.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# (Re-)generate all deploy keys on https://github.com/cockpit-project/cockpit-podman/settings/environments
+
+set -eux
+
+ORG=cockpit-project
+THIS=cockpit-podman
+
+[ -e bots ] || make bots
+
+# for weblate-sync-pot.yml: push to https://github.com/cockpit-project/cockpit-podman-weblate/settings/keys
+bots/github-upload-secrets --receiver "${ORG}/${THIS}" --env "${THIS}-weblate" --ssh-keygen DEPLOY_KEY --deploy-to "${ORG}/${THIS}-weblate"


### PR DESCRIPTION
These deploy keys were created manually so far. Let's keep them in a
shell script so that we don't need to remember which ones we need, and
how to re-generate them en masse if/when we need to.

cockpit-podman currently just uses one deploy key, but other projects
have a lot more. Write it in a generic way, so that it will look similar
in other projects.

-----

I ran the script with my own token, and it deplaced the secret key on https://github.com/cockpit-project/cockpit-podman-weblate/settings/keys and the public key on https://github.com/cockpit-project/cockpit-podman/settings/environments/267165291/edit with my own (the previous one was generated by @allisonkarlitskaya ). I [manually ran the pot refresh workflow](https://github.com/cockpit-project/cockpit-podman/runs/3836593135?check_suite_focus=true), and it [pushed to weblate repo](https://github.com/cockpit-project/cockpit-podman-weblate/commit/a0366159c946e656283183bd6d422e5c1cd95038), so this all works.

Once this is approved, I'll do the same for c-machines and cockpit, as these have several more deploy keys.