### PR TITLE
npm: Update to latest eslint-plugin-jsx-a11y

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint-config-standard-react": "^11.0.1",
     "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jsx-a11y": "~6.4.1",
+    "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-react": "^7.23.0",


### PR DESCRIPTION
Version 6.5.1 got released which works with ESLint 7 again and fixes
[1]. Bump the dependency. This essentially reverts the hack from
commit 195979e0e.

[1] https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/824