### PR TITLE
Revert "test: Adjust tests for coreos", run tests offline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,11 +132,11 @@ rpm: $(TARFILE) $(SPEC)
 	rm -r "`pwd`/output" "`pwd`/build"
 
 # build a VM with locally built distro pkgs installed
-# HACK for fedora-coreos: with network as the image does not have our expected containers, and we skip the rpm build/install
+# HACK for fedora-coreos: skip the rpm build/install
 # HACK for rhel-8-7: https://bugzilla.redhat.com/show_bug.cgi?id=2086757
 $(VM_IMAGE): $(TARFILE) packaging/debian/rules packaging/debian/control packaging/arch/PKGBUILD bots
 	if [ "$$TEST_OS" = "fedora-coreos" ]; then \
-	    bots/image-customize --verbose --fresh --run-command 'mkdir -p /usr/local/share/cockpit' \
+	    bots/image-customize --verbose --fresh --no-network --run-command 'mkdir -p /usr/local/share/cockpit' \
 	                         --upload dist:/usr/local/share/cockpit/podman \
 	                         --script $(CURDIR)/test/vm.install $(TEST_OS); \
 	else \

--- a/test/check-application
+++ b/test/check-application
@@ -647,18 +647,15 @@ class TestApplication(testlib.MachineCase):
             b.wait_collected_text("#containers-containers .container-name", "abc")
 
         # Test intermediate images
-        # fedora-coreos contains intermediate image already
-        if not auth or self.machine.image != "fedora-coreos":
-            b.wait_not_present(".listing-action")
-            tmpdir = self.execute(auth, "mktemp -d").strip()
-            self.execute(auth, f"echo 'FROM quay.io/cockpit/registry:2\nRUN ls' > {tmpdir}/Dockerfile")
-            self.execute(auth, f"podman build {tmpdir}")
-            b.wait_not_in_text("#containers-images", "<none>:<none>")
+        b.wait_not_present(".listing-action")
+        tmpdir = self.execute(auth, "mktemp -d").strip()
+        self.execute(auth, f"echo 'FROM quay.io/cockpit/registry:2\nRUN ls' > {tmpdir}/Dockerfile")
+        self.execute(auth, f"podman build {tmpdir}")
 
+        b.wait_not_in_text("#containers-images", "<none>:<none>")
         b.click(".listing-action button:contains('Show intermediate images')")
         b.wait_in_text("#containers-images", "<none>:<none>")
-        if not auth or self.machine.image != "fedora-coreos":
-            b.wait_in_text("#containers-images tbody:last-child td[data-label=Created]", "today at")
+        b.wait_in_text("#containers-images tbody:last-child td[data-label=Created]", "today at")
 
         b.click(".listing-action button:contains('Hide intermediate images')")
         b.wait_not_in_text("#containers-images", "<none>:<none>")
@@ -733,7 +730,7 @@ class TestApplication(testlib.MachineCase):
             if auth:
                 expected += 3
                 if self.machine.ostree_image:
-                    expected += 2  # cockpit/ws + intermediate one
+                    expected += 1  # cockpit/ws
 
             b.wait_in_text("#containers-images", f"{expected} images")
 
@@ -1809,10 +1806,7 @@ class TestApplication(testlib.MachineCase):
         b.click("button:contains(Prune unused images)")
 
         if auth:
-            if self.machine.image == "fedora-coreos":
-                b.wait_js_func("ph_count_check", ".pf-c-modal-box__body .pf-c-list li", 6)
-            else:
-                b.wait_js_func("ph_count_check", ".pf-c-modal-box__body .pf-c-list li", 5)
+            b.wait_js_func("ph_count_check", ".pf-c-modal-box__body .pf-c-list li", 5)
         else:
             b.wait_js_func("ph_count_check", ".pf-c-modal-box__body .pf-c-list li", 2)
         b.click(".pf-c-modal-box button:contains(Prune)")
@@ -1846,10 +1840,7 @@ class TestApplication(testlib.MachineCase):
         b.wait_visible(".pf-c-modal-box button:contains(Prune):disabled")
 
         # Admin / user images are selected
-        if self.machine.image == "fedora-coreos":
-            b.wait_js_func("ph_count_check", ".pf-c-modal-box__body .pf-c-list li", 7)
-        else:
-            b.wait_js_func("ph_count_check", ".pf-c-modal-box__body .pf-c-list li", 6)
+        b.wait_js_func("ph_count_check", ".pf-c-modal-box__body .pf-c-list li", 6)
         # Select user images
         b.click("#deleteUserImages")
         b.click(".pf-c-modal-box button:contains(Prune)")
@@ -1863,10 +1854,7 @@ class TestApplication(testlib.MachineCase):
         # Pruning again, should delete all system images
         b.click("#image-actions-dropdown")
         b.click("button:contains(Prune unused images)")
-        if self.machine.image == "fedora-coreos":
-            b.wait_js_func("ph_count_check", ".pf-c-modal-box__body .pf-c-list li", 4)
-        else:
-            b.wait_js_func("ph_count_check", ".pf-c-modal-box__body .pf-c-list li", 3)
+        b.wait_js_func("ph_count_check", ".pf-c-modal-box__body .pf-c-list li", 3)
         b.click(".pf-c-modal-box button:contains(Prune)")
         self.waitNumImages(0, True)
 

--- a/test/vm.install
+++ b/test/vm.install
@@ -35,14 +35,6 @@ if [ "$ID" = "fedora" ]; then
     fi
 fi
 
-# grab a few images to play with; tests run offline, so they cannot download images
-# FIXME: put these images onto fedora-coreos image, and enable image-customize --no-network
-if [ "${VARIANT_ID:-}" = "coreos" ]; then
-    for img in quay.io/libpod/busybox quay.io/libpod/alpine quay.io/cockpit/registry:2; do
-        podman pull $img
-    done
-fi
-
 # copy images for user podman tests; podman insists on user session
 loginctl enable-linger $(id -u admin)
 for img in quay.io/libpod/busybox quay.io/libpod/alpine quay.io/cockpit/registry:2; do


### PR DESCRIPTION
The intermediate images were the previous versions of the images which
`podman pull` in test/vm.install updated. That was a time bomb, as
sometimes there would be a new version and sometimes not.

Now that we never refresh the images any more during tests, these
transient intermediate images should be gone.
    
This reverts commit fb0437f5045cd03346d16b282235ce7bc7a233b4.

---

Spotted by/blocks https://github.com/cockpit-project/bots/pull/3437