### PR TITLE
Test fixes

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -53,6 +53,7 @@ class TestApplication(testlib.MachineCase):
 
         # HACK: sometimes podman leaks mounts
         self.addCleanup(m.execute, "findmnt --list -otarget | grep /var/lib/containers/. | xargs -r umount")
+        self.addCleanup(m.execute, "killall -9 podman || true")
         self.addCleanup(m.execute, "systemctl stop podman.service")
         self.addCleanup(m.execute, "podman rm --force --all")
         self.addCleanup(m.execute, "podman pod rm --force --all || true")
@@ -80,8 +81,6 @@ class TestApplication(testlib.MachineCase):
 
         # But disable it globally so that "systemctl --user disable" does what we expect
         m.execute("systemctl --global disable podman.socket")
-
-        self.addCleanup(m.execute, "killall -9 podman || true")
 
         self.allow_journal_messages("/run.*/podman/podman: couldn't connect.*")
         self.allow_journal_messages(".*/run.*/podman/podman.*Connection reset by peer")

--- a/test/check-application
+++ b/test/check-application
@@ -52,11 +52,13 @@ class TestApplication(testlib.MachineCase):
         self.restore_dir("/var/lib/containers", reboot_safe=True)
 
         # HACK: sometimes podman leaks mounts
-        self.addCleanup(m.execute, "findmnt --list -otarget | grep /var/lib/containers/. | xargs -r umount")
-        self.addCleanup(m.execute, "killall -9 podman || true")
-        self.addCleanup(m.execute, "systemctl stop podman.service")
-        self.addCleanup(m.execute, "podman rm --force --all")
-        self.addCleanup(m.execute, "podman pod rm --force --all || true")
+        self.addCleanup(m.execute, """set -eu
+            podman pod rm --force --all
+            podman rm --force --all
+            systemctl stop podman.service
+            killall -9 podman || true
+            findmnt --list -otarget | grep /var/lib/containers/. | xargs -r umount
+            """)
 
         # Create admin session
         m.execute("""

--- a/test/check-application
+++ b/test/check-application
@@ -55,8 +55,7 @@ class TestApplication(testlib.MachineCase):
         self.addCleanup(m.execute, """set -eu
             systemctl stop podman.service podman.socket
             systemctl reset-failed podman.service podman.socket
-            podman pod rm --force --all
-            podman rm --force --all
+            podman system reset --force
             killall -9 podman || true
             findmnt --list -otarget | grep /var/lib/containers/. | xargs -r umount
             """)

--- a/test/check-application
+++ b/test/check-application
@@ -53,9 +53,10 @@ class TestApplication(testlib.MachineCase):
 
         # HACK: sometimes podman leaks mounts
         self.addCleanup(m.execute, """set -eu
+            systemctl stop podman.service podman.socket
+            systemctl reset-failed podman.service podman.socket
             podman pod rm --force --all
             podman rm --force --all
-            systemctl stop podman.service
             killall -9 podman || true
             findmnt --list -otarget | grep /var/lib/containers/. | xargs -r umount
             """)

--- a/test/check-application
+++ b/test/check-application
@@ -51,11 +51,10 @@ class TestApplication(testlib.MachineCase):
         # backup/restore pristine podman state, so that tests can run on existing testbeds
         self.restore_dir("/var/lib/containers", reboot_safe=True)
 
-        self.addCleanup(m.execute, "systemctl stop podman.service")
-
         # HACK: sometimes podman leaks mounts
-        self.addCleanup(m.execute, "podman rm --force --all && "
-                        "findmnt --list -otarget | grep /var/lib/containers/. | xargs -r umount || true")
+        self.addCleanup(m.execute, "findmnt --list -otarget | grep /var/lib/containers/. | xargs -r umount")
+        self.addCleanup(m.execute, "systemctl stop podman.service")
+        self.addCleanup(m.execute, "podman rm --force --all")
         self.addCleanup(m.execute, "podman pod rm --force --all || true")
 
         # Create admin session


### PR DESCRIPTION
Should address [this failure](https://logs.cockpit-project.org/logs/pull-3227-20220411-220701-f3ad8f1b-fedora-36-cockpit-project-cockpit-podman/log.html) and similar ones (see long test failure history below). Blocking image refresh in https://github.com/cockpit-project/bots/pull/3227