### PR TITLE
Call the correct function on error

### DIFF
--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -511,7 +511,7 @@ export class ImageRunModal extends React.Component {
                         });
             })
                     .catch(ex => {
-                        this.props.onDownloadContainerFinished(createConfig);
+                        onDownloadContainerFinished(createConfig);
                         const error = cockpit.format(_("Failed to pull image $0"), tempImage.image);
                         this.props.onAddNotification({ type: 'danger', error, errorDetail: ex.reason });
                     });


### PR DESCRIPTION
In 7b2954196 we introduced the 'pull latest image' option which changed
the onDownloadContainerFinished function but the pullImage's catch
wasn't updated. Causing the download to stay forever when it fails and
no error message being shown.

Closes #914