### PR TITLE
cockpituous: Build in cockpit-preview COPR

### DIFF
--- a/cockpituous-release
+++ b/cockpituous-release
@@ -27,4 +27,4 @@ job release-bodhi F36
 # so that failures there will fail the release early, before publishing on GitHub
 
 job release-github
-job release-copr @cockpit/cockpit-podman
+job release-copr @cockpit/cockpit-preview


### PR DESCRIPTION
All our other projects release to that. For a user it does not make too
much sense to have each project in its own COPR. All Cockpit packages
have similar QA standards, after all.