### PR TITLE
Implement prune unused images dialog

### DIFF
--- a/src/PruneUnusedImagesModal.jsx
+++ b/src/PruneUnusedImagesModal.jsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+import { Button, Checkbox, Flex, FlexItem, List, ListItem, Modal, } from '@patternfly/react-core';
+import cockpit from 'cockpit';
+
+import * as client from './client.js';
+
+const _ = cockpit.gettext;
+
+function ImageOptions({ images, checked, isSystem, handleChange, name, showCheckbox }) {
+    const [isExpanded, onToggle] = useState(false);
+    let shownImages = images;
+    if (!isExpanded) {
+        shownImages = shownImages.slice(0, 5);
+    }
+
+    if (shownImages.length === 0) {
+        return null;
+    }
+
+    return (
+        <Flex flex={{ default: 'column' }}>
+            {showCheckbox &&
+            <FlexItem>
+                <Checkbox
+                  label={isSystem ? _("The following unused system images will be deleted:") : _("The following unused user images will be deleted:")}
+                  isChecked={checked}
+                  id={name}
+                  name={name}
+                  onChange={handleChange}
+                />
+            </FlexItem>
+            }
+            <FlexItem>
+                <List>
+                    {shownImages.map((image, index) =>
+                        <ListItem key={index}>{image.RepoTags ? image.RepoTags[0] : "<none>:<none>"}</ListItem> // TODO: common function for RepoTags
+                    )}
+                    {!isExpanded && images.length > 5 &&
+                        <Button onClick={onToggle} variant="link" isInline>
+                            {_("Show more")}
+                        </Button>
+                    }
+                </List>
+            </FlexItem>
+        </Flex>
+    );
+}
+
+class PruneUnusedImagesModal extends React.Component {
+    constructor(props) {
+        super(props);
+        const isSystem = this.props.userServiceAvailable && this.props.systemServiceAvailable;
+        this.state = {
+            deleteUserImages: true,
+            deleteSystemImages: isSystem,
+            isPruning: false,
+        };
+    }
+
+    handlePruneUnusedImages = () => {
+        this.setState({ isPruning: true });
+
+        const actions = [];
+        if (this.state.deleteUserImages) {
+            actions.push(client.pruneUnusedImages(false));
+        }
+        if (this.state.deleteSystemImages) {
+            actions.push(client.pruneUnusedImages(true));
+        }
+        Promise.all(actions).then(this.props.close)
+                .catch(ex => {
+                    const error = _("Failed to prune unused images");
+                    this.props.onAddNotification({ type: 'danger', error, errorDetail: ex.message });
+                    this.props.close();
+                });
+    }
+
+    handleChange = (checked, event) => {
+        this.setState({ [event.target.name]: checked });
+    }
+
+    render() {
+        const isSystem = this.props.userServiceAvailable && this.props.systemServiceAvailable;
+        const userImages = this.props.unusedImages.filter(image => !image.isSystem);
+        const systemImages = this.props.unusedImages.filter(image => image.isSystem);
+        const showCheckboxes = userImages.length > 0 && systemImages.length > 0;
+        return (
+            <Modal isOpen
+                   onClose={this.props.close}
+                   position="top" variant="medium"
+                   title={cockpit.format(_("Prune unused images"))}
+                   footer={<>
+                       <Button id="btn-img-delete" variant="danger"
+                               spinnerAriaValueText={this.state.isPruning ? _("Pruning images") : undefined}
+                               isLoading={this.state.isPruning}
+                               isDisabled={!this.state.deleteUserImages && !this.state.deleteSystemImages}
+                               onClick={this.handlePruneUnusedImages}>
+                           {this.state.isPruning ? _("Pruning images") : _("Prune")}
+                       </Button>
+                       <Button variant="link" onClick={() => this.props.close()}>{_("Cancel")}</Button>
+                   </>}
+            >
+                <Flex flex={{ default: 'column' }}>
+                    {isSystem && <ImageOptions
+                  images={systemImages}
+                  name="deleteSystemImages"
+                  checked={this.state.deleteSystemImages}
+                  handleChange={this.handleChange}
+                  showCheckbox={showCheckboxes}
+                  isSystem
+                    />
+                    }
+                    <ImageOptions
+                  images={userImages}
+                  name="deleteUserImages"
+                  checked={this.state.deleteUserImages}
+                  handleChange={this.handleChange}
+                  showCheckbox={showCheckboxes}
+                  isSystem={false}
+                    />
+                </Flex>
+            </Modal>
+        );
+    }
+}
+
+export default PruneUnusedImagesModal;

--- a/src/client.js
+++ b/src/client.js
@@ -274,6 +274,14 @@ export function pullImage(system, reference) {
     });
 }
 
+export function pruneUnusedImages(system) {
+    return new Promise((resolve, reject) => {
+        podmanCall("libpod/images/prune?all=true", "POST", {}, system).then(resolve)
+                .then(reply => resolve(JSON.parse(reply)))
+                .catch(reject);
+    });
+}
+
 export function imageExists(system, id) {
     return podmanCall("libpod/images/" + id + "/exists", "GET", {}, system);
 }

--- a/test/check-application
+++ b/test/check-application
@@ -1590,6 +1590,44 @@ class TestApplication(testlib.MachineCase):
         b.click(".pf-c-modal-box footer button:contains(%s)" % text)
         b.wait_not_present(".pf-c-modal-box footer button:contains(%s)" % text)
 
+    @testlib.nondestructive
+    def testPruneUnusedImagesSystem(self):
+        self._testPruneUnusedImagesSystem(True)
+
+    @testlib.nondestructive
+    def testPruneUnusedImagesUser(self):
+        self._testPruneUnusedImagesSystem(False)
+
+    def _testPruneUnusedImagesSystem(self, auth):
+        b = self.browser
+        self.login(auth)
+
+        # By default we have 3 unused images, start one.
+        self.execute(auth, "podman run -d --name used_image alpine:latest sh")
+        b.click("#image-actions-dropdown")
+        b.click("button:contains(Prune unused images)")
+
+        if auth:
+            b.wait_js_func("ph_count_check", ".pf-c-modal-box__body .pf-c-list li", 5)
+        else:
+            b.wait_js_func("ph_count_check", ".pf-c-modal-box__body .pf-c-list li", 2)
+        b.click(".pf-c-modal-box button:contains(Prune)")
+
+        # When being superuser, admin images are also removed
+        if auth:
+            b.wait_js_func("ph_count_check", "#containers-images table tbody", 1)
+            checkImage(b, "quay.io/libpod/alpine:latest", "system")
+        else:
+            b.wait_js_func("ph_count_check", "#containers-images table tbody", 1)
+            # Two images removed, one in use kept
+            b.wait_not_present("#containers-images:contains('quay.io/libpod/busybox:latest')")
+            b.wait_not_present("#containers-images:contains('quay.io/cockpit/registry:2')")
+            b.wait_visible("#containers-images:contains('quay.io/libpod/alpine:latest')")
+
+        # Prune button should now be disabled
+        b.click("#image-actions-dropdown")
+        b.wait_visible("button:contains(Prune unused images).pf-m-disabled")
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
Here's a quick mockup:

![Screenshot 2021-10-20 at 17-05-59 PatternFly 4 • Modal](https://user-images.githubusercontent.com/10246/138119847-82c48e82-3cc8-40b9-a098-35d602edb6c1.png)

It's really not much different from what you have in the PR; it's just a few tweaks.

---

# Podman: Prune unused images

Unused images can now be cleaned up in cockpit-podman. This behaves similar to `podman image prune -a` and can delete unused system _and_ user container images at the same time.

![139233630-1ca43c26-a276-4f9a-9ac5-5caf0d56b277](https://user-images.githubusercontent.com/10246/141100150-b17bb84a-7571-4e85-b8a0-586df2b56472.png)

![140961475-7dbd2501-5a3b-49e0-8edc-f5d5f1f7df53](https://user-images.githubusercontent.com/10246/141100197-327b9b02-4f70-4a76-bdcc-ef433627ede4.png)