### PR TITLE
packit: build SRPM in Copr

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -12,6 +12,9 @@ actions:
     # dummy LICENSE.txt, as terser did not run
     - touch dist/index.js.LICENSE.txt.gz
     - make dist
+srpm_build_deps:
+  - make
+  - npm
 jobs:
   - job: tests
     trigger: pull_request


### PR DESCRIPTION
and be able to specify the precise list of deps needed to create the
SRPM

Details: https://packit.dev/posts/copr-srpms/

~~The current implementation requires the key `srpm_build_deps` to be set and since cockpit-podman doesn't require any extra, the value is an empty list.~~ make is needed :)