### PR TITLE
Remove created container if it doesn't start

### DIFF
--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -382,10 +382,21 @@ export class ImageRunModal extends React.Component {
                         client.postContainer(isSystem, "start", reply.Id, {})
                                 .then(() => this.props.close())
                                 .catch(ex => {
-                                    this.setState({
-                                        dialogError: _("Container failed to be started"),
-                                        dialogErrorDetail: cockpit.format("$0: $1", ex.reason, ex.message)
-                                    });
+                                    // If container failed to start remove it, so a user can fix the settings and retry and
+                                    // won't get another error that the container name is already taken.
+                                    client.delContainer(isSystem, reply.Id, true)
+                                            .then(() => {
+                                                this.setState({
+                                                    dialogError: _("Container failed to be started"),
+                                                    dialogErrorDetail: cockpit.format("$0: $1", ex.reason, ex.message)
+                                                });
+                                            })
+                                            .catch(ex => {
+                                                this.setState({
+                                                    dialogError: _("Failed to clean up container"),
+                                                    dialogErrorDetail: cockpit.format("$0: $1", ex.reason, ex.message)
+                                                });
+                                            });
                                 });
                     } else {
                         this.props.close();

--- a/test/check-application
+++ b/test/check-application
@@ -1661,6 +1661,35 @@ class TestApplication(testlib.MachineCase):
         b.click("#image-actions-dropdown")
         b.wait_visible("button:contains(Prune unused images).pf-m-disabled")
 
+    def testCreateContainerValidation(self):
+        ''' Test the validation errors'''
+        b = self.browser
+        self.login(False)
+        container_name = 'portused'
+
+        # Start a podman container which uses a port
+        self.execute(False, "podman run -d -p 5000:5000 --name registry registry:2")
+        b.click("#containers-images button.pf-c-expandable-section__toggle")
+
+        b.wait_visible('#containers-images td[data-label="Image"]:contains("busybox:latest")')
+        b.click('#containers-images tbody tr:contains("busybox:latest") .ct-container-create')
+        b.wait_visible('div.pf-c-modal-box header:contains("Create container")')
+
+        b.set_input_text("#run-image-dialog-name", container_name)
+
+        # Switch to Integration tab
+        b.click("#pf-tab-1-create-image-dialog-tab-integration")
+        b.click('.publish-port-form .btn-add')
+        b.set_input_text('#run-image-dialog-publish-0-host-port', '5000')
+        b.set_input_text('#run-image-dialog-publish-0-container-port', '5000')
+        b.click('.pf-c-modal-box__footer button:contains("Create")')
+        b.wait_in_text(".pf-c-alert", "address already in use")
+
+        # Changing the port should allow creation of container
+        b.set_input_text('#run-image-dialog-publish-0-host-port', '5001')
+        b.click('.pf-c-modal-box__footer button:contains("Create")')
+        self.waitContainerRow(container_name)
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
When a user tries to create a container of which the port is already
used the container doesn't start and is not removed. If the user
corrects the host port and clicks create again the container won't be
created as the name is already in use so removed it on error.