### PR TITLE
npm: Drop unused svgo dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "sizzle": "^2.3.3",
     "stdio": "^2.1.0",
     "string-replace-loader": "^3.0.0",
-    "svgo": "^1.3.0",
     "terser-webpack-plugin": "^5.1.3",
     "webpack": "^5.31.0",
     "webpack-cli": "^4.6.0"


### PR DESCRIPTION
This depends on "coa", which recently got a trojan horse:
https://github.com/advisories/GHSA-73qr-pfmq-6rp8

As it's not being used at all, just drop it.