### PR TITLE
Bump cockpit's lib and test API to 268.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 267; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 268.1; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 
@@ -170,7 +170,7 @@ test/reference: test/common
 # checkout Cockpit's PF/React/build library; again this has no API stability guarantee, so check out a stable tag
 $(LIB_TEST):
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 84598562813090b041e0a2eba09a84ac5998d762; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 268.1; \
 	    git checkout --force FETCH_HEAD -- pkg/lib; \
 	    git reset -- pkg/lib'
 	mv pkg/lib src/ && rmdir -p pkg

--- a/test/vm.install
+++ b/test/vm.install
@@ -17,8 +17,6 @@ if grep -q ID.*debian /usr/lib/os-release; then
     systemctl disable tuned
 fi
 
-systemctl enable cockpit.socket
-
 # don't force https:// (self-signed cert)
 printf "[WebService]\\nAllowUnencrypted=true\\n" > /etc/cockpit/cockpit.conf
 


### PR DESCRIPTION
In particular, this will lower the default browser wait timeout from 60
to 15 seconds [1].
    
[1] https://github.com/cockpit-project/cockpit/pull/17192
