### PR TITLE
Fetch tools/node-modules in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
           set -eux
           # this is a shared repo, prefix with project name
           TAG="${GITHUB_REPOSITORY#*/}-$(basename $GITHUB_REF)"
+          make tools/node-modules
           tools/node-modules checkout
           cd node_modules
           git tag "$TAG"


### PR DESCRIPTION
tools/node-modules are not defautly present on cockpit-podman. Instead
they should be fetched from cockpit repository.

This is a clone of https://github.com/cockpit-project/cockpit-machines/pull/736