### PR TITLE
package.json: Update chrome-remote-interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@babel/preset-env": "7.12.17",
     "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.0",
-    "chrome-remote-interface": "^0.28.0",
+    "chrome-remote-interface": "^0.31.2",
     "compression-webpack-plugin": "^6.0.0",
     "copy-webpack-plugin": "^6.1.0",
     "css-loader": "^5.2.0",


### PR DESCRIPTION
This release contains a fix for nodejs to prefer ipv4 resolving which
is needed as Firefox the CDP runs only on ipv4 on Fedora rawhide on
packit.