### PR TITLE
Port AppStream i18n from starter-kit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/images/
 *.pot
 POTFILES*
 tmp/
+/po/LINGUAS

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ export TEST_OS
 TARFILE=cockpit-$(PACKAGE_NAME)-$(VERSION).tar.xz
 NODE_CACHE=cockpit-$(PACKAGE_NAME)-node-$(VERSION).tar.xz
 SPEC=$(RPM_NAME).spec
+APPSTREAMFILE=org.cockpit-project.$(PACKAGE_NAME).metainfo.xml
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check if/when npm install ran
 NODE_MODULES_TEST=package-lock.json
@@ -42,7 +43,7 @@ po/$(PACKAGE_NAME).html.pot: $(NODE_MODULES_TEST)
 po/$(PACKAGE_NAME).manifest.pot: $(NODE_MODULES_TEST)
 	po/manifest2po src/manifest.json -o $@
 
-po/$(PACKAGE_NAME).metainfo.pot: org.cockpit-project.$(PACKAGE_NAME).metainfo.xml
+po/$(PACKAGE_NAME).metainfo.pot: $(APPSTREAMFILE)
 	xgettext --default-domain=$(PACKAGE_NAME) --output=$@ $<
 
 po/$(PACKAGE_NAME).pot: po/$(PACKAGE_NAME).html.pot po/$(PACKAGE_NAME).js.pot po/$(PACKAGE_NAME).manifest.pot po/$(PACKAGE_NAME).metainfo.pot
@@ -86,8 +87,8 @@ install: $(WEBPACK_TEST) po/LINGUAS
 	cp -r dist/* $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)
 	mkdir -p $(DESTDIR)/usr/share/metainfo/
 	msgfmt --xml -d po \
-		--template org.cockpit-project.$(PACKAGE_NAME).metainfo.xml \
-		-o $(DESTDIR)/usr/share/metainfo/org.cockpit-project.$(PACKAGE_NAME).metainfo.xml
+		--template $(APPSTREAMFILE) \
+		-o $(DESTDIR)/usr/share/metainfo/$(APPSTREAMFILE)
 
 # this requires a built source tree and avoids having to install anything system-wide
 devel-install: $(WEBPACK_TEST)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ LINGUAS=$(basename $(notdir $(wildcard po/*.po)))
 
 po/$(PACKAGE_NAME).js.pot:
 	xgettext --default-domain=cockpit --output=$@ --language=C --keyword= \
-		--keyword=_:1,1t --keyword=_:1c,2,1t --keyword=C_:1c,2 \
+		--keyword=_:1,1t --keyword=_:1c,2,2t --keyword=C_:1c,2 \
 		--keyword=N_ --keyword=NC_:1c,2 \
 		--keyword=gettext:1,1t --keyword=gettext:1c,2,2t \
 		--keyword=ngettext:1,2,3t --keyword=ngettext:1c,2,3,4t \

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ all: $(WEBPACK_TEST)
 LINGUAS=$(basename $(notdir $(wildcard po/*.po)))
 
 po/$(PACKAGE_NAME).js.pot:
-	xgettext --default-domain=cockpit --output=$@ --language=C --keyword= \
+	xgettext --default-domain=$(PACKAGE_NAME) --output=$@ --language=C --keyword= \
 		--keyword=_:1,1t --keyword=_:1c,2,2t --keyword=C_:1c,2 \
 		--keyword=N_ --keyword=NC_:1c,2 \
 		--keyword=gettext:1,1t --keyword=gettext:1c,2,2t \

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,10 @@ po/$(PACKAGE_NAME).html.pot: $(NODE_MODULES_TEST)
 po/$(PACKAGE_NAME).manifest.pot: $(NODE_MODULES_TEST)
 	po/manifest2po src/manifest.json -o $@
 
-po/$(PACKAGE_NAME).pot: po/$(PACKAGE_NAME).html.pot po/$(PACKAGE_NAME).js.pot po/$(PACKAGE_NAME).manifest.pot
+po/$(PACKAGE_NAME).metainfo.pot: org.cockpit-project.$(PACKAGE_NAME).metainfo.xml
+	xgettext --default-domain=$(PACKAGE_NAME) --output=$@ $<
+
+po/$(PACKAGE_NAME).pot: po/$(PACKAGE_NAME).html.pot po/$(PACKAGE_NAME).js.pot po/$(PACKAGE_NAME).manifest.pot po/$(PACKAGE_NAME).metainfo.pot
 	msgcat --sort-output --output-file=$@ $^
 
 #

--- a/packaging/cockpit-podman.spec.in
+++ b/packaging/cockpit-podman.spec.in
@@ -26,6 +26,10 @@ Source0:        https://github.com/cockpit-project/%{name}/releases/download/%{v
 BuildArch:      noarch
 BuildRequires:  libappstream-glib
 BuildRequires:  make
+BuildRequires: gettext
+%if 0%{?rhel} && 0%{?rhel} <= 8
+BuildRequires: libappstream-glib-devel
+%endif
 
 Requires:       cockpit-bridge >= 138
 Requires:       podman >= 2.0.4

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -22,7 +22,7 @@ dnf install --disablerepo=fedora-cisco-openh264 -y --setopt=install_weak_deps=Fa
 dnf update -y podman crun conmon
 
 # Show critical package versions
-rpm -q runc crun podman criu kernel-core selinux-policy || true
+rpm -q runc crun podman criu kernel-core selinux-policy cockpit-podman cockpit-bridge || true
 
 # create user account for logging in
 if ! id admin 2>/dev/null; then


### PR DESCRIPTION
Tested by `make update-po`, adding German translations locally, `make install DESTDIR=/tmp/x` and inspecting /tmp/x/usr/share/metainfo/org.cockpit-project.podman.metainfo.xml . This works fine.

After that lands, and the next POT refresh, I'm happy to add the translations to weblate.