### PR TITLE
Ship npm integration test dependencies in dist tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,19 +118,28 @@ devel-uninstall:
 print-version:
 	@echo "$(VERSION)"
 
+# required for running integration tests; commander and ws are deps of chrome-remote-interface
+TEST_NPMS = \
+       node_modules/chrome-remote-interface \
+       node_modules/commander \
+       node_modules/sizzle \
+       node_modules/ws \
+       $(NULL)
+
 dist: $(TARFILE)
 	@ls -1 $(TARFILE)
 
 # when building a distribution tarball, call webpack with a 'production' environment
-# we don't ship node_modules for license and compactness reasons; we ship a
-# pre-built dist/ (so it's not necessary) and ship package-lock.json (so that
-# node_modules/ can be reconstructed if necessary)
+# we don't ship most node_modules for license and compactness reasons, only the ones necessary for running tests
+# we ship a pre-built dist/ (so it's not necessary) and ship package-lock.json (so that node_modules/ can be reconstructed if necessary)
 $(TARFILE): export NODE_ENV=production
 $(TARFILE): $(WEBPACK_TEST) $(SPEC) packaging/arch/PKGBUILD packaging/debian/changelog
 	if type appstream-util >/dev/null 2>&1; then appstream-util validate-relax --nonet *.metainfo.xml; fi
 	tar --xz $(TAR_ARGS) -cf $(TARFILE) --transform 's,^,$(RPM_NAME)/,' \
-		--exclude '*.in' --exclude test/reference --exclude node_modules \
-		$$(git ls-files) $(COCKPIT_REPO_FILES) $(NODE_MODULES_TEST) $(SPEC) packaging/arch/PKGBUILD packaging/debian/changelog dist/
+		--exclude '*.in' --exclude test/reference \
+		$$(git ls-files | grep -v node_modules) \
+		$(COCKPIT_REPO_FILES) $(NODE_MODULES_TEST) $(SPEC) $(TEST_NPMS) \
+		packaging/arch/PKGBUILD packaging/debian/changelog dist/
 
 # convenience target for developers
 rpm: $(TARFILE)

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -8,7 +8,7 @@ require:
   - git-core
   - libvirt-python3
   - make
-  - npm
+  - nodejs
   - python3
 test: ./browser.sh
 duration: 60m

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -6,20 +6,13 @@ cd $SOURCE
 rm -f bots  # common local case: existing bots symlink
 make bots test/common
 
-# ensure current node_modules for testing
-rm -rf node_modules
 if [ -e .git ]; then
     tools/node-modules checkout
     # disable detection of affected tests; testing takes too long as there is no parallelization
     mv .git dot-git
-
 else
-    # move package.json temporarily, otherwise npm might try to install the dependencies from it
-    rm -f package-lock.json  # otherwise the command below installs *everything*, argh
-    mv package.json .package.json
-    # only install a subset to save time/space
-    npm install chrome-remote-interface sizzle
-    mv .package.json package.json
+    # upstream tarballs ship test dependencies; print version for debugging
+    grep '"version"' node_modules/chrome-remote-interface/package.json
 fi
 
 . /etc/os-release


### PR DESCRIPTION
This avoids having to run `npm`, and thus a potentially brittle internet
access, during FMF test runs. It also avoids the npm test dependency,
which tends to be uninstallable in Rawhide.

We have successfully used this approach in cockpit for a long time.

----

Avoids [this failure](https://artifacts.dev.testing-farm.io/b3b0d33e-b8f6-4cb5-80da-5a94c5a07095/), which has been going on for a week [bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2110750). This already hit us in the past.

By and large the same as https://github.com/cockpit-project/cockpit-machines/pull/784