### PR TITLE
Display error details for pulling the image

### DIFF
--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -513,7 +513,7 @@ export class ImageRunModal extends React.Component {
                     .catch(ex => {
                         onDownloadContainerFinished(createConfig);
                         const error = cockpit.format(_("Failed to pull image $0"), tempImage.image);
-                        this.props.onAddNotification({ type: 'danger', error, errorDetail: ex.reason });
+                        this.props.onAddNotification({ type: 'danger', error, errorDetail: ex.message });
                     });
         }
     }


### PR DESCRIPTION
The exception object has no reason member.

On aarch64 it now shows:

![image](https://user-images.githubusercontent.com/67428/153563930-4793047d-3c0d-4741-8ba0-6d3a72dce4e6.png)

Since podman does not have any error codes this is the best what we can show.