### PR TITLE
packit: Use upstream tarball for release COPR build

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -29,3 +29,10 @@ jobs:
       - fedora-development
       - centos-stream-8-x86_64
       - centos-stream-9-x86_64
+    actions:
+      post-upstream-clone: make cockpit-podman.spec
+      # HACK: tarball for releases (copr_build, koji, etc.), copying spec's Source0; this
+      # really should be the default, see https://github.com/packit/packit-service/issues/1505
+      create-archive:
+        - sh -exc "curl -L -O https://github.com/cockpit-project/cockpit-podman/releases/download/${PACKIT_PROJECT_VERSION}/${PACKIT_PROJECT_NAME_VERSION}.tar.xz"
+        - sh -exc "ls ${PACKIT_PROJECT_NAME_VERSION}.tar.xz"


### PR DESCRIPTION
Current packit defaults to runing the `create-archive:` action for
release copr_builds. It should rather behave like `propose_downstream:`
and download the official release tarball from the spec's `Source0:`, as
this is conceptually much closer to releasing to Fedora than building a
temporary COPR for a PR.

This is currently being discussed in
https://github.com/packit/packit-service/issues/1505 , and this is the
recommended workaround until this becomes the default.

---

I tested this on my [fork](https://github.com/martinpitt/cockpit-podman), with an [extra debug commit](https://github.com/martinpitt/cockpit-podman/commit/0e54ce506aefa6bf9125dff1896074ab3470127e) which would divert to [my own copr](https://copr.fedorainfracloud.org/coprs/martinpitt/test-fixes). I made a [47.5 release](https://github.com/martinpitt/cockpit-podman/releases/tag/47.5) and this resulted in a [COPR release build](https://copr.fedorainfracloud.org/coprs/martinpitt/test-fixes/build/4420582/) with the expected upstream tarball instead of building it by itself:

```
❱❱❱ curl -L https://github.com/martinpitt/cockpit-podman/releases/download/47.5/cockpit-podman-47.5.tar.xz | sha512sum
e45db8a184b7134e62de5d19f6cb800067210a5c3478f383696d1dff7e500a80df6d773531c6b4b008c14dcb7d9c78e00dafa2a3511526b7bdf11478ae785cb2  -

❱❱❱ curl -O -L https://download.copr.fedorainfracloud.org/results/martinpitt/test-fixes/centos-stream-9-x86_64/04420582-cockpit-podman/cockpit-podman-47.5-1.el9.src.rpm

❱❱❱ rpm2cpio cockpit-podman-47.5-1.el9.src.rpm  | cpio -i --to-stdout cockpit-podman-47.5.tar.xz | sha512sum
e45db8a184b7134e62de5d19f6cb800067210a5c3478f383696d1dff7e500a80df6d773531c6b4b008c14dcb7d9c78e00dafa2a3511526b7bdf11478ae785cb2  -
```

Once landed, I will apply this to our other projects.

Many thanks to @TomasTomecek for his guidance!