### PR TITLE
Add restart policy to create new container

### DIFF
--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -505,6 +505,7 @@ class Containers extends React.Component {
                 close={() => this.setState({ showCreateContainerModal: false })}
                 registries={this.props.registries}
                 selinuxAvailable={this.props.selinuxAvailable}
+                podmanRestartAvailable={this.props.podmanRestartAvailable}
                 systemServiceAvailable={this.props.systemServiceAvailable}
                 userServiceAvailable={this.props.userServiceAvailable}
                 onAddNotification={this.props.onAddNotification}

--- a/src/ImageRunModal.scss
+++ b/src/ImageRunModal.scss
@@ -64,3 +64,16 @@
         max-width: 10rem;
     }
 }
+
+
+ // PF4 does not yet support multiple form fields for the same label
+.ct-input-group-spacer-sm.pf-l-flex {
+    // Limit width for select entries and inputs in the input groups otherwise they take up the whole space
+    > .pf-c-select, .pf-c-form-control:not(.pf-c-select__toggle-typeahead) {
+      max-width: 8ch;
+    }
+}
+
+.run-image-dialog-restart-retries {
+    max-width: 5ch;
+}

--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -129,7 +129,8 @@ class Images extends React.Component {
                 title: <ImageActions image={image} onAddNotification={this.props.onAddNotification} selinuxAvailable={this.props.selinuxAvailable}
                                      registries={this.props.registries} user={this.props.user}
                                      userServiceAvailable={this.props.userServiceAvailable}
-                                     systemServiceAvailable={this.props.systemServiceAvailable} />,
+                                     systemServiceAvailable={this.props.systemServiceAvailable}
+                                     podmanRestartAvailable={this.props.podmanRestartAvailable} />,
                 props: { className: 'pf-c-table__action' }
             },
         ];
@@ -333,7 +334,7 @@ const ImageOverActions = ({ handleDownloadNewImage, handlePruneUsedImages, unuse
     );
 };
 
-const ImageActions = ({ image, onAddNotification, registries, selinuxAvailable, user, systemServiceAvailable, userServiceAvailable }) => {
+const ImageActions = ({ image, onAddNotification, registries, selinuxAvailable, user, systemServiceAvailable, userServiceAvailable, podmanRestartAvailable }) => {
     const [showRunImageModal, setShowImageRunModal] = useState(false);
     const [showImageDeleteModal, setShowImageDeleteModal] = useState(false);
     const [showImageDeleteErrorModal, setShowImageDeleteErrorModal] = useState(false);
@@ -422,6 +423,7 @@ const ImageActions = ({ image, onAddNotification, registries, selinuxAvailable, 
                 close={() => setShowImageRunModal(false)}
                 registries={registries}
                 selinuxAvailable={selinuxAvailable}
+                podmanRestartAvailable={podmanRestartAvailable}
                 systemServiceAvailable={systemServiceAvailable}
                 userServiceAvailable={userServiceAvailable}
                 user={user}

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -62,6 +62,7 @@ class Application extends React.Component {
             showStartService: true,
             version: '1.3.0',
             selinuxAvailable: false,
+            podmanRestartAvailable: false,
             currentUser: _("User"),
             privileged: false,
         };
@@ -495,6 +496,16 @@ class Application extends React.Component {
                 .then(() => this.setState({ selinuxAvailable: true }))
                 .catch(() => this.setState({ selinuxAvailable: false }));
 
+        cockpit.spawn(["systemctl", "show", "--value", "-p", "LoadState", "podman-restart"], { environ: ["LC_ALL=C"], error: "ignore" })
+                .then(out => {
+                    console.log(out);
+                    if (out.trim() === "loaded") {
+                        this.setState({ podmanRestartAvailable: true });
+                    } else {
+                        this.setState({ podmanRestartAvailable: false });
+                    }
+                });
+
         superuser.addEventListener("changed", () => this.setState({ privileged: !!superuser.allowed }));
         this.setState({ privileged: superuser.allowed });
 
@@ -639,6 +650,7 @@ class Application extends React.Component {
                 systemServiceAvailable={this.state.systemServiceAvailable}
                 registries={this.state.registries}
                 selinuxAvailable={this.state.selinuxAvailable}
+                podmanRestartAvailable={this.state.podmanRestartAvailable}
             />;
         const containerList =
             <Containers
@@ -660,6 +672,7 @@ class Application extends React.Component {
                 cgroupVersion={this.state.cgroupVersion}
                 registries={this.state.registries}
                 selinuxAvailable={this.state.selinuxAvailable}
+                podmanRestartAvailable={this.state.podmanRestartAvailable}
             />;
 
         const notificationList = (

--- a/src/podman.scss
+++ b/src/podman.scss
@@ -59,14 +59,6 @@
     justify-content: space-around;
 }
 
- // PF4 does not yet support multiple form fields for the same label
-.ct-input-group-spacer-sm.pf-l-flex {
-    // Limit width for select entries and inputs in the input groups otherwise they take up the whole space
-    > .pf-c-select, .pf-c-form-control:not(.pf-c-select__toggle-typeahead) {
-      max-width: 40%;
-    }
-}
-
 .ct-badge-container-running, .ct-badge-pod-running {
   background-color: var(--pf-global--info-color--100);
   color: white;

--- a/test/check-application
+++ b/test/check-application
@@ -24,6 +24,10 @@ registries = ['localhost:5000', 'localhost:6000']
 
 NOT_RUNNING = ["exited", "stopped"]
 
+# Ubuntu stable has 3.2.1 while we need podman 3.3. debian-testing has 3.4 but does not ship the podman-restart unit.
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1001780
+DISTROS_WITHOUT_PODMAN_RESTART = ['ubuntu-stable', 'debian-testing']
+
 
 def checkImage(browser, name, owner):
     if browser.attr("#containers-images button.pf-c-expandable-section__toggle", "aria-expanded") == 'false':
@@ -1326,6 +1330,13 @@ class TestApplication(testlib.MachineCase):
         # Set up command line
         b.set_input_text('#run-image-dialog-command', "sh -c 'for i in $(seq 20); do sleep 1; echo $i; done; sleep infinity'")
 
+        if auth and m.image not in DISTROS_WITHOUT_PODMAN_RESTART:
+            # Set restart policy to 3 retries
+            b.set_val("#run-image-dialog-restart-policy", "on-failure")
+            b.set_input_text('#run-image-dialog-restart-retries', '3')
+        else:
+            b.wait_not_present("#run-image-dialog-restart-policy")
+
         # Switch to Integration tab
         b.click("#pf-tab-1-create-image-dialog-tab-integration")
 
@@ -1418,6 +1429,13 @@ class TestApplication(testlib.MachineCase):
         if auth:
             cpuShares = self.execute(auth, "podman inspect --format '{{.HostConfig.CpuShares}}' busybox-with-tty || podman inspect --format '{{.HostConfig.CPUShares}}' busybox-with-tty").strip()
             self.assertEqual(cpuShares, '512')
+
+        restartPolicy = self.execute(auth, "podman inspect --format '{{.HostConfig.RestartPolicy}}' busybox-with-tty").strip()
+        if auth and m.image not in DISTROS_WITHOUT_PODMAN_RESTART:
+            self.assertEqual(restartPolicy, '{on-failure 3}')
+        else:
+            # No restart policy
+            self.assertEqual(restartPolicy, '{ 0}')
 
         b.wait(lambda: "3" in self.execute(auth, "podman logs busybox-with-tty"))
 
@@ -1744,6 +1762,41 @@ class TestApplication(testlib.MachineCase):
         b.set_input_text('#run-image-dialog-publish-0-host-port', '5001')
         b.click('.pf-c-modal-box__footer button:contains("Create")')
         self.waitContainerRow(container_name)
+
+    @testlib.skipImage("podman-restart not available in debian/ubuntu", *DISTROS_WITHOUT_PODMAN_RESTART)
+    def testPodmanRestartEnabled(self):
+        b = self.browser
+        self.addCleanup(self.machine.execute, "systemctl disable podman-restart.service")
+
+        # Drop user images for easy selection
+        if "busybox" in self.execute(False, "podman images"):
+            self.execute(False, "podman rmi busybox")
+
+        self.login(True)
+        b.click("#containers-images button.pf-c-expandable-section__toggle")
+
+        def create_container(name, policy=None):
+            b.wait_visible('#containers-images td[data-label="Image"]:contains("busybox:latest")')
+            b.click('#containers-images tbody tr:contains("busybox:latest") .ct-container-create')
+            b.wait_visible('div.pf-c-modal-box header:contains("Create container")')
+
+            b.set_input_text("#run-image-dialog-name", name)
+            if policy:
+                b.set_val("#run-image-dialog-restart-policy", "always")
+            b.click('.pf-c-modal-box__footer button:contains("Create")')
+            self.waitContainerRow(name)
+
+        container_name = 'none'
+        create_container(container_name)
+        restartPolicy = self.execute(True, f"podman inspect --format '{{{{.HostConfig.RestartPolicy}}}}' {container_name}").strip()
+        self.assertEqual(restartPolicy, '{ 0}')
+
+        container_name = 'restart'
+        create_container(container_name, 'always')
+        restartPolicy = self.execute(True, f"podman inspect --format '{{{{.HostConfig.RestartPolicy}}}}' {container_name}").strip()
+        self.assertEqual(restartPolicy, '{always 0}')
+        podmanRestartEnabled = self.execute(True, "systemctl is-enabled podman-restart.service || true").strip()
+        self.assertEqual(podmanRestartEnabled, 'enabled')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implement the option to configure a restart policy for containers, the
default is no restart policy which means the container exits.
'on-failure' means it's restarted when the container exists with a
non-zero exit code for a maximum of retries. Always means it is always
restarted, to make this work on reboot the podman-restart service needs
to be enabled. For user containers this means `loginctl enable-linger`
has to set if a user wants his container to start without logging in
after a reboot.

---

# Podman restart policy

For system containers it is now possible to set a restart policy for new containers.

![image](https://user-images.githubusercontent.com/67428/145615232-03c941e3-0488-4354-ba46-33dd6b1b20c2.png)