### PR TITLE
Reformat code for eslint-plugin-react 7.29.x

### DIFF
--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -797,14 +797,16 @@ export class ImageRunModal extends React.Component {
                 {registries.map(registry => {
                     const index = this.truncateRegistryDomain(registry);
                     return (
-                        <ToggleGroupItem text={index} key={index} isSelected={this.state.searchByRegistry == index} onChange={(_, ev) => {
-                            ev.stopPropagation();
-                            this.setState({ searchByRegistry: index });
-                        }}
-                        onTouchStart={ev => {
-                            ev.stopPropagation();
-                        }}
-                        />);
+                        <ToggleGroupItem
+                            text={index} key={index}
+                            isSelected={ this.state.searchByRegistry == index }
+                            onChange={ (_, ev) => {
+                                ev.stopPropagation();
+                                this.setState({ searchByRegistry: index });
+                            } }
+                            onTouchStart={ ev => ev.stopPropagation() }
+                        />
+                    );
                 })}
             </ToggleGroup>
         );

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -596,7 +596,8 @@ class Application extends React.Component {
                             </Button>
                         </EmptyStateSecondaryActions>
                     }
-                </EmptyState>);
+                </EmptyState>
+            );
         }
 
         let imageContainerList = {};


### PR DESCRIPTION
The expected indentation of self-closing tags and closing parentheses
became stricter with current eslint-plugin-react versions.

---

See e.g. [this failure](https://logs.cockpit-project.org/logs/pull-3009-20220227-024922-aa8d8db8-ubuntu-stable-cockpit-project-cockpit-podman/log.html) in https://github.com/cockpit-project/bots/pull/3009 or https://github.com/cockpit-project/bots/pull/2960