### PR TITLE
Enable CRIU test for Arch Linux

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -82,7 +82,7 @@ class TestApplication(testlib.MachineCase):
         self.allow_journal_messages("/run.*/podman/podman: couldn't connect.*")
         self.allow_journal_messages(".*/run.*/podman/podman.*Connection reset by peer")
 
-        self.has_criu = m.image not in ["debian-testing", "ubuntu-stable", "arch"]
+        self.has_criu = m.image not in ["debian-testing", "ubuntu-stable"]
         self.has_selinux = "arch" not in m.image and "debian" not in m.image and "ubuntu" not in m.image
         self.has_cgroupsV2 = m.image not in ["ubuntu-stable"] and not m.image.startswith('rhel-8')
 
@@ -915,7 +915,6 @@ class TestApplication(testlib.MachineCase):
         b.wait(lambda: self.getContainerAttr("swamped-crate", "CPU") == "")
         b.wait(lambda: self.getContainerAttr("swamped-crate", "Memory") == "")
 
-    @testlib.skipImage("Arch Linux does not support checkpoint/restore", "arch")
     @testlib.nondestructive
     def testCheckpointRestoreCGroupsV2(self):
         b = self.browser
@@ -945,7 +944,7 @@ class TestApplication(testlib.MachineCase):
 
         b.wait(lambda: "checkpoint/restore requires at least criu" in b.text(".pf-c-alert.pf-m-danger > .pf-c-alert__description").lower())
 
-    @testlib.skipImage("Arch Linux does not support checkpoint/restore", "arch")
+    @testlib.skipImage("Arch Linux has cgroups v1 by default", "arch")
     def testCheckpointRestoreCGroupsV1(self):
         m = self.machine
 


### PR DESCRIPTION
The crun package in Arch Linux was compiled without criu support which
was fixed in 1.1-2.

https://github.com/archlinux/svntogit-community/commit/1ac5d53d080d4b833049d12948df5a919e5f7b59#diff-3e341d2d9c67be01819b25b25d5e53ea3cdf3a38d28846cda85a195eb9b7203a

---

I've kept cgroupsv1 support disabled as the default is cgroupsv2 on Arch Linux and I don't expect folks to enable it (everything in the repository supports the v2 API)