### PR TITLE
test: Update pixel references for Chromium 96

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,13 +115,9 @@ rpm: $(TARFILE) $(SPEC)
 	rm -r "`pwd`/rpmbuild"
 	rm -r "`pwd`/output" "`pwd`/build"
 
-ifeq ($(TEST_SCENARIO),rawhide)
-UPGRADES=--run-command 'dnf update -y --releasever=rawhide podman conmon crun containernetworking-plugins containers-common kernel'
-endif
-
 # build a VM with locally built distro pkgs installed
 $(VM_IMAGE): $(TARFILE) packaging/debian/rules packaging/debian/control packaging/arch/PKGBUILD bots
-	bots/image-customize --verbose --fresh --build $(TARFILE) --script $(CURDIR)/test/vm.install $(UPGRADES) $(TEST_OS)
+	bots/image-customize --verbose --fresh --build $(TARFILE) --script $(CURDIR)/test/vm.install $(TEST_OS)
 
 # convenience target for the above
 vm: $(VM_IMAGE)


### PR DESCRIPTION
Our recent tasks container refresh updated Chromium from 94 to 96, which
changes the pixels a bit.

[pixel diffs](https://github.com/cockpit-project/pixel-test-reference/compare/44585b3d10aebacd9d543c3efbb72e4d77102e32..a82718624031fc91eec3ddf0f90b110f29d38a0e)