### PR TITLE
Makefile: Use rsync-friendly directory path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ rpm: $(TARFILE) $(SPEC)
 $(VM_IMAGE): $(TARFILE) packaging/debian/rules packaging/debian/control packaging/arch/PKGBUILD bots
 	if [ "$$TEST_OS" = "fedora-coreos" ]; then \
 	    bots/image-customize --verbose --fresh --no-network --run-command 'mkdir -p /usr/local/share/cockpit' \
-	                         --upload dist:/usr/local/share/cockpit/podman \
+	                         --upload dist/:/usr/local/share/cockpit/podman \
 	                         --script $(CURDIR)/test/vm.install $(TEST_OS); \
 	else \
 	    bots/image-customize --verbose --fresh --no-network --build $(TARFILE) --script $(CURDIR)/test/vm.install $(TEST_OS); \


### PR DESCRIPTION
We want to move bots API from deprecated scp to rsync. rsync uses
trailing slashes to tell apart copying a directory as a different name
in the target (trailing slash) from copying a directory *into* the given
target path (no trailing slash). Here we want to do the former.

---

This blocks https://github.com/cockpit-project/bots/pull/3640