### PR TITLE
images: Do not danger-ify disabled menu items

### DIFF
--- a/src/Images.css
+++ b/src/Images.css
@@ -4,7 +4,7 @@
 }
 
 /* Danger dropdown items should be red */
-.pf-c-dropdown__menu-item.pf-m-danger {
+.pf-c-dropdown__menu-item.pf-m-danger:not(.pf-m-disabled):not(.pf-m-aria-disabled) {
     color: var(--pf-global--danger-color--200);
 }
 


### PR DESCRIPTION
When I tried to prune images, the mouse didn't change to make it look clickable and it didn't work as expected. It turned out there were no images to prune, so we should not restyle the color to a danger state when it's disabled.

I have it skip recoloring menu items that are either pf-m-disabled and/or using the PF aria disabling class.