### PR TITLE
Show volume permission in container integration tab

### DIFF
--- a/src/ContainerIntegration.jsx
+++ b/src/ContainerIntegration.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import cockpit from 'cockpit';
 
-import { Button, DescriptionList, DescriptionListTerm, DescriptionListDescription, DescriptionListGroup, List, ListItem } from "@patternfly/react-core";
+import { Button, DescriptionList, DescriptionListTerm, DescriptionListDescription, DescriptionListGroup, List, ListItem, Tooltip } from "@patternfly/react-core";
 
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
@@ -35,7 +35,11 @@ const renderContainerVolumes = (volumes) => {
     const result = volumes.map(volume => {
         return (
             <ListItem key={volume.Source + volume.Destination}>
-                {volume.Source} &rarr; {volume.Destination}
+                {volume.Source}
+                {volume.RW
+                    ? <Tooltip content={_("Read-write access")}><span> &harr; </span></Tooltip>
+                    : <Tooltip content={_("Read-only access")}><span> &rarr; </span></Tooltip>}
+                {volume.Destination}
             </ListItem>
         );
     });

--- a/test/check-application
+++ b/test/check-application
@@ -1611,7 +1611,7 @@ class TestApplication(testlib.MachineCase):
         self.assertNotIn('MELON=GRAPE', env)
 
         b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Volumes") + dd', f"{rodir} \u2192 /tmp/ro")
-        b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Volumes") + dd', f"{rwdir} \u2192 /tmp/rw")
+        b.wait_in_text('#containers-containers tr:contains("busybox:latest") dt:contains("Volumes") + dd', f"{rwdir} \u2194 /tmp/rw")
 
         romnt = self.execute(auth, "podman exec busybox-with-tty cat /proc/self/mountinfo | grep /tmp/ro")
         self.assertIn('ro', romnt)


### PR DESCRIPTION
Read-write volumes use left-right arrow,
Read-only volumes use right arrow.

![image](https://user-images.githubusercontent.com/74668142/182395147-e5e48970-e344-4924-bfde-bc1cf6797825.png)

Both arrows have a tooltip:
![image](https://user-images.githubusercontent.com/74668142/182395388-25dc2e32-4941-455b-bc6d-652447344af5.png)
![image](https://user-images.githubusercontent.com/74668142/182395330-185ff958-4fee-46b3-9f32-4d1b53270646.png)
