### PR TITLE
Create a container in a pod

### DIFF
--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -273,6 +273,7 @@ class Containers extends React.Component {
         this.state = {
             width: 0,
             showCreateContainerModal: false,
+            createPod: null,
             downloadingContainers: [],
         };
         this.renderRow = this.renderRow.bind(this);
@@ -502,7 +503,8 @@ class Containers extends React.Component {
                 <ImageRunModal
                 user={this.props.user}
                 localImages={localImages}
-                close={() => this.setState({ showCreateContainerModal: false })}
+                close={() => this.setState({ showCreateContainerModal: false, createPod: null })}
+                pod={this.state.createPod}
                 registries={this.props.registries}
                 selinuxAvailable={this.props.selinuxAvailable}
                 podmanRestartAvailable={this.props.podmanRestartAvailable}
@@ -566,6 +568,12 @@ class Containers extends React.Component {
                                                         <span>{_("pod group")}</span>
                                                     </CardTitle>
                                                     <CardActions className='panel-actions'>
+                                                        <Button
+                                                          variant="primary"
+                                                          className="create-container-in-pod"
+                                                          onClick={() => this.setState({ showCreateContainerModal: true, createPod: this.props.pods[section] })}>
+                                                            {_("Create container in pod")}
+                                                        </Button>
                                                         <Badge isRead className={"ct-badge-pod-" + podStatus.toLowerCase()}>{_(podStatus)}</Badge>
                                                         <PodActions onAddNotification={this.props.onAddNotification} pod={this.props.pods[section]} />
                                                     </CardActions>

--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -350,6 +350,10 @@ export class ImageRunModal extends React.Component {
     getCreateConfig() {
         const createConfig = {};
 
+        if (this.props.pod) {
+            createConfig.pod = this.props.pod.Id;
+        }
+
         if (this.state.image) {
             createConfig.image = this.state.image.RepoTags ? this.state.image.RepoTags[0] : "";
         } else {
@@ -1021,7 +1025,7 @@ export class ImageRunModal extends React.Component {
                            this.props.close();
                        }
                    }}
-                   title={_("Create container")}
+                   title={this.props.pod ? cockpit.format(_("Create container in $0"), this.props.pod.Name) : _("Create container")}
                    footer={<>
                        {this.state.dialogError && <ErrorNotification errorMessage={this.state.dialogError} errorDetail={this.state.dialogErrorDetail} />}
                        <Button variant='primary' onClick={this.onCreateClicked} isDisabled={!image && selectedImage === ""}>

--- a/test/check-application
+++ b/test/check-application
@@ -57,6 +57,7 @@ class TestApplication(testlib.MachineCase):
         # HACK: sometimes podman leaks mounts
         self.addCleanup(m.execute, "podman rm --force --all && "
                         "findmnt --list -otarget | grep /var/lib/containers/. | xargs -r umount || true")
+        self.addCleanup(m.execute, "podman pod rm --force --all || true")
 
         # Create admin session
         m.execute("""
@@ -77,6 +78,7 @@ class TestApplication(testlib.MachineCase):
         self.restore_dir("/home/admin/.local/share/containers", reboot_safe=True)
         self.addCleanup(self.admin_s.execute, "systemctl --user stop podman.service podman.socket || true")
         self.addCleanup(self.admin_s.execute, "podman rm --force --all || true")
+        self.addCleanup(self.admin_s.execute, "podman pod rm --force --all || true")
 
         # But disable it globally so that "systemctl --user disable" does what we expect
         m.execute("systemctl --global disable podman.socket")
@@ -1803,6 +1805,37 @@ class TestApplication(testlib.MachineCase):
         self.assertEqual(restartPolicy, '{always 0}')
         podmanRestartEnabled = self.execute(True, "systemctl is-enabled podman-restart.service || true").strip()
         self.assertEqual(podmanRestartEnabled, 'enabled')
+
+    def _testCreateContainerInPod(self, auth):
+        b = self.browser
+
+        container_name = 'containerinpod'
+        podname = "pod1"
+        self.execute(auth, f"podman pod create --infra=false --name={podname}")
+
+        self.login(auth)
+
+        self.filter_containers('all')
+        b.click(".create-container-in-pod")
+
+        # the podname should be in the "Create container" header
+        self.assertIn(podname, b.text("#pf-modal-part-1"))
+
+        b.set_input_text("#run-image-dialog-name", container_name)
+        b.set_input_text("#create-image-image-select-typeahead", "quay.io/libpod/busybox:latest")
+        b.click('button.pf-c-toggle-group__button:contains("Local")')
+        b.click('button.pf-c-select__menu-item:contains("quay.io/libpod/busybox:latest")')
+        b.click('.pf-c-modal-box__footer button:contains("Create")')
+
+        container_sha = self.execute(auth, f"podman inspect --format '{{{{.Id}}}}' {container_name}").strip()
+        self.waitContainer(container_sha, auth, name=container_name, image='busybox:latest', cmd='sh',
+                           state='running', owner="system" if auth else "admin", pod=podname)
+
+    def testCreateContainerInPodSystem(self):
+        self._testCreateContainerInPod(True)
+
+    def testCreateContainerInPodUser(self):
+        self._testCreateContainerInPod(False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds the ability to create a new container in a pod group, a
container cannot be moved out or into a pod once it has been created.

Closes: #487

---

# Create container in pod

It is now possible to create a container in an existing pod using the `Create container in pod` button.


![image](https://user-images.githubusercontent.com/67428/146522770-e06a8462-fae2-44a8-9fbf-d93ce0bec157.png)


Create container dialog now shows in which pod the container is created

![image](https://user-images.githubusercontent.com/67428/146522493-c8f6e3c9-bfbd-4305-bd3a-e3aae461c848.png)
