### PR TITLE
Fix jumping headers in container details

### DIFF
--- a/src/ContainerLogs.jsx
+++ b/src/ContainerLogs.jsx
@@ -74,7 +74,11 @@ class ContainerLogs extends React.Component {
     }
 
     resize(width) {
-        const padding = 11 + 5 + 50;
+        // 24 PF padding * 4
+        // 3 line border
+        // 21 inner padding of xterm.js
+        // xterm.js scrollbar 20
+        const padding = 24 * 4 + 3 + 21 + 20;
         const realWidth = this.view._core._renderService.dimensions.actualCellWidth;
         const cols = Math.floor((width - padding) / realWidth);
         this.view.resize(cols, 24);

--- a/src/ContainerTerminal.jsx
+++ b/src/ContainerTerminal.jsx
@@ -103,7 +103,11 @@ class ContainerTerminal extends React.Component {
     }
 
     resize(width) {
-        const padding = 11 + 5 + 50;
+        // 24 PF padding * 4
+        // 3 line border
+        // 21 inner padding of xterm.js
+        // xterm.js scrollbar 20
+        const padding = 24 * 4 + 3 + 21 + 20;
         const realWidth = this.state.term._core._renderService.dimensions.actualCellWidth;
         const cols = Math.floor((width - padding) / realWidth);
         this.state.term.resize(cols, 24);


### PR DESCRIPTION
The calculation for the padding in the card and table was incorrect
leading to the table headers to "jump" when switching between details
and logs as the terminals does not fit in the card.