### PR TITLE
Right align some columns

### DIFF
--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -378,9 +378,9 @@ class Containers extends React.Component {
         const containerState = container.State.charAt(0).toUpperCase() + container.State.slice(1);
         const columns = [
             { title: info_block },
-            { title: container.isSystem ? _("system") : <div><span className="ct-grey-text">{_("user:")} </span>{this.props.user}</div>, props: { modifier: "nowrap" } },
-            { title: proc, props: { modifier: "nowrap" } },
-            { title: mem, props: { modifier: "nowrap" } },
+            { title: container.isSystem ? _("system") : <div><span className="ct-grey-text">{_("user:")} </span>{this.props.user}</div>, props: { modifier: "nowrap", style: { "text-align": "right" } } },
+            { title: proc, props: { modifier: "nowrap", style: { "text-align": "right" } } },
+            { title: mem, props: { modifier: "nowrap", style: { "text-align": "right" } } },
             { title: <Badge isRead className={containerStateClass}>{_(containerState)}</Badge> }, // States are defined in util.js
         ];
 

--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -121,10 +121,10 @@ class Images extends React.Component {
 
         const columns = [
             { title: utils.image_name(image), header: true, props: { modifier: "breakWord" } },
-            { title: image.isSystem ? _("system") : <div><span className="ct-grey-text">{_("user:")} </span>{this.props.user}</div>, props: { modifier: "nowrap" } },
-            utils.localize_time(image.Created),
+            { title: image.isSystem ? _("system") : <div><span className="ct-grey-text">{_("user:")} </span>{this.props.user}</div>, props: { modifier: "nowrap", style: { "text-align": "right" } } },
+            { title: utils.localize_time(image.Created), props: { style: { "text-align": "right" } } },
             utils.truncate_id(image.Id),
-            { title: cockpit.format_bytes(image.Size, 1000), props: { modifier: "nowrap" } },
+            { title: cockpit.format_bytes(image.Size, 1000), props: { modifier: "nowrap", style: { "text-align": "right" } } },
             { title: <span className={usedByCount === 0 ? "ct-grey-text" : ""}>{usedByText}</span>, props: { modifier: "nowrap" } },
             {
                 title: <ImageActions image={image} onAddNotification={this.props.onAddNotification} selinuxAvailable={this.props.selinuxAvailable}


### PR DESCRIPTION
It behaves the same as #930 but does not look great:
![Screenshot from 2022-03-17 07-29-53](https://user-images.githubusercontent.com/12330670/158750457-5ed7d6d0-4c68-430d-962a-9805d2d22225.png)

@garrett mentioned that columns should  constrain to their content. Not sure how to do that. By any chance, do you know if we use this right-alight and constraining anywhere else when using ListingTable?