### PR TITLE
Bump cockpit test lib to fix Browser.logout() for cockpit 258

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 257; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 8b00034ff0aa0dc8014aef32067559ccfb88afb2; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 


### PR DESCRIPTION
The shell DOM changed in Cockpit 258. Pick up the Browser.logout()
change which can deal with both old and new shell versions.

 - [x] https://github.com/cockpit-project/cockpit/pull/16662 then bump the sha