### PR TITLE
Enable checkbox when input is focussed

### DIFF
--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -862,6 +862,7 @@ export class ImageRunModal extends React.Component {
                                    step={1}
                                    min={0}
                                    isReadOnly={!this.state.memoryConfigure}
+                                   onClick={() => !this.state.memoryConfigure && this.onValueChanged('memoryConfigure', true)}
                                    onChange={value => this.onValueChanged('memory', value)} />
                                 <FormSelect id='memory-unit-select'
                                     aria-label={_("Memory unit")}
@@ -896,6 +897,7 @@ export class ImageRunModal extends React.Component {
                                     <TextInput type='number'
                                         id="run-image-cpu-priority"
                                         value={dialogValues.cpuShares}
+                                        onClick={() => !this.state.cpuSharesConfigure && this.onValueChanged('cpuSharesConfigure', true)}
                                         step={1}
                                         min={2}
                                         max={262144}

--- a/test/check-application
+++ b/test/check-application
@@ -1313,6 +1313,12 @@ class TestApplication(testlib.MachineCase):
 
         # CPU shares work only with system containers
         if auth:
+            # Check that the checkbox is enabled when clicked on the field
+            b.wait_visible("#run-image-dialog-cpu-priority-checkbox:not(:checked)")
+            b.click('#run-image-cpu-priority')
+            b.wait_visible("#run-image-dialog-cpu-priority-checkbox:checked")
+            b.set_checked("#run-image-dialog-cpu-priority-checkbox", False)
+
             b.set_checked("#run-image-dialog-cpu-priority-checkbox", True)
             b.wait_visible("#run-image-dialog-cpu-priority-checkbox:checked")
             b.wait_visible('#run-image-dialog-cpu-priority input[value="1024"]')


### PR DESCRIPTION
When a user clicks on the cpu shares / memory limit input automatically
enable the corresponding checkboxes. For a <FormSelect> the onFocus
method does not trigger when a user clicks on it, making it impossible
to enable the checkbox.

Closes #849