### PR TITLE
packit: Drop Fedora 35, add Fedora 37

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -19,8 +19,8 @@ jobs:
   - job: tests
     trigger: pull_request
     targets:
-      - fedora-35
       - fedora-36
+      - fedora-37
       - fedora-development
       - centos-stream-9-x86_64
 
@@ -33,9 +33,8 @@ jobs:
     # should just use the existing config for permanent COPRs;
     # https://github.com/packit/packit-service/issues/1499
     targets:
-      - fedora-35
       - fedora-36
-      - fedora-development
+      - fedora-37
       - centos-stream-8-x86_64
       - centos-stream-9-x86_64
     actions:
@@ -50,19 +49,19 @@ jobs:
     trigger: release
     dist_git_branches:
       - fedora-development
-      - fedora-35
       - fedora-36
+      - fedora-37
 
   - job: koji_build
     trigger: commit
     dist_git_branches:
       - fedora-development
-      - fedora-35
       - fedora-36
+      - fedora-37
 
   - job: bodhi_update
     trigger: commit
     dist_git_branches:
       # rawhide updates are created automatically
-      - fedora-35
       - fedora-36
+      - fedora-37


### PR DESCRIPTION
As usual, keep supporting the two most recent branched versions.

Also drop Rawhide from our cockpit-preview COPR build: We directly
upload new releases to Rawhide anyway, so this is redundant.

----

I already reconfigured our [preview repo](https://copr.fedorainfracloud.org/coprs/g/cockpit/cockpit-preview/) accordingly.