### PR TITLE
test: Drop installing basic cockpit packages on Debian/Ubuntu

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -4,9 +4,6 @@ set -eu
 
 # for Debian based images, build and install debs; for RPM based ones, the locally built rpm gets installed separately
 if [ -d /var/tmp/debian ]; then
-    apt-get update
-    eatmydata apt-get install ${APT_INSTALL_OPTIONS:-} -y cockpit-ws cockpit-system podman
-
     # build source package
     cd /var/tmp
     TAR=$(ls cockpit-podman-*.tar.xz)


### PR DESCRIPTION
Since https://github.com/cockpit-project/bots/commit/b06bd37b0ad our
Debian/Ubuntu test VMs have the basic cockpit packages pre-installed.
Drop the apt calls to install them, so that we stop getting surprise
breakages due to new cockpit versions. These will now properly appear on
image refreshes.