### PR TITLE
cockpituous: Add Fedora 36, drop 34

### DIFF
--- a/cockpituous-release
+++ b/cockpituous-release
@@ -18,10 +18,10 @@ job release-srpm -V
 cat ~/.fedora-password | kinit cockpit@FEDORAPROJECT.ORG
 # Do fedora builds for the tag, using tarball
 job release-koji rawhide
-job release-koji f34
 job release-koji f35
-job release-bodhi F34
+job release-koji f36
 job release-bodhi F35
+# job release-bodhi F36  # enable after 2022-02-22
 
 # These are likely the first of your release targets; but run them after Fedora uploads,
 # so that failures there will fail the release early, before publishing on GitHub


### PR DESCRIPTION
Fedora 36 got branched off and now needs its own koji builds. It does
not yet use bodhi. See
https://fedorapeople.org/groups/schedule/f-36/f-36-key-tasks.html

Drop Fedora 34, so that we keep the two latest releases, as usual.