### PR TITLE
test flake/failure fixes

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -19,7 +19,7 @@ chmod a+w "$LOGS"
 dnf install --disablerepo=fedora-cisco-openh264 -y --setopt=install_weak_deps=False firefox
 
 # HACK: ensure that critical components are up to date: https://github.com/psss/tmt/issues/682
-dnf update -y podman crun conmon
+dnf update -y podman crun conmon criu
 
 # Show critical package versions
 rpm -q runc crun podman criu kernel-core selinux-policy cockpit-podman cockpit-bridge || true

--- a/test/check-application
+++ b/test/check-application
@@ -56,8 +56,10 @@ class TestApplication(testlib.MachineCase):
             systemctl stop podman.service podman.socket
             systemctl reset-failed podman.service podman.socket
             podman system reset --force
-            killall -9 podman || true
+            pkill -e -9 podman || true
+            while pgrep -e podman; do sleep 0.1; done
             findmnt --list -otarget | grep /var/lib/containers/. | xargs -r umount
+            sync
             """)
 
         # Create admin session

--- a/test/check-application
+++ b/test/check-application
@@ -992,6 +992,7 @@ class TestApplication(testlib.MachineCase):
 
         # Check we show usage
         b.wait(lambda: self.getContainerAttr("busybox:latest", "CPU") != "")
+        b.wait(lambda: self.getContainerAttr("busybox:latest", "Memory") != "")
         memory = self.getContainerAttr("busybox:latest", "Memory")
         if auth or self.has_cgroupsV2:
             cpu = get_cpu_usage("busybox:latest")


### PR DESCRIPTION
testLifecycleOperationsUser flakes in CI where the CPU statistics are
available but the memory statistics are not yet. So wait on both to be
available.

Examples:

https://cockpit-logs.us-east-1.linodeobjects.com/pull-1039-20220718-145652-17708f5b-arch/log.html#16-2
https://cockpit-logs.us-east-1.linodeobjects.com/pull-1017-20220715-090657-252dda76-arch/log.html#16