### PR TITLE
Bump test/common API to 259

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 8b00034ff0aa0dc8014aef32067559ccfb88afb2; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 259; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 


### PR DESCRIPTION
This will fix the tests when running against cockpit 259, where the
shell got changed to not render the `#machine-reconnect` button all the
time any more.

This should fix broken rawhide tests