### PR TITLE
Makefile: run tests fully offline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,15 +131,9 @@ rpm: $(TARFILE) $(SPEC)
 	rm -r "`pwd`/rpmbuild"
 	rm -r "`pwd`/output" "`pwd`/build"
 
-# fedora can be built offline; the rest does not pull podman containers in image-create yet
-NETWORK=--no-network
-ifeq (,$(findstring fedora,$(TEST_OS)))
-NETWORK=
-endif
-
 # build a VM with locally built distro pkgs installed
 $(VM_IMAGE): $(TARFILE) packaging/debian/rules packaging/debian/control packaging/arch/PKGBUILD bots
-	bots/image-customize --verbose --fresh $(NETWORK) --build $(TARFILE) --script $(CURDIR)/test/vm.install $(TEST_OS)
+	bots/image-customize --verbose --fresh --no-network --build $(TARFILE) --script $(CURDIR)/test/vm.install $(TEST_OS)
 
 # convenience target for the above
 vm: $(VM_IMAGE)

--- a/packit.yaml
+++ b/packit.yaml
@@ -20,5 +20,7 @@ jobs:
     trigger: pull_request
     metadata:
       targets:
-      - fedora-all
+      - fedora-35
+      - fedora-36
+      - fedora-development
       - centos-stream-9-x86_64

--- a/test/vm.install
+++ b/test/vm.install
@@ -32,11 +32,6 @@ if [ "$ID" = "fedora" ]; then
     # Remove extra images for containers tests
     podman rmi localhost/cockpit/base
     podman rmi registry.fedoraproject.org/fedora:"$VERSION_ID"
-else
-    podman rmi --all
-    podman pull quay.io/libpod/busybox
-    podman pull quay.io/libpod/alpine
-    podman pull quay.io/cockpit/registry:2
 fi
 
 # copy images for user podman tests; podman insists on user session


### PR DESCRIPTION
All our test images now pull the requires podman test images during
image creation.