### PR TITLE
test: Move to flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 195

--- a/Makefile
+++ b/Makefile
@@ -174,8 +174,7 @@ print-vm:
 PYEXEFILES=$(shell git grep -lI '^#!.*python')
 
 codecheck:
-	python3 -m pyflakes $(PYEXEFILES)
-	python3 -m pycodestyle --max-line-length=195 $(PYEXEFILES) # TODO: Fix long lines
+	flake8 $(PYEXEFILES)
 
 # convenience target to setup all the bits needed for the integration tests
 # without actually running them


### PR DESCRIPTION
This is easier to use, more flexible as pycodestyle errors can be
overridden on specific lines, and IDEs/vim-ale can read .flake8 and stop
complaining about the line length.