### PR TITLE
Show pod details

### DIFF
--- a/src/ContainerIntegration.jsx
+++ b/src/ContainerIntegration.jsx
@@ -7,7 +7,7 @@ import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
 const _ = cockpit.gettext;
 
-const renderContainerPublishedPorts = (ports) => {
+export const renderContainerPublishedPorts = (ports) => {
     if (!ports)
         return null;
 
@@ -28,7 +28,7 @@ const renderContainerPublishedPorts = (ports) => {
     return <List isPlain>{result}</List>;
 };
 
-const renderContainerVolumes = (volumes) => {
+export const renderContainerVolumes = (volumes) => {
     if (!volumes.length)
         return null;
 

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -742,7 +742,7 @@ class Containers extends React.Component {
                                                 {caption && <CardHeader>
                                                     <CardTitle>
                                                         <Flex justifyContent={{ default: 'justifyContentFlexStart' }}>
-                                                            <span className='pod-name'>{caption}</span>
+                                                            <h3 className='pod-name'>{caption}</h3>
                                                             <span>{_("pod group")}</span>
                                                             {this.renderPodDetails(this.props.pods[section], podStatus)}
                                                         </Flex>

--- a/src/Containers.scss
+++ b/src/Containers.scss
@@ -1,7 +1,26 @@
-.container-section {
+@import "global-variables";
+
+.container-pod {
     .pf-c-card__header {
         border-color: #ddd;
         padding-top: var(--pf-global--spacer--md);
+    }
+
+    .pod-header-details {
+	border-color: #ddd;
+	margin-top: var(--pf-global--spacer--md);
+	margin-left: var(--pf-global--spacer--md);
+	margin-right: var(--pf-global--spacer--md);
+    }
+
+    .pod-details-button {
+       padding-left: 0;
+       padding-right: 0;
+       margin-right: var(--pf-global--spacer--md);
+    }
+
+    .pod-details-button-color {
+       color: var(--pf-c-button--m-secondary--Color);
     }
 
     .pf-c-card__title {
@@ -16,8 +35,35 @@
         }
     }
 
-    .pf-c-card__header:not(:last-child) {
-        padding-bottom: var(--pf-global--spacer-sm);
+    > .pf-c-card__header {
+        &:not(:last-child) {
+            padding-bottom: var(--pf-global--spacer-sm);
+        }
+
+        // Reduce vertical padding of pod header items
+        > .pf-c-card__title > .pf-l-flex {
+            row-gap: var(--pf-global--spacer--sm);
+        }
+    }
+}
+
+.pod-stat {
+    @media (max-width: $pf-global--breakpoint--sm - 1) {
+        // Place each pod stat on its own row
+        flex-basis: 100%;
+        display: grid;
+        // Give labels to the same space
+        grid-template-columns: minmax(auto, 4rem) 1fr;
+
+        > svg {
+            // Hide icons in mobile to be consistent with container lists
+            display: none;
+        }
+    }
+
+    // Center the icons for proper vertical alignment
+    > svg {
+        align-self: center;
     }
 }
 

--- a/src/podman.scss
+++ b/src/podman.scss
@@ -110,7 +110,7 @@
     }
 
     // Add  borders to no pod containers list and images list
-    .container-section.pf-m-plain tbody,
+    .container-pod.pf-m-plain tbody,
     .containers-images tbody {
         border: var(--pf-c-card--m-flat--BorderWidth) solid var(--pf-c-card--m-flat--BorderColor);
     }

--- a/test/check-application
+++ b/test/check-application
@@ -50,7 +50,14 @@ class TestApplication(testlib.MachineCase):
     def setUp(self):
         super().setUp()
         m = self.machine
-        m.execute("systemctl stop podman.service; systemctl --now enable podman.socket")
+        m.execute("""
+            systemctl stop podman.service; systemctl --now enable podman.socket
+            # Ensure podman is really stopped, as sometimes restore_dir flakes on Debian-testing
+            pkill -e -9 podman || true
+            while pgrep podman; do sleep 0.1; done
+            findmnt --list -otarget | grep /var/lib/containers/. | xargs -r umount
+            sync
+            """)
 
         # backup/restore pristine podman state, so that tests can run on existing testbeds
         self.restore_dir("/var/lib/containers", reboot_safe=True)

--- a/test/check-application
+++ b/test/check-application
@@ -214,9 +214,27 @@ class TestApplication(testlib.MachineCase):
         self.filter_containers("all")
         self.waitPodContainer("pod-1", [])
 
+        def get_pod_cpu_usage(pod_name):
+            cpu = self.browser.text(f"#table-{pod_name}-title .pod-cpu")
+            self.assertIn('%', cpu)
+            return float(cpu[:-1])
+
+        def get_pod_memory(pod_name):
+            memory = self.browser.text(f"#table-{pod_name}-title .pod-memory")
+            memory, unit = memory.split(' ')
+            self.assertIn(unit, ["GB", "MB", "KB"])
+            return float(memory)
+
         containerId = self.machine.execute("podman run -d --pod pod-1 --name test-pod-1-system alpine sleep 100").strip()
         self.waitPodContainer("pod-1", [{"name": "test-pod-1-system", "image": "alpine", "command": "sleep 100", "state": "Running", "id": containerId}])
-        self.machine.execute("podman pod stop pod-1")
+        cpu = get_pod_cpu_usage("pod-1")
+        b.wait(lambda: get_pod_memory("pod-1") > 0)
+
+        # Test that cpu usage increases
+        self.machine.execute("podman exec -i test-pod-1-system sh -c 'dd bs=1024 count=1000000 < /dev/urandom > /dev/null'")
+        b.wait(lambda: get_pod_cpu_usage("pod-1") > cpu)
+
+        self.machine.execute("podman pod stop -t0 pod-1")  # disable timeout, so test doesn't wait endlessly
         self.waitPodContainer("pod-1", [{"name": "test-pod-1-system", "image": "alpine", "command": "sleep 100", "state": NOT_RUNNING, "id": containerId}])
         self.filter_containers("running")
         self.waitPodRow("pod-1", False)
@@ -266,6 +284,20 @@ class TestApplication(testlib.MachineCase):
         b.wait_not_in_text(".pf-c-modal-box__body", "test-pod-2-system")
         b.click(".pf-c-modal-box button:contains('Delete')")
         self.waitPodRow("pod-2", False)
+
+        # Volumes / mounts
+        self.machine.execute("podman pod create -p 9999:9999 -v /tmp:/app --name pod-3")
+        self.machine.execute("podman pod start pod-3")
+
+        self.waitPodContainer("pod-3", [])
+        # Verify 1 port mapping
+        b.wait_in_text("#table-pod-3-title .pod-details-ports-btn", "1")
+        b.click("#table-pod-3-title .pod-details-ports-btn")
+        b.wait_in_text(".pf-c-popover__content", "0.0.0.0:9999 → 9999/tcp")
+        # Verify 1 mount
+        b.wait_in_text("#table-pod-3-title .pod-details-volumes-btn", "1")
+        b.click("#table-pod-3-title .pod-details-volumes-btn")
+        b.wait_in_text(".pf-c-popover__content", "/tmp ↔ /app")
 
     @testlib.nondestructive
     def testBasicSystem(self):


### PR DESCRIPTION
Show the port details of a pod using a popover.


---

# Pod CPU, memory, port and volume details

Podman now shows the CPU and memory usage of a pod. The amount port and volume mappings of a pod are now shown with a popover showing the exact detailed mapping. 

![image](https://user-images.githubusercontent.com/67428/190441287-e9c57cfb-56c8-48e0-abee-b6963e2851eb.png)


![image](https://user-images.githubusercontent.com/67428/190441374-21699f8b-2a19-43ca-9fac-090cfb9eb77b.png)
