### PR TITLE
Support healthcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ test/reference: test/common
 # checkout Cockpit's PF/React/build library; again this has no API stability guarantee, so check out a stable tag
 $(LIB_TEST):
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 268.1; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 47539d6d31520da8b0ed916ee6d78e5aefc1ea87; \
 	    git checkout --force FETCH_HEAD -- pkg/lib; \
 	    git reset -- pkg/lib'
 	mv pkg/lib src/ && rmdir -p pkg

--- a/src/ContainerHealthLogs.jsx
+++ b/src/ContainerHealthLogs.jsx
@@ -1,0 +1,127 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import cockpit from 'cockpit';
+import * as utils from './util.js';
+import * as client from './client.js';
+
+import { ListingTable } from "cockpit-components-table.jsx";
+import {
+    Button,
+    DescriptionList, DescriptionListGroup, DescriptionListTerm, DescriptionListDescription,
+    Flex, FlexItem,
+} from '@patternfly/react-core';
+import { CheckCircleIcon, ErrorCircleOIcon } from "@patternfly/react-icons";
+
+const _ = cockpit.gettext;
+
+const format_nanoseconds = (ns) => {
+    const seconds = ns / 1000000000;
+    return cockpit.format(cockpit.ngettext("$0 second", "$0 seconds", seconds), seconds);
+};
+
+const ContainerHealthLogs = ({ container, containerDetail, onAddNotification, state }) => {
+    let healthCheck = {};
+    let failingStreak = 0;
+    let logs = [];
+    if (containerDetail) {
+        healthCheck = containerDetail.Config.Healthcheck || containerDetail.Config.Health;
+        const healthState = containerDetail.State.Healthcheck || containerDetail.State.Health;
+        failingStreak = healthState.FailingStreak || 0;
+        logs = [...(healthState.Log || [])].reverse();
+    }
+
+    return (
+        <>
+            <Flex alignItems={{ default: "alignItemsFlexStart" }}>
+                <FlexItem grow={{ default: 'grow' }}>
+                    <DescriptionList isAutoFit id="container-details-healthcheck">
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>{_("Status")}</DescriptionListTerm>
+                            <DescriptionListDescription>{state}</DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>{_("Command")}</DescriptionListTerm>
+                            <DescriptionListDescription>{utils.quote_cmdline(healthCheck.Test)}</DescriptionListDescription>
+                        </DescriptionListGroup>
+                        {healthCheck.Interval && <DescriptionListGroup>
+                            <DescriptionListTerm>{_("Interval")}</DescriptionListTerm>
+                            <DescriptionListDescription>{format_nanoseconds(healthCheck.Interval)}</DescriptionListDescription>
+                        </DescriptionListGroup>}
+                        {healthCheck.Retries && <DescriptionListGroup>
+                            <DescriptionListTerm>{_("Retries")}</DescriptionListTerm>
+                            <DescriptionListDescription>{healthCheck.Retries}</DescriptionListDescription>
+                        </DescriptionListGroup>}
+                        {healthCheck.StartPeriod && <DescriptionListGroup>
+                            <DescriptionListTerm>{_("Start period")}</DescriptionListTerm>
+                            <DescriptionListDescription>{format_nanoseconds(healthCheck.StartPeriod)}</DescriptionListDescription>
+                        </DescriptionListGroup>}
+                        {healthCheck.Timeout && <DescriptionListGroup>
+                            <DescriptionListTerm>{_("Timeout")}</DescriptionListTerm>
+                            <DescriptionListDescription>{format_nanoseconds(healthCheck.Timeout)}</DescriptionListDescription>
+                        </DescriptionListGroup>}
+                        {failingStreak !== 0 && <DescriptionListGroup>
+                            <DescriptionListTerm>{_("Failing streak")}</DescriptionListTerm>
+                            <DescriptionListDescription>{failingStreak}</DescriptionListDescription>
+                        </DescriptionListGroup>}
+                    </DescriptionList>
+                </FlexItem>
+                { container.State === "running" &&
+                    <FlexItem>
+                        <Button variant="secondary" onClick={() => {
+                            client.runHealthcheck(container.isSystem, container.Id)
+                                    .catch(ex => {
+                                        const error = cockpit.format(_("Failed to run health check on container $0"), container.Names);
+                                        onAddNotification({ type: 'danger', error, errorDetail: ex.message });
+                                    });
+                        }}>
+                            {_("Run health check")}
+                        </Button>
+                    </FlexItem>}
+            </Flex>
+            <ListingTable aria-label={_("Logs")}
+                          variant='compact'
+                          columns={[_("Last 5 runs"), _("Started at")]}
+                          rows={
+                              logs.map(log => {
+                                  const id = "hc" + log.Start + container.Id;
+                                  return {
+                                      expandedContent: log.Output ? <pre>{log.Output}</pre> : null,
+                                      columns: [
+                                          {
+                                              title: <Flex flexWrap={{ default: 'nowrap' }} spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+                                                  {log.ExitCode === 0 ? <CheckCircleIcon className="green" /> : <ErrorCircleOIcon className="red" />}
+                                                  <span>{log.ExitCode === 0 ? _("Passed health run") : _("Failed health run")}</span>
+                                              </Flex>
+                                          },
+                                          utils.localize_time(Date.parse(log.Start) / 1000)
+                                      ],
+                                      props: {
+                                          key : id,
+                                          "data-row-id": id,
+                                      },
+                                  };
+                              })
+                          } />
+        </>
+    );
+};
+
+export default ContainerHealthLogs;

--- a/src/Containers.scss
+++ b/src/Containers.scss
@@ -25,6 +25,12 @@
     padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--md) var(--pf-global--spacer--lg);
 }
 
+/* HACK - force DescriptionList to wrap but not fill the width */
+#container-details-healthcheck {
+    display: flex;
+    flex-wrap: wrap;
+}
+
 /* Upstream issue https://github.com/patternfly/patternfly/pull/3714 */
 .containers-containers .pf-c-toolbar__content-section {
     gap: var(--pf-global--spacer--sm);

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -395,6 +395,7 @@ class Application extends React.Component {
         case 'checkpoint':
         case 'create':
         case 'died':
+        case 'exec_died':
         case 'kill':
         case 'mount':
         case 'pause':

--- a/src/client.js
+++ b/src/client.js
@@ -95,6 +95,8 @@ export const commitContainer = (system, commitData) => podmanCall("libpod/commit
 
 export const postContainer = (system, action, id, args) => podmanCall("libpod/containers/" + id + "/" + action, "POST", args, system);
 
+export const runHealthcheck = (system, id) => podmanCall("libpod/containers/" + id + "/healthcheck", "GET", {}, system);
+
 export const postPod = (system, action, id, args) => podmanCall("libpod/pods/" + id + "/" + action, "POST", args, system);
 
 export const delPod = (system, id, force) => podmanCall("libpod/pods/" + id, "DELETE", { force }, system);

--- a/src/podman.scss
+++ b/src/podman.scss
@@ -56,6 +56,24 @@
   color: white;
 }
 
+.ct-badge-container-healthy {
+  background-color: var(--pf-global--success-color--100);
+  color: white;
+}
+
+.ct-badge-container-unhealthy {
+  background-color: var(--pf-global--danger-color--100);
+  color: white;
+}
+
+.green {
+    color: var(--pf-global--success-color--100);
+}
+
+.red {
+  color: var(--pf-global--danger-color--100);
+}
+
 // Hide the header nav from the expandable rows - this should be better done with JS but the current cockpit-listing-panel implementation does not support this variant
 #containers-images .ct-listing-panel-head {
     display: none;

--- a/test/check-application
+++ b/test/check-application
@@ -972,6 +972,10 @@ class TestApplication(testlib.MachineCase):
             # Checkpoint/restore is not supported on user containers yet - the related buttons should not be shown
             # Check that the restore option is not present
             b.wait_not_present(self.getContainerAction('swamped-crate', 'Restore'))
+
+        # Health check is not set up
+        b.wait_not_present(self.getContainerAction('swamped-crate', 'Run health check'))
+
         b.click("#containers-containers tbody tr:contains('swamped-crate') .pf-c-dropdown__toggle")
 
         # Start the container
@@ -1318,7 +1322,7 @@ class TestApplication(testlib.MachineCase):
 
         # Create Container, image is pulled and should end up being "running"
         b.click('.pf-c-modal-box__footer #create-image-create-run-btn')
-        sel = "> span:not(.downloading)"
+        sel = " span:not(.downloading)"
         b.wait(lambda: self.getContainerAttr(container_name, "State", sel) in 'Running')
         output = self.execute(auth, f"podman exec {container_name} ls -lh /latest || true").strip()
         self.assertEqual('', output)
@@ -1347,7 +1351,7 @@ class TestApplication(testlib.MachineCase):
 
         # Create Container, image is pulled and should end up being "running"
         b.click('.pf-c-modal-box__footer #create-image-create-run-btn')
-        sel = "> span:not(.downloading)"
+        sel = " span:not(.downloading)"
         b.wait(lambda: self.getContainerAttr(container_name, "State", sel) in 'Running')
         # Verify that the latest file exists
         output = self.execute(auth, f"podman exec {container_name} ls -lh /latest").strip()
@@ -1604,8 +1608,10 @@ class TestApplication(testlib.MachineCase):
             except ValueError:
                 return 0
 
+        b.wait_not_present("button:contains('Health check logs')")
         b.click(".pf-m-expanded button:contains('Logs')")
         b.wait_text(".pf-m-expanded .container-logs .xterm-accessibility-tree > div:nth-child(1)", "1")
+
         # firefox optimizes these out when not visible
         b.eval_js("document.querySelector('.pf-m-expanded .container-logs .xterm-accessibility-tree').scrollIntoView()")
         b.wait_in_text(".pf-m-expanded .container-logs .xterm-accessibility-tree", "6")
@@ -1896,6 +1902,94 @@ class TestApplication(testlib.MachineCase):
         b.set_input_text('#run-image-dialog-publish-0-host-port', '5001')
         b.click('.pf-c-modal-box__footer #create-image-create-run-btn')
         self.waitContainerRow(container_name)
+
+    def _testHealthcheck(self, auth):
+        b = self.browser
+
+        # Just drop user images so we can use simpler selectors
+        if auth:
+            self.execute(False, "podman rmi busybox")
+
+        self.login(auth)
+
+        b.click("#containers-images button.pf-c-expandable-section__toggle")
+
+        b.wait_visible('#containers-images td[data-label="Image"]:contains("busybox:latest")')
+        b.click('#containers-images tbody tr:contains("busybox:latest") .ct-container-create')
+        b.wait_visible('div.pf-c-modal-box header:contains("Create container")')
+
+        b.set_input_text("#run-image-dialog-name", "healthy")
+
+        b.click("#pf-tab-2-create-image-dialog-tab-healthcheck")
+        b.set_input_text('#run-image-dialog-healthcheck-command', 'true')
+        b.set_input_text('#run-image-healthcheck-interval input', '325')
+        b.set_input_text('#run-image-healthcheck-timeout input', '35')
+        b.set_input_text('#run-image-healthcheck-start-period input', '5')
+        b.click('#run-image-healthcheck-retries button:nth-child(1)')
+        b.wait_val("#run-image-healthcheck-retries input", 2)
+        if auth:
+            b.assert_pixels('.pf-c-modal-box', "healthcheck-modal")
+        b.click('.pf-c-modal-box__footer #create-image-create-run-btn')
+
+        self.waitContainerRow("healthy")
+        b.click("#containers-images button.pf-c-expandable-section__toggle")
+
+        healthy_sha = self.execute(auth, "podman inspect --format '{{.Id}}' healthy").strip()
+        self.waitContainer(healthy_sha, auth, state='RunningHealthy')
+
+        self.toggleExpandedContainer("healthy")
+        b.click(".pf-m-expanded button:contains('Health check')")
+
+        b.wait_in_text('#container-details-healthcheck dt:contains("Command") + dd', 'true')
+        b.wait_in_text('#container-details-healthcheck dt:contains("Interval") + dd', '325 seconds')
+        b.wait_in_text('#container-details-healthcheck dt:contains("Retries") + dd', '2')
+        b.wait_in_text('#container-details-healthcheck dt:contains("Timeout") + dd', '35 seconds')
+        b.wait_in_text('#container-details-healthcheck dt:contains("Start period") + dd', '5 seconds')
+        b.wait_not_present('#container-details-healthcheck dt:contains("Failing streak")')
+
+        self.assertEqual(self.execute(auth, "podman inspect --format '{{.Config.Healthcheck}}' healthy").strip(), "{[true] 5s 5m25s 35s 2}")
+
+        b.wait_in_text(".ct-listing-panel-body tbody tr", "Passed health run")
+        b.wait_not_present(".ct-listing-panel-body tbody tr:nth-child(2)")
+        b.wait_visible(".ct-listing-panel-body tbody:nth-child(2) svg.green")
+
+        # Trigger run manually
+        self.performContainerAction("healthy", "Run health check")
+        b.wait_visible(".ct-listing-panel-body tbody tr:nth-child(2)")
+
+        self.toggleExpandedContainer("healthy")
+
+        self.execute(auth, "podman run --name sick -dt --health-cmd false --health-interval 5s busybox")
+        self.waitContainerRow("sick")
+        unhealthy_sha = self.execute(auth, "podman inspect --format '{{.Id}}' sick").strip()
+        self.waitContainer(unhealthy_sha, auth, state='RunningUnhealthy')
+        # Unhealthy should be first
+        expected_ws = ""
+        if auth and self.machine.ostree_image:
+            expected_ws = "ws"
+        b.wait_collected_text("#containers-containers .container-name", "sickhealthy" + expected_ws)
+
+        self.toggleExpandedContainer("sick")
+        b.click(".pf-m-expanded button:contains('Health check')")
+        b.wait_visible(".pf-m-expanded .ct-listing-panel-body tbody tr:nth-child(1)")
+        b.wait_visible(".pf-m-expanded .ct-listing-panel-body tbody tr:nth-child(4)")
+        b.wait_visible(".pf-m-expanded .ct-listing-panel-body tbody tr:nth-child(2) svg.red")
+        b.wait_visible('#container-details-healthcheck dt:contains("Failing streak")')
+        self.assertGreater(int(b.text('#container-details-healthcheck dt:contains("Failing streak") + dd')), 3)
+        if auth:
+            b.wait_js_func("ph_count_check", ".pf-m-expanded table[aria-label=Logs] tbody tr", 5)
+            b.assert_pixels(".pf-m-expanded .pf-c-table__expandable-row-content",
+                            "healthcheck-details",
+                            ignore=["thead", "#container-details-healthcheck dt:contains('Failing streak') + dd",
+                                    "td[data-label='Started at']"])
+
+    @testlib.skipImage("Ubuntu-stable does not get health check run signals", "ubuntu-stable")
+    def testHealthcheckSystem(self):
+        self._testHealthcheck(True)
+
+    @testlib.skipImage("Ubuntu-stable does not get health check run signals", "ubuntu-stable")
+    def testHealthcheckUser(self):
+        self._testHealthcheck(False)
 
     @testlib.skipImage("podman-restart not available in debian/ubuntu", *DISTROS_WITHOUT_PODMAN_RESTART)
     def testPodmanRestartEnabled(self):


### PR DESCRIPTION
Fixes #345
One known limitation is reported in https://github.com/containers/podman/issues/13083

TODO - if image has healthcheck defined, prefill the values

---

# Support for health checks

It is now possible to set up, inspect and trigger health checks for container. Also the most recent history as well as overall status are presented.

![Screenshot from 2022-02-04 10-41-59](https://user-images.githubusercontent.com/12330670/152507040-c46a8354-9c2d-43be-977a-f603c8eca0db.png)

