### PR TITLE
Support url parameters for filtering

### DIFF
--- a/src/ContainerHeader.jsx
+++ b/src/ContainerHeader.jsx
@@ -6,60 +6,33 @@ import {
 } from '@patternfly/react-core';
 const _ = cockpit.gettext;
 
-class ContainerHeader extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            owner: 'all',
-            filterText: ''
-        };
-        this.handleFilterTextChange = this.handleFilterTextChange.bind(this);
-        this.handleOwnerChange = this.handleOwnerChange.bind(this);
-    }
-
-    filterChanged() {
-        if (this.props.onFilterChanged)
-            this.props.onFilterChanged(this.state.filterText);
-    }
-
-    handleOwnerChange (value) {
-        this.setState({ owner: value });
-        if (this.props.onOwnerChanged) {
-            this.props.onOwnerChanged(value);
-        }
-    }
-
-    handleFilterTextChange(value) {
-        this.setState({ filterText: value }, this.filterChanged);
-    }
-
-    render() {
-        return (
-            <Toolbar className="pf-m-page-insets">
-                <ToolbarContent>
-                    { this.props.twoOwners &&
+const ContainerHeader = ({ user, twoOwners, ownerFilter, handleOwnerChanged, textFilter, handleFilterChanged }) => {
+    return (
+        <Toolbar className="pf-m-page-insets">
+            <ToolbarContent>
+                { twoOwners &&
                     <>
                         <ToolbarItem variant="label">
                             {_("Owner")}
                         </ToolbarItem>
                         <ToolbarItem>
-                            <FormSelect id="containers-containers-owner" value={this.state.owner} onChange={this.handleOwnerChange}>
-                                <FormSelectOption value='user' label={this.props.user} />
+                            <FormSelect id="containers-containers-owner" value={ownerFilter} onChange={handleOwnerChanged}>
+                                <FormSelectOption value='user' label={user} />
                                 <FormSelectOption value='system' label={_("System")} />
                                 <FormSelectOption value='all' label={_("All")} />
                             </FormSelect>
                         </ToolbarItem>
                     </>
-                    }
-                    <ToolbarItem>
-                        <TextInput id="containers-filter"
+                }
+                <ToolbarItem>
+                    <TextInput id="containers-filter"
                                    placeholder={_("Type to filter…")}
-                                   onChange={this.handleFilterTextChange} />
-                    </ToolbarItem>
-                </ToolbarContent>
-            </Toolbar>
-        );
-    }
-}
+                                   value={textFilter}
+                                   onChange={handleFilterChanged} />
+                </ToolbarItem>
+            </ToolbarContent>
+        </Toolbar>
+    );
+};
 
 export default ContainerHeader;

--- a/test/check-application
+++ b/test/check-application
@@ -445,17 +445,29 @@ class TestApplication(testlib.MachineCase):
             self.waitNumImages(6, True)
             self.waitNumContainers(2, True)
 
+            def verify_system():
+                self.waitNumImages(3, True)
+                b.wait_in_text("#containers-images", "system")
+                self.waitNumContainers(1, True)
+                b.wait_in_text("#containers-containers", "system")
+
             b.set_val("#containers-containers-owner", "system")
-            self.waitNumImages(3, True)
-            b.wait_in_text("#containers-images", "system")
-            self.waitNumContainers(1, True)
-            b.wait_in_text("#containers-containers", "system")
+            verify_system()
+            b.set_val("#containers-containers-owner", "all")
+            b.go("#/?owner=system")
+            verify_system()
+
+            def verify_user():
+                self.waitNumImages(3, False)
+                b.wait_in_text("#containers-images", "admin")
+                self.waitNumContainers(1, False)
+                b.wait_in_text("#containers-containers", "admin")
 
             b.set_val("#containers-containers-owner", "user")
-            self.waitNumImages(3, False)
-            b.wait_in_text("#containers-images", "admin")
-            self.waitNumContainers(1, False)
-            b.wait_in_text("#containers-containers", "admin")
+            verify_user()
+            b.set_val("#containers-containers-owner", "all")
+            b.go("#/?owner=user")
+            verify_user()
 
             b.set_val("#containers-containers-owner", "all")
             self.waitNumImages(6, True)
@@ -488,7 +500,7 @@ class TestApplication(testlib.MachineCase):
         b.wait_not_in_text("#containers-containers", "alpine:latest")
 
         # show all containers and check status
-        self.filter_containers('all')
+        b.go("#/?container=all")
 
         # exited alpine under everything list
         b.wait_visible("#containers-containers")
@@ -1634,18 +1646,26 @@ class TestApplication(testlib.MachineCase):
         self.waitContainer(sha, auth, state=NOT_RUNNING)
         b.click('#containers-containers tr:contains("busybox-without-publish")')
 
+        b.go("#/?name=tty")
+        self.check_containers(["busybox-with-tty"], ["busybox-without-publish"])
+        b.go("#/?name=busy")
+        self.check_containers(["busybox-with-tty", "busybox-without-publish"], [])
+
         b.set_input_text('#containers-filter', 'tty')
         self.check_containers(["busybox-with-tty"], ["busybox-without-publish"])
         self.check_images([], ["busybox:latest", "alpine:latest", "registry:2"])
         b.set_input_text('#containers-filter', 'busy')
+        b.wait_js_cond('window.location.hash === "#/?name=busy"')
         self.check_containers(["busybox-with-tty", "busybox-without-publish"], [])
         self.check_images(["busybox:latest"], ["alpine:latest", "registry:2"])
         b.set_input_text('#containers-filter', 'alpine')
+        b.wait_js_cond('window.location.hash === "#/?name=alpine"')
         self.check_containers([], ["busybox-with-tty", "busybox-without-publish"])
         self.check_images(["alpine:latest"], ["busybox:latest", "registry:2"])
         b.set_input_text('#containers-filter', '')
         self.check_containers(["busybox-with-tty", "busybox-without-publish"], [])
         self.check_images(["busybox:latest", "alpine:latest", "registry:2"], [])
+        b.wait_js_cond('window.location.hash === "#/"')
 
         b.set_val("#containers-containers-filter", "all")
         self.waitContainer(sha, auth, name='busybox-without-publish', image='busybox:latest', state=NOT_RUNNING)


### PR DESCRIPTION
Since Cockpit 269 the service top CPU usage lists podman containers and
links to the podman page without filtering on a specific container name.
For users it would be more useful if they could directly spot the
container, the newly introduced url parameters can filter based on owner
and a search string.