### PR TITLE
Add Volumes and Env Variables to container details

### DIFF
--- a/src/ContainerDetails.jsx
+++ b/src/ContainerDetails.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import cockpit from 'cockpit';
 import * as utils from './util.js';
 
-import { DescriptionList, DescriptionListTerm, DescriptionListDescription, DescriptionListGroup, Flex, List, FlexItem, ListItem } from "@patternfly/react-core";
+import { DescriptionList, DescriptionListTerm, DescriptionListDescription, DescriptionListGroup, Flex, FlexItem } from "@patternfly/react-core";
 
 const _ = cockpit.gettext;
 
@@ -13,35 +13,13 @@ const render_container_state = (container) => {
     return cockpit.format(_("Exited"));
 };
 
-const render_container_published_ports = (ports) => {
-    if (!ports)
-        return null;
-
-    const result = ports.map(port => {
-        // podman v4 has different names than v3
-        const protocol = port.protocol;
-        const host_port = port.hostPort || port.host_port;
-        const container_port = port.containerPort || port.container_port;
-        const host_ip = port.hostIP || port.host_ip || '0.0.0.0';
-        return (
-            <ListItem key={ protocol + host_port + container_port }>
-                { host_ip }:{ host_port } &rarr; { container_port }/{ protocol }
-            </ListItem>
-        );
-    });
-
-    return <List isPlain>{result}</List>;
-};
-
 const ContainerDetails = ({ container, containerDetail }) => {
-    const ports = render_container_published_ports(container.Ports);
     const networkOptions = (
         containerDetail &&
         [
             containerDetail.NetworkSettings.IPAddress,
             containerDetail.NetworkSettings.Gateway,
             containerDetail.NetworkSettings.MacAddress,
-            ports
         ].some(itm => !!itm)
     );
 
@@ -65,10 +43,6 @@ const ContainerDetails = ({ container, containerDetail }) => {
             </FlexItem>
             <FlexItem>
                 {networkOptions && <DescriptionList columnModifier={{ default: '2Col' }} className='container-details-networking'>
-                    {ports && <DescriptionListGroup>
-                        <DescriptionListTerm>{_("Ports")}</DescriptionListTerm>
-                        <DescriptionListDescription>{ports}</DescriptionListDescription>
-                    </DescriptionListGroup>}
                     {containerDetail && containerDetail.NetworkSettings.IPAddress && <DescriptionListGroup>
                         <DescriptionListTerm>{_("IP address")}</DescriptionListTerm>
                         <DescriptionListDescription>{containerDetail.NetworkSettings.IPAddress}</DescriptionListDescription>

--- a/src/ContainerIntegration.jsx
+++ b/src/ContainerIntegration.jsx
@@ -1,0 +1,116 @@
+import React, { useState } from 'react';
+import cockpit from 'cockpit';
+
+import { Button, DescriptionList, DescriptionListTerm, DescriptionListDescription, DescriptionListGroup, List, ListItem } from "@patternfly/react-core";
+
+import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
+
+const _ = cockpit.gettext;
+
+const renderContainerPublishedPorts = (ports) => {
+    if (!ports)
+        return null;
+
+    const result = ports.map(port => {
+        // podman v4 has different names than v3
+        const protocol = port.protocol;
+        const hostPort = port.hostPort || port.host_port;
+        const containerPort = port.containerPort || port.container_port;
+        const hostIp = port.hostIP || port.host_ip || '0.0.0.0';
+
+        return (
+            <ListItem key={ protocol + hostPort + containerPort }>
+                { hostIp }:{ hostPort } &rarr; { containerPort }/{ protocol }
+            </ListItem>
+        );
+    });
+
+    return <List isPlain>{result}</List>;
+};
+
+const renderContainerVolumes = (volumes) => {
+    if (!volumes.length)
+        return null;
+
+    const result = volumes.map(volume => {
+        return (
+            <ListItem key={volume.Source + volume.Destination}>
+                {volume.Source} &rarr; {volume.Destination}
+            </ListItem>
+        );
+    });
+
+    return <List isPlain>{result}</List>;
+};
+
+const renderContainerEnv = (containerEnv, imageEnv) => {
+    // filter out some Environment variables set by podman or by image
+    const toRemoveEnv = [...imageEnv, 'container=podman'];
+    let toShow = containerEnv.filter(variable => {
+        if (toRemoveEnv.includes(variable)) {
+            return false;
+        }
+
+        return !variable.match(/(HOME|TERM)=.*/);
+    });
+
+    // append filtered out variables to always shown variables when 'show more' is clicked
+    const [showMore, setShowMore] = useState(false);
+    if (showMore)
+        toShow = toShow.concat(containerEnv.filter(variable => !toShow.includes(variable)));
+
+    if (!toShow.length)
+        return null;
+
+    const result = toShow.map(variable => {
+        return (
+            <ListItem key={variable}>
+                {variable}
+            </ListItem>
+        );
+    });
+
+    result.push(
+        <ListItem key='show-more-env-button'>
+            <Button variant='link' isInline
+                onClick={() => setShowMore(!showMore)}>
+                {showMore ? _("Show less") : _("Show more")}
+            </Button>
+        </ListItem>
+    );
+
+    return <List isPlain>{result}</List>;
+};
+
+const ContainerIntegration = ({ container, containerDetail, localImages }) => {
+    if (containerDetail === null || localImages === null) {
+        return (
+            <EmptyStatePanel title='Loading details...' loading />
+        );
+    }
+
+    const ports = renderContainerPublishedPorts(container.Ports);
+    const volumes = renderContainerVolumes(containerDetail.Mounts);
+
+    const image = localImages.filter(img => img.Id === container.ImageID)[0];
+    const env = renderContainerEnv(containerDetail.Config.Env, image.Env);
+
+    return (
+        <DescriptionList isAutoColumnWidths columnModifier={{ md: '3Col' }} className='container-integration'>
+            {ports && <DescriptionListGroup>
+                <DescriptionListTerm>{_("Ports")}</DescriptionListTerm>
+                <DescriptionListDescription>{ports}</DescriptionListDescription>
+            </DescriptionListGroup>}
+            {volumes && <DescriptionListGroup>
+                <DescriptionListTerm>{_("Volumes")}</DescriptionListTerm>
+                <DescriptionListDescription>{volumes}</DescriptionListDescription>
+            </DescriptionListGroup>}
+            {env && <DescriptionListGroup>
+                <DescriptionListTerm>{_("Environment variables")}</DescriptionListTerm>
+                <DescriptionListDescription>{env}</DescriptionListDescription>
+            </DescriptionListGroup>}
+        </DescriptionList>
+    );
+};
+
+export default ContainerIntegration;

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -17,6 +17,7 @@ import cockpit from 'cockpit';
 import { ListingTable } from "cockpit-components-table.jsx";
 import { ListingPanel } from 'cockpit-components-listing-panel.jsx';
 import ContainerDetails from './ContainerDetails.jsx';
+import ContainerIntegration from './ContainerIntegration.jsx';
 import ContainerTerminal from './ContainerTerminal.jsx';
 import ContainerLogs from './ContainerLogs.jsx';
 import ContainerHealthLogs from './ContainerHealthLogs.jsx';
@@ -403,6 +404,10 @@ class Containers extends React.Component {
             name: _("Details"),
             renderer: ContainerDetails,
             data: { container: container, containerDetail: containerDetail }
+        }, {
+            name: _("Integration"),
+            renderer: ContainerIntegration,
+            data: { container: container, containerDetail: containerDetail, localImages: localImages }
         }, {
             name: _("Logs"),
             renderer: ContainerLogs,

--- a/src/client.js
+++ b/src/client.js
@@ -137,6 +137,7 @@ function parseImageInfo(info) {
         image.Entrypoint = info.Config.Entrypoint;
         image.Command = info.Config.Cmd;
         image.Ports = Object.keys(info.Config.ExposedPorts || {});
+        image.Env = info.Config.Env;
     }
     image.Author = info.Author;
 

--- a/test/check-application
+++ b/test/check-application
@@ -1497,6 +1497,10 @@ class TestApplication(testlib.MachineCase):
         # set_val does not trigger onChange so append a space.
         b.set_input_text('#run-image-dialog-env-2-value', ' ', append=True, value_check=False)
 
+        b.click('.env-form .btn-add')
+        b.set_input_text('#run-image-dialog-env-4-key', 'HOSTNAME')
+        b.set_input_text('#run-image-dialog-env-4-value', 'busybox')
+
         # Configure volumes
         b.click('.volume-form .btn-add')
         rodir, rwdir = m.execute("mktemp; mktemp").split('\n')[:2]
@@ -1562,27 +1566,55 @@ class TestApplication(testlib.MachineCase):
 
         self.toggleExpandedContainer("busybox:latest")
 
+        b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Created") + dd', 'today at')
+
+        b.click(".pf-m-expanded button:contains('Integration')")
+
         b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Ports") + dd', '0.0.0.0:6000 \u2192 5000/tcp')
         b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Ports") + dd', '127.0.0.1:6001 \u2192 5001/udp')
         b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Ports") + dd', '127.0.0.2:')
         b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Ports") + dd', ' \u2192 8001/tcp')
         b.wait_not_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Ports") + dd', '7001/tcp')
+
         ports = self.execute(auth, "podman inspect --format '{{.NetworkSettings.Ports}}' busybox-with-tty")
-
-        b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Created") + dd', 'today at')
-
         self.assertIn('5000/tcp:[{ 6000}]', ports)
         self.assertIn('5001/udp:[{127.0.0.1 6001}]', ports)
         self.assertIn('8001/tcp:[{ ', ports)
         self.assertIn('9001/tcp:[{127.0.0.2 ', ports)
         self.assertNotIn('7001/tcp', ports)
 
+        b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Environment variables") + dd', 'APPLE=ORANGE')
+        b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Environment variables") + dd', 'PEAR=BANANA')
+        b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Environment variables") + dd', 'RHUBARB=STRAWBERRY')
+        b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Environment variables") + dd', 'DURIAN=LEMON')
+        b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Environment variables") + dd', 'HOSTNAME=busybox')
+        # variables are present in env but are not displayed in the UI
+        b.wait_not_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Environment variables") + dd', 'container=podman')
+        b.wait_not_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Environment variables") + dd', 'TERM=xterm')
+        b.wait_not_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Environment variables") + dd', 'HOME=/root')
+        b.wait_not_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Environment variables") + dd', 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin')
+
+        b.click(".container-integration button:contains('Show more')")
+        # previously hidden variables are now visible
+        b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Environment variables") + dd', 'container=podman')
+        b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Environment variables") + dd', 'TERM=xterm')
+        b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Environment variables") + dd', 'HOME=/root')
+        b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Environment variables") + dd', 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin')
+
         env = self.execute(auth, "podman exec busybox-with-tty env")
         self.assertIn('APPLE=ORANGE', env)
         self.assertIn('PEAR=BANANA', env)
         self.assertIn('RHUBARB=STRAWBERRY', env)
         self.assertIn('DURIAN=LEMON', env)
+        self.assertIn('HOSTNAME=busybox', env)
+        self.assertIn('container=podman', env)
+        self.assertIn('TERM=xterm', env)
+        self.assertIn('HOME=/root', env)
+        self.assertIn('PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', env)
         self.assertNotIn('MELON=GRAPE', env)
+
+        b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Volumes") + dd', f"{rodir} \u2192 /tmp/ro")
+        b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Volumes") + dd', f"{rwdir} \u2192 /tmp/rw")
 
         romnt = self.execute(auth, "podman exec busybox-with-tty cat /proc/self/mountinfo | grep /tmp/ro")
         self.assertIn('ro', romnt)


### PR DESCRIPTION
Following conversation in #923 this adds new tab in container details
which shows ports, mounted volumes and filtered environment variables.

I decided someone might find it useful to check all env variables so I've added `Show more` button which shows all variables.

---
## Display ports, volumes and environment variables

Published ports, mounted volumes and environment variables are now visible in container integration tab.
By default only variables set by user are shown and after clicking `Show more` all variables are visible.

![containers-integration](https://user-images.githubusercontent.com/10246/179953332-a7686942-624c-4c65-970d-cedce0847958.png)
