### PR TITLE
Images: Improve mobile layout

### DIFF
--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import {
     Button,
-    Card, CardBody, CardHeader, CardTitle, CardActions, CardFooter,
+    Card, CardBody, CardHeader, CardFooter,
     Dropdown, DropdownItem,
-    Flex,
+    Flex, FlexItem,
     ExpandableSection,
     KebabToggle,
     Text, TextVariants
@@ -23,6 +23,7 @@ import * as client from './client.js';
 import * as utils from './util.js';
 
 import './Images.css';
+import '@patternfly/react-styles/css/utilities/Sizing/sizing.css';
 
 const _ = cockpit.gettext;
 
@@ -119,7 +120,7 @@ class Images extends React.Component {
         const { title: usedByText, count: usedByCount } = this.getUsedByText(image);
 
         const columns = [
-            { title: utils.image_name(image), header: true },
+            { title: utils.image_name(image), header: true, props: { modifier: "breakWord" } },
             { title: image.isSystem ? _("system") : <div><span className="ct-grey-text">{_("user:")} </span>{this.props.user}</div> },
             utils.localize_time(image.Created),
             utils.truncate_id(image.Id),
@@ -131,7 +132,7 @@ class Images extends React.Component {
                                      userServiceAvailable={this.props.userServiceAvailable}
                                      systemServiceAvailable={this.props.systemServiceAvailable}
                                      podmanRestartAvailable={this.props.podmanRestartAvailable} />,
-                props: { className: 'pf-c-table__action' }
+                props: { className: 'pf-c-table__action content-action' }
             },
         ];
 
@@ -163,8 +164,7 @@ class Images extends React.Component {
             _("Created"),
             _("ID"),
             _("Disk space"),
-            _("Used by"),
-            ''
+            _("Used by")
         ];
         let emptyCaption = _("No images");
         if (this.props.images === null)
@@ -263,17 +263,19 @@ class Images extends React.Component {
         return (
             <Card id="containers-images" key="images" className="containers-images">
                 <CardHeader>
-                    <CardTitle>
-                        <Flex>
-                            <Text className="images-title" component={TextVariants.h3}>{_("Images")}</Text>
-                            {imageTitleStats}
-                        </Flex>
-                    </CardTitle>
-                    <CardActions>
-                        <ImageOverActions handleDownloadNewImage={this.onOpenNewImagesDialog}
-                                          handlePruneUsedImages={this.onOpenPruneUnusedImagesDialog}
-                                          unusedImages={unusedImages} />
-                    </CardActions>
+                    <Flex flexWrap={{ default: 'nowrap' }} className="pf-u-w-100">
+                        <FlexItem grow={{ default: 'grow' }}>
+                            <Flex>
+                                <Text className="images-title" component={TextVariants.h3}>{_("Images")}</Text>
+                                <Flex>{imageTitleStats}</Flex>
+                            </Flex>
+                        </FlexItem>
+                        <FlexItem>
+                            <ImageOverActions handleDownloadNewImage={this.onOpenNewImagesDialog}
+                                              handlePruneUsedImages={this.onOpenPruneUnusedImagesDialog}
+                                              unusedImages={unusedImages} />
+                        </FlexItem>
+                    </Flex>
                 </CardHeader>
                 <CardBody>
                     {filtered.length
@@ -377,7 +379,7 @@ const ImageActions = ({ image, onAddNotification, registries, selinuxAvailable, 
 
     const runImage = (
         <Button key={image.Id + "create"}
-                className="ct-container-create"
+                className="ct-container-create show-only-when-wide"
                 variant='secondary'
                 onClick={ e => {
                     e.stopPropagation();
@@ -393,7 +395,14 @@ const ImageActions = ({ image, onAddNotification, registries, selinuxAvailable, 
         <Dropdown toggle={<KebabToggle onToggle={() => setIsActionsKebabOpen(!isActionsKebabOpen)} />}
                   isOpen={isActionsKebabOpen}
                   isPlain
+                  position="right"
                   dropdownItems={[
+                      <DropdownItem key={image.Id + "create-menu"}
+                                    component="button"
+                                    className="show-only-when-narrow"
+                                    onClick={() => setShowImageRunModal(true)}>
+                          {_("Create container")}
+                      </DropdownItem>,
                       <DropdownItem key={image.Id + "delete"}
                                     component="button"
                                     className="pf-m-danger btn-delete"
@@ -404,7 +413,7 @@ const ImageActions = ({ image, onAddNotification, registries, selinuxAvailable, 
     );
 
     return (
-        <Flex flexWrap={{ default: 'nowrap' }}>
+        <>
             {runImage}
             {extraActions}
             {showImageDeleteErrorModal &&
@@ -430,7 +439,7 @@ const ImageActions = ({ image, onAddNotification, registries, selinuxAvailable, 
                 image={image}
                 onAddNotification={onAddNotification}
             /> }
-        </Flex>
+        </>
     );
 };
 

--- a/src/podman.scss
+++ b/src/podman.scss
@@ -1,5 +1,6 @@
 @use "ct-card.scss";
 @use "page.scss";
+@import "global-variables";
 // For pf-line-clamp
 @import "@patternfly/patternfly/sass-utilities/mixins.scss";
 
@@ -79,4 +80,21 @@
 .container-section.pf-m-plain tbody,
 .containers-images tbody {
     border: var(--pf-c-card--m-flat--BorderWidth) solid var(--pf-c-card--m-flat--BorderColor);
+}
+
+.content-action {
+    text-align: right;
+    white-space: nowrap !important;
+}
+
+@media ( max-width: $pf-global--breakpoint--md - 1 ) {
+    .show-only-when-wide {
+        display: none;
+    }
+}
+
+@media ( min-width: $pf-global--breakpoint--md ) {
+    .show-only-when-narrow {
+        display: none;
+    }
 }


### PR DESCRIPTION
- Don't use a Flex to group button and menu, this avoids some extra
  space between the button and the menu.

- Don't give the actions column a title, this avoids some extra space
  between the first field and the menu in mobile layout.

- Let the image name be broken at every character, this prevents the
  table from being wider than its container at certain widths.

- Move the "Create container" button into the menu in mobile layout.
  This is done by always having both button and menu entry in the DOM,
  and only showing one of them as appropriate.

- Take control over the card header layout, so that the actions stay
  in the top-right corner.  Also, the title stats stay together as
  long as possible.

Fixes: #864

New pixel test references: https://github.com/cockpit-project/pixel-test-reference/compare/8ae010f8744dc2eacef7f860459b4f3aa57ea0bc..e45318da3c227623af5062326fab086d87f7e9cd