### PR TITLE
fmf: Go back to firefox distro version

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -12,12 +12,9 @@ LOGS="$(pwd)/logs"
 mkdir -p "$LOGS"
 chmod a+w "$LOGS"
 
-# install firefox (available everywhere in Fedora and RHEL); install the package to pull in all the dependencies
+# install firefox (available everywhere in Fedora and RHEL)
 # we don't need the H.264 codec, and it is sometimes not available (rhbz#2005760)
 dnf install --disablerepo=fedora-cisco-openh264 -y firefox
-# install nightly for Chrome DevTools Protocol support
-curl --location 'https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US' | tar -C /usr/local/lib/ -xj
-ln -s /usr/local/lib/firefox/firefox /usr/local/bin/
 
 # HACK: ensure that critical components are up to date: https://github.com/psss/tmt/issues/682
 dnf update -y podman crun


### PR DESCRIPTION
By now the packaged firefox contains CDP. This makes the tests more
robust against CDP breakage in nightly.

Cherry-picked from starter-kit commit 9e162423eba.