### PR TITLE
tmt: Put back absolute log path for older tmt versions

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -10,7 +10,7 @@ else
 fi
 
 # https://tmt.readthedocs.io/en/stable/overview.html#variables
-LOGS="${TMT_TEST_DATA:-logs}"
+LOGS="${TMT_TEST_DATA:-$(pwd)/logs}"
 mkdir -p "$LOGS"
 chmod a+w "$LOGS"
 


### PR DESCRIPTION
Commit e626b72074f accidentally dropped setting `$LOGS` to an absolute
path if `$TMT_TEST_DATA` is not set. This causes the test to fail with

    test/browser/run-test.sh: line 75: logs/exitcode: No such file or directory

when running against older `tmt` versions. This is the case on the
internal RHEL testing farm, but not on the public Fedora/CentOS one
(which is why we didn't see this in packit).