### PR TITLE
fmf: Add non-git fallback for npm module installation

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -3,16 +3,24 @@ set -eux
 
 # tests need cockpit's bots/ libraries and test infrastructure
 cd $SOURCE
-git init
 rm -f bots  # common local case: existing bots symlink
 make bots test/common
 
 # ensure current node_modules for testing
 rm -rf node_modules
-tools/node-modules checkout
+if [ -e .git ]; then
+    tools/node-modules checkout
+    # disable detection of affected tests; testing takes too long as there is no parallelization
+    mv .git dot-git
 
-# disable detection of affected tests; testing takes too long as there is no parallelization
-mv .git dot-git
+else
+    # move package.json temporarily, otherwise npm might try to install the dependencies from it
+    rm -f package-lock.json  # otherwise the command below installs *everything*, argh
+    mv package.json .package.json
+    # only install a subset to save time/space
+    npm install chrome-remote-interface sizzle
+    mv .package.json package.json
+fi
 
 . /etc/os-release
 export TEST_OS="${ID}-${VERSION_ID/./-}"


### PR DESCRIPTION
Commit c22bb7121cd73324e broke running tests for tarball releases [1].
Bring back the `npm install` for the non-git case.

Clean up the pointless `git init` and make the dot-git moving
conditional on the presence of .git (i.e. testing an upstream PR).

[1] https://src.fedoraproject.org/rpms/cockpit-podman/pull-request/53

---

I'll do a 50.1 release after that, to fix the [gating test failure](https://artifacts.dev.testing-farm.io/4e2af3c2-3e7f-4111-8439-2fadbcfffdbc/).