### PR TITLE
npm: Avoid broken eslint-plugin-jsx-a11y 6.5.0 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint-config-standard-react": "^11.0.1",
     "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jsx-a11y": "^6.3.1",
+    "eslint-plugin-jsx-a11y": "~6.4.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-react": "^7.23.0",


### PR DESCRIPTION
That latest version has a grave regression:

    TypeError: Error while loading rule 'jsx-a11y/alt-text': rule.create is not a function

Downgrade back to 6.4.1 for the time being.

See https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/824

---

This just [broke the release](https://github.com/cockpit-project/cockpit-podman/runs/4162488559?check_suite_focus=true). c-machines is affected as well.