### PR TITLE
DBG: Get logs from failing rawhide tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ endif
 
 ifeq ($(TEST_SCENARIO),rawhide)
 # needs to run as a separate command, as --run-command is executed before --script
-RAWHIDE=bots/image-customize -v --run-command 'dnf update -y --releasever=rawhide podman conmon crun containernetworking-plugins containers-common kernel' $(TEST_OS)
+RAWHIDE=bots/image-customize -v --run-command 'dnf update -y --releasever=rawhide podman conmon crun criu containernetworking-plugins containers-common kernel' $(TEST_OS)
 endif
 
 # build a VM with locally built rpm/dsc installed


### PR DESCRIPTION
To get logs from this: http://artifacts.dev.testing-farm.io/abe0bdc3-7096-4ea9-81d2-607d956f5e47/work-alltUWxYe/plans/all/execute/data/test/browser/logs/TestApplication-testCheckpointRestoreCGroupsV2-fedora-36-127.0.0.1-22-FAIL.png