### PR TITLE
Reply from REST can come in pieces

### DIFF
--- a/src/rest.js
+++ b/src/rest.js
@@ -20,12 +20,19 @@ function connect(address, system) {
 
     connection.monitor = function(options, callback, system, return_raw) {
         return new Promise((resolve, reject) => {
+            let buffer = "";
+
             http.request(options)
                     .stream(data => {
                         if (return_raw)
                             callback(data);
-                        else
-                            callback(JSON.parse(data));
+                        else {
+                            buffer += data;
+                            const chunks = buffer.split("\n");
+                            buffer = chunks.pop();
+
+                            chunks.forEach(chunk => callback(JSON.parse(chunk)));
+                        }
                     })
                     .catch((error, content) => {
                         manage_error(reject, error, content);

--- a/test/check-application
+++ b/test/check-application
@@ -2122,6 +2122,19 @@ class TestApplication(testlib.MachineCase):
         self.execute(auth, f"podman inspect --format '{{{{.Id}}}}' {container_name_new}").strip()
         self.waitContainerRow(container_name_new)
 
+    def testMultipleContainers(self):
+        self.login()
+
+        # Create 31 containers
+        for i in range(31):
+            self.execute(True, f"podman run -dt --name container{i} quay.io/libpod/busybox:latest")
+
+        self.waitContainerRow("container30")
+
+        # Generic cleanup takes too long and timeouts, so remove these container manually one by one
+        for i in range(31):
+            self.execute(True, f"podman rm -f container{i}")
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
Maximum length on one message is 4096 characters. When the reply is
longer than that it will come in multiple messages. In such case we need to
connect them before trying to parse such message.
    
This for example happens when there are multiple containers and `Stats` often
are split into multiple messages.
    
Fixes #1025