### PR TITLE
Make the system/user text bold in unused images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ test/common:
 # checkout Cockpit's PF/React/build library; again this has no API stability guarantee, so check out a stable tag
 $(LIB_TEST):
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 5108999badee3834fcc8e57222b5f9c82feae3a9; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 257; \
 	    git checkout --force FETCH_HEAD -- pkg/lib; \
 	    git reset -- pkg/lib'
 	mv pkg/lib src/ && rmdir -p pkg

--- a/src/PruneUnusedImagesModal.jsx
+++ b/src/PruneUnusedImagesModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Button, Checkbox, Flex, List, ListItem, Modal, } from '@patternfly/react-core';
 import cockpit from 'cockpit';
+import { fmt_to_fragments } from 'utils.jsx';
 
 import * as client from './client.js';
 
@@ -24,7 +25,7 @@ function ImageOptions({ images, checked, isSystem, handleChange, name, showCheck
         <Flex flex={{ default: 'column' }}>
             {showCheckbox &&
                 <Checkbox
-                  label={isSystem ? _("Delete unused system images:") : _("Delete unused user images:")}
+                  label={fmt_to_fragments(_("Delete unused $0 images:"), <b>{isSystem ? _("system") : _("user")}</b>)}
                   isChecked={checked}
                   id={name}
                   name={name}


### PR DESCRIPTION
As per design, let the system/user images stand out when pruning as an
administrator. As in https://github.com/cockpit-project/cockpit-podman/pull/799#issuecomment-948586523