### PR TITLE
Merge image-customize calls for rawhide scenario

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,14 +133,13 @@ endif
 endif
 
 ifeq ($(TEST_SCENARIO),rawhide)
-# needs to run as a separate command, as --run-command is executed before --script
-RAWHIDE=bots/image-customize -v --run-command 'dnf update -y --releasever=rawhide podman conmon crun containernetworking-plugins containers-common kernel' $(TEST_OS)
+UPGRADES=--run-command 'dnf update -y --releasever=rawhide podman conmon crun containernetworking-plugins containers-common kernel'
 endif
 
 # build a VM with locally built rpm/dsc installed
 $(VM_IMAGE): $(VM_DEP) bots
 	rm -f $(VM_IMAGE) $(VM_IMAGE).qcow2
-	bots/image-customize -v $(VM_PACKAGE) -s $(CURDIR)/test/vm.install $(TEST_OS)
+	bots/image-customize -v $(VM_PACKAGE) -s $(CURDIR)/test/vm.install $(UPGRADES) $(TEST_OS)
 	$(RAWHIDE)
 
 # convenience target for the above


### PR DESCRIPTION
With image-customize now processing its arguments in the given order
[1], we can do the rawhide upgrade and the other VM preparation in one
step. This saves a now unnecessary shutdown/reboot.

[1] https://github.com/cockpit-project/bots/commit/78e199f600f