### PR TITLE
test: Bump Cockpit test API to 267, use --track-naughties option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ codecheck:
 
 # run the browser integration tests; skip check for SELinux denials
 check: $(NODE_MODULES_TEST) $(VM_IMAGE) test/common test/reference
-	TEST_AUDIT_NO_SELINUX=1 test/common/run-tests
+	TEST_AUDIT_NO_SELINUX=1 test/common/run-tests ${RUN_TESTS_OPTIONS}
 
 # checkout Cockpit's bots for standard test VM images and API to launch them
 # must be from main, as only that has current and existing images; but testvm.py API is stable
@@ -160,7 +160,7 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 6e65510bc9dcf571d75fa592ed7b7c4d7cd3fc48; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 267; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 

--- a/test/run
+++ b/test/run
@@ -4,6 +4,8 @@
 
 set -eu
 
+export RUN_TESTS_OPTIONS=--track-naughties
+
 make codecheck
 make check
 make po/podman.pot


### PR DESCRIPTION
run-tests recently got a new `--track-naughties` option [1] to explicitly
enable updating known issues on GitHub. Enable it for CI runs, and leave
it disabled for local runs and PackIt, as in these cases we don't want
to try and talk to GitHub.

[1] https://github.com/cockpit-project/cockpit/commit/7ef88e80ce613c

Cherry-picked from starter-kit commit a937b82cd2dc.