### PR TITLE
Fix system logic in prune unused images dialog

### DIFF
--- a/src/PruneUnusedImagesModal.jsx
+++ b/src/PruneUnusedImagesModal.jsx
@@ -52,10 +52,9 @@ function ImageOptions({ images, checked, isSystem, handleChange, name, showCheck
 class PruneUnusedImagesModal extends React.Component {
     constructor(props) {
         super(props);
-        const isSystem = this.props.userServiceAvailable && this.props.systemServiceAvailable;
         this.state = {
-            deleteUserImages: true,
-            deleteSystemImages: isSystem,
+            deleteUserImages: this.props.userServiceAvailable !== null && this.props.userServiceAvailable,
+            deleteSystemImages: this.props.systemServiceAvailable,
             isPruning: false,
         };
     }
@@ -83,7 +82,7 @@ class PruneUnusedImagesModal extends React.Component {
     }
 
     render() {
-        const isSystem = this.props.userServiceAvailable && this.props.systemServiceAvailable;
+        const isSystem = this.props.systemServiceAvailable;
         const userImages = this.props.unusedImages.filter(image => !image.isSystem);
         const systemImages = this.props.unusedImages.filter(image => image.isSystem);
         const showCheckboxes = userImages.length > 0 && systemImages.length > 0;

--- a/test/check-application
+++ b/test/check-application
@@ -1808,12 +1808,21 @@ class TestApplication(testlib.MachineCase):
     def testPruneUnusedImagesUser(self):
         self._testPruneUnusedImagesSystem(False)
 
-    def _testPruneUnusedImagesSystem(self, auth):
+    @testlib.skipImage("no root login available on coreos", "fedora-coreos")
+    @testlib.nondestructive
+    def testPruneUnusedImagesRoot(self):
+        self._testPruneUnusedImagesSystem(False, True)
+
+    def _testPruneUnusedImagesSystem(self, auth, root=False):
         b = self.browser
-        self.login(auth)
+        if root:
+            self.login_and_go("/podman", user="root")
+            b.wait_visible("#app")
+        else:
+            self.login(auth)
 
         # By default we have 3 unused images, start one.
-        self.execute(auth, "podman run -d --name used_image alpine:latest sh")
+        self.execute(auth or root, "podman run -d --name used_image alpine:latest sh")
         b.click("#image-actions-dropdown")
         b.click("button:contains(Prune unused images)")
 


### PR DESCRIPTION
Check if the user or system service is avaiable instead of checking if
both are true. Which does not work as userServiceAvailbe is null when
logging in as root.

Closes #1022