### PR TITLE
test: Fix TestApplication.testBasicSystem on fedora-coreos

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -354,8 +354,14 @@ class TestApplication(testlib.MachineCase):
         # Checking images is harder but if there would be more than one this would fail
         b.wait_visible("#containers-images:contains('quay.io/cockpit/registry:2')")
 
-        # Test that when root is logged in we don't present "user" and "system"
         b.logout()
+
+        if self.machine.ostree_image:
+            self.write_file("/etc/ssh/sshd_config.d/99-root-password.conf", "PermitRootLogin yes",
+                            "systemctl try-restart sshd")
+            self.machine.execute("systemctl try-restart sshd")
+
+        # Test that when root is logged in we don't present "user" and "system"
         self.login_and_go("/podman", user="root")
         b.wait_visible("#app")
 


### PR DESCRIPTION
The test tries to log in as root with password, which is not allowed by
default through SSH. Enable that temporarily.

---

Fixes [this failure](https://logs.cockpit-project.org/logs/pull-3390-20220517-131823-342f3f53-fedora-coreos-cockpit-project-cockpit-podman/log.html). It still worked in PR #972 two weeks ago, but I forgot to enable fedora-coreos in the testmap. I am doing this in https://github.com/cockpit-project/bots/pull/3390