### PR TITLE
container rename support

### DIFF
--- a/src/ContainerRenameModal.jsx
+++ b/src/ContainerRenameModal.jsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import {
+    Button,
+    Form, FormGroup,
+    Modal, TextInput
+} from '@patternfly/react-core';
+import cockpit from 'cockpit';
+
+import * as client from './client.js';
+import { ErrorNotification } from './Notification.jsx';
+
+const _ = cockpit.gettext;
+
+const ContainerRenameModal = ({ container, version, onHide, updateContainerAfterEvent }) => {
+    const [name, setName] = useState(container.Names[0]);
+    const [nameError, setNameError] = useState(null);
+    const [dialogError, setDialogError] = useState(null);
+    const [dialogErrorDetail, setDialogErrorDetail] = useState(null);
+
+    const handleInputChange = (targetName, value) => {
+        if (targetName === "name") {
+            setName(value);
+            if (value === "") {
+                setNameError(_("Container name is required."));
+            } else if (/^[a-zA-Z0-9][a-zA-Z0-9_\\.-]*$/.test(value)) {
+                setNameError(null);
+            } else {
+                setNameError(_("Invalid characters. Name can only contain letters, numbers, and certain punctuation (_ . -)."));
+            }
+        }
+    };
+
+    const handleRename = () => {
+        if (!name) {
+            setNameError(_("Container name is required."));
+            return;
+        }
+
+        setNameError(null);
+        setDialogError(null);
+        client.renameContainer(container.isSystem, container.Id, { name })
+                .then(() => {
+                    onHide();
+                    // HACK: This is a workaround for missing API rename event in Podman versions less than 4.1.
+                    if (version.localeCompare("4.1", undefined, { numeric: true, sensitivity: 'base' }) < 0) {
+                        updateContainerAfterEvent(container.Id, container.isSystem);
+                    }
+                })
+                .catch(ex => {
+                    setDialogError(cockpit.format(_("Failed to rename container $0"), container.Names[0]));
+                    setDialogErrorDetail(cockpit.format("$0: $1", ex.message, ex.reason));
+                });
+    };
+
+    const handleKeyPress = (event) => {
+        if (event.key === "Enter") {
+            event.preventDefault();
+            handleRename(name);
+        }
+    };
+
+    const renameContent =
+        <Form isHorizontal>
+            <FormGroup fieldId="rename-dialog-container-name" label={_("New container name")}
+                    validated={nameError ? "error" : "default"}
+                    helperTextInvalid={nameError}>
+                <TextInput id="rename-dialog-container-name"
+                        value={name}
+                        validated={nameError ? "error" : "default"}
+                        type="text"
+                        aria-label={nameError}
+                        onChange={value => handleInputChange("name", value)} />
+            </FormGroup>
+        </Form>;
+
+    return (
+        <Modal isOpen
+            position="top" variant="medium"
+            onClose={onHide}
+            onKeyPress={handleKeyPress}
+            title={cockpit.format(_("Rename container $0"), container.Names[0])}
+            footer={<>
+                <Button variant="primary"
+                        className="btn-ctr-rename"
+                        id="btn-rename-dialog-container"
+                        isDisabled={nameError}
+                        onClick={handleRename}>
+                    {_("Rename")}
+                </Button>
+                <Button variant="link"
+                        className="btn-ctr-cancel-commit"
+                        onClick={onHide}>
+                    {_("Cancel")}
+                </Button>
+            </>}
+        >
+            {dialogError && <ErrorNotification errorMessage={dialogError} errorDetail={dialogErrorDetail} onDismiss={() => setDialogError(null)} />}
+            {renameContent}
+        </Modal>
+    );
+};
+
+export default ContainerRenameModal;

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -367,6 +367,7 @@ class Application extends React.Component {
         case 'sync':
         case 'unmount':
         case 'unpause':
+        case 'rename': // rename event is available starting podman v4.1; until then the container does not get refreshed after renaming
             this.updateContainerAfterEvent(event.Actor.ID, system);
             break;
         case 'remove':
@@ -673,6 +674,7 @@ class Application extends React.Component {
                 registries={this.state.registries}
                 selinuxAvailable={this.state.selinuxAvailable}
                 podmanRestartAvailable={this.state.podmanRestartAvailable}
+                updateContainerAfterEvent={this.updateContainerAfterEvent}
             />;
 
         const notificationList = (

--- a/src/client.js
+++ b/src/client.js
@@ -81,6 +81,8 @@ export function inspectContainer(system, id) {
 
 export const delContainer = (system, id, force) => podmanCall("libpod/containers/" + id, "DELETE", { force }, system);
 
+export const renameContainer = (system, id, config) => podmanCall("libpod/containers/" + id + "/rename", "POST", config, system);
+
 export function createContainer(system, config) {
     return new Promise((resolve, reject) => {
         podmanCall("libpod/containers/create", "POST", {}, system, JSON.stringify(config))

--- a/test/check-application
+++ b/test/check-application
@@ -1949,6 +1949,36 @@ class TestApplication(testlib.MachineCase):
         self.performContainerAction(container_name, "Resume")
         b.wait(lambda: self.getContainerAttr(container_name, "State") == "Running")
 
+    def testRenameContainerSystem(self):
+        self._testRenameContainer(True)
+
+    def testRenameContainerUser(self):
+        self._testRenameContainer(False)
+
+    def _testRenameContainer(self, auth):
+        b = self.browser
+        container_name = "rename"
+        container_name_new = "rename-new"
+
+        self.execute(auth, f"podman container create -t --name {container_name} quay.io/libpod/busybox:latest")
+        self.login(auth)
+
+        self.filter_containers('all')
+
+        self.waitContainerRow(container_name)
+        self.toggleExpandedContainer(container_name)
+        self.performContainerAction(container_name, "Rename")
+
+        # the container name should be in the "Rename container" header
+        b.wait_in_text("#pf-modal-part-1", container_name)
+
+        b.set_input_text("#rename-dialog-container-name", container_name_new)
+        b.click('#btn-rename-dialog-container')
+        b.wait_not_present("#rename-dialog-container-name")
+
+        self.execute(auth, f"podman inspect --format '{{{{.Id}}}}' {container_name_new}").strip()
+        self.waitContainerRow(container_name_new)
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
Allow to rename a container, if it is not running or paused.

There is an issue with container not being refreshed after renamed, as no rename event is fired. This should be fixed in podman v4.1 according to https://github.com/containers/podman/issues/13919