### PR TITLE
Show image history

### DIFF
--- a/src/ImageHistory.jsx
+++ b/src/ImageHistory.jsx
@@ -1,0 +1,63 @@
+import React, { useState, useEffect } from 'react';
+import cockpit from 'cockpit';
+import * as utils from './util.js';
+import * as client from './client.js';
+
+import { ListingTable } from "cockpit-components-table.jsx";
+
+const _ = cockpit.gettext;
+
+const IdColumn = Id => {
+    Id = utils.truncate_id(Id);
+    // Not an id but <missing> or something else
+    if (/<[a-z]+>/.test(Id)) {
+        return <div className="pf-u-disabled-color-100">{Id}</div>;
+    }
+    return Id;
+};
+
+const ImageDetails = ({ image }) => {
+    const [history, setHistory] = useState([]);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        client.imageHistory(image.isSystem, image.Id).then(setHistory)
+                .catch(ex => {
+                    console.error("Cannot get image history", ex);
+                    setError(true);
+                });
+    }, []);
+
+    const columns = ["ID", _("Created"), _("Created by"), _("Size"), _("Comments")];
+    let showComments = false;
+    const rows = history.map(layer => {
+        const row = {
+            columns: [
+                { title: IdColumn(layer.Id), props: { className: "ignore-pixels" } },
+                { title: utils.localize_time(layer.Created), props: { className: "ignore-pixels" } },
+                { title: layer.CreatedBy, props: { className: "ignore-pixels" } },
+                { title: cockpit.format_bytes(layer.Size), props: { className: "ignore-pixels" } },
+                { title: layer.Comment, props: { className: "ignore-pixels" } },
+            ]
+        };
+        if (layer.Comment) {
+            showComments = true;
+        }
+        return row;
+    });
+
+    if (!showComments) {
+        columns.pop();
+    }
+
+    return (
+        <ListingTable
+            variant='compact'
+            isStickyHeader
+            emptyCaption={error ? _("Unable to load image history") : _("Loading details...")}
+            columns={columns}
+            rows={rows} />
+    );
+};
+
+export default ImageDetails;

--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -14,6 +14,7 @@ import cockpit from 'cockpit';
 import { ListingTable } from "cockpit-components-table.jsx";
 import { ListingPanel } from 'cockpit-components-listing-panel.jsx';
 import ImageDetails from './ImageDetails.jsx';
+import ImageHistory from './ImageHistory.jsx';
 import { ImageRunModal } from './ImageRunModal.jsx';
 import { ImageSearchModal } from './ImageSearchModal.jsx';
 import { ImageDeleteModal } from './ImageDeleteModal.jsx';
@@ -150,6 +151,13 @@ class Images extends React.Component {
                 image: image,
                 containers: this.props.imageContainerList !== null ? this.props.imageContainerList[image.Id + image.isSystem.toString()] : null,
                 showAll: this.props.showAll,
+            }
+        });
+        tabs.push({
+            name: _("History"),
+            renderer: ImageHistory,
+            data: {
+                image: image,
             }
         });
         return {

--- a/src/client.js
+++ b/src/client.js
@@ -229,4 +229,12 @@ export function pruneUnusedImages(system) {
     });
 }
 
+export function imageHistory(system, id) {
+    return new Promise((resolve, reject) => {
+        podmanCall(`libpod/images/${id}/history`, "GET", {}, system)
+                .then(reply => resolve(JSON.parse(reply)))
+                .catch(reject);
+    });
+}
+
 export const imageExists = (system, id) => podmanCall("libpod/images/" + id + "/exists", "GET", {}, system);

--- a/src/podman.scss
+++ b/src/podman.scss
@@ -3,6 +3,8 @@
 @import "global-variables";
 // For pf-line-clamp
 @import "@patternfly/patternfly/sass-utilities/mixins.scss";
+// For pf-u-disabled-color-100
+@import "@patternfly/patternfly/utilities/Text/text.css";
 
 #app .pf-c-card.containers-containers, #app .pf-c-card.containers-images {
     @extend .ct-card;
@@ -83,15 +85,17 @@
    color: var(--pf-global--Color--200);
 }
 
-// Add  borders to no pod containers list and images list
-.container-section.pf-m-plain tbody,
-.containers-images tbody {
-    border: var(--pf-c-card--m-flat--BorderWidth) solid var(--pf-c-card--m-flat--BorderColor);
-}
-
 .content-action {
     text-align: right;
     white-space: nowrap !important;
+}
+
+// Remove doubled-up padding and borders on nested tables in mobile
+.ct-listing-panel-body .ct-table tr {
+    --pf-c-table-tr--responsive--PaddingTop: 0;
+    --pf-c-table-tr--responsive--PaddingRight: 0;
+    --pf-c-table-tr--responsive--PaddingBottom: 0;
+    --pf-c-table-tr--responsive--PaddingLeft: 0;
 }
 
 @media (max-width: $pf-global--breakpoint--md - 1) {
@@ -103,5 +107,11 @@
 @media (min-width: $pf-global--breakpoint--md) {
     .show-only-when-narrow {
         display: none;
+    }
+
+    // Add  borders to no pod containers list and images list
+    .container-section.pf-m-plain tbody,
+    .containers-images tbody {
+        border: var(--pf-c-card--m-flat--BorderWidth) solid var(--pf-c-card--m-flat--BorderColor);
     }
 }

--- a/test/check-application
+++ b/test/check-application
@@ -100,7 +100,7 @@ class TestApplication(testlib.MachineCase):
         else:
             extra = 0
 
-        self.browser.wait_js_func("ph_count_check", "#containers-images tbody", expected + extra)
+        self.browser.wait_js_func("ph_count_check", "#containers-images table[aria-label='Images'] > tbody", expected + extra)
 
     def waitNumContainers(self, expected, auth):
         if auth and self.machine.ostree_image:
@@ -434,6 +434,10 @@ class TestApplication(testlib.MachineCase):
         b.click(busybox_sel + " .pf-c-dropdown__toggle")
         b.wait_visible(busybox_sel + " button.btn-delete")
         b.wait_in_text("#containers-images tbody.pf-m-expanded tr .image-details:first-child", "Commandsh")
+        # Show history
+        b.click("#containers-images tbody.pf-m-expanded .pf-c-tabs__list li:nth-child(2) button")
+        b.wait_in_text("#containers-images .pf-c-table__expandable-row.pf-m-expanded td[data-label=\"ID\"]:first", images['quay.io/libpod/busybox:latest'][:12])
+        b.assert_pixels('#containers-images .pf-c-table__expandable-row.pf-m-expanded', "history", ignore=[".ignore-pixels"])
         b.click(busybox_sel + " td.pf-c-table__toggle button")
 
         # make sure no running containers shown; on CoreOS there's the cockpit/ws container


### PR DESCRIPTION
A new History tab has been added to the images view which fetches the
history on demand.

The comment field always seems to be empty.. and therefore cut off.

@garrett please take a look:

![image](https://user-images.githubusercontent.com/67428/185223228-cca0fd5a-9165-48a7-8a49-0523bbda820f.png)

![image](https://user-images.githubusercontent.com/67428/185223298-cbac5c3c-ba41-420a-a7b6-7d4287358eae.png)

On Mobile

![image](https://user-images.githubusercontent.com/67428/185223692-968c6e7b-5cd2-4c1d-8973-addab4055736.png)

On tablet

![image](https://user-images.githubusercontent.com/67428/185223786-dd5c04eb-9b5c-4e40-a027-6f9efaffd45c.png)
