### PR TITLE
test: Don't timeout on cleanups

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -71,8 +71,8 @@ class TestApplication(testlib.MachineCase):
         # Enable user service as well
         self.admin_s.execute("systemctl --user stop podman.service; systemctl --now --user enable podman.socket")
         self.restore_dir("/home/admin/.local/share/containers", reboot_safe=True)
-        self.addCleanup(self.admin_s.execute, "timeout 10s systemctl --user stop podman.service podman.socket || true")
-        self.addCleanup(self.admin_s.execute, "timeout 10s podman rm --force --all || true")
+        self.addCleanup(self.admin_s.execute, "systemctl --user stop podman.service podman.socket || true")
+        self.addCleanup(self.admin_s.execute, "podman rm --force --all || true")
 
         # But disable it globally so that "systemctl --user disable" does what we expect
         m.execute("systemctl --global disable podman.socket")


### PR DESCRIPTION
Removing running container takes longer and if we timeout we often
don't let podman cleanup bound ports which makes subsequent tests to fail.

This is common issue we had. It can be reproduced like this.
1. Add something which makes tests to fail:
```diff
diff --git test/check-application test/check-application
index 1cc0f7e1..e32d4be8 100755
--- test/check-application
+++ test/check-application
@@ -1383,6 +1383,7 @@ class TestApplication(testlib.MachineCase):
         self.assertIn('8001/tcp:[{ ', ports)
         self.assertIn('9001/tcp:[{127.0.0.2 ', ports)
         self.assertNotIn('7001/tcp', ports)
+        b.wait_visible("#foo")
 
         env = self.execute(auth, "podman exec busybox-with-tty env")
         self.assertIn('APPLE=ORANGE', env)
```

2. `./test/common/run-tests TestApplication.testRunImageSystem TestApplication.testRunImageUser TestApplication.testCreateContainerSystem`

Without this patch, the first test fails on `#foo` and all other on `port 6000 already in use`. With this patch the first fails on `#foo` and all other succeed.