### PR TITLE
Reconnect console after container restart

### DIFF
--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -564,7 +564,7 @@ class Containers extends React.Component {
             emptyCaption = _("No running containers");
 
         if (this.props.containers !== null && this.props.pods !== null) {
-            filtered = Object.keys(this.props.containers).filter(id => !(this.props.filter == "running") || this.props.containers[id].State == "running");
+            filtered = Object.keys(this.props.containers).filter(id => !(this.props.filter == "running") || ["running", "restarting"].includes(this.props.containers[id].State));
 
             if (this.props.userServiceAvailable && this.props.systemServiceAvailable && this.props.ownerFilter !== "all") {
                 filtered = filtered.filter(id => {

--- a/src/util.js
+++ b/src/util.js
@@ -5,7 +5,8 @@ import { formatRelative } from 'date-fns';
 const _ = cockpit.gettext;
 
 // https://github.com/containers/podman/blob/main/libpod/define/containerstate.go
-export const states = [_("Configured"), _("Created"), _("Running"), _("Stopped"), _("Paused"), _("Exited"), _("Removing")];
+// "Restarting" comes from special handling of restart case in Application.updateContainerAfterEvent()
+export const states = [_("Configured"), _("Created"), _("Running"), _("Stopped"), _("Paused"), _("Exited"), _("Removing"), _("Restarting")];
 
 // https://github.com/containers/podman/blob/main/libpod/define/podstate.go
 export const podStates = [_("Created"), _("Running"), _("Stopped"), _("Paused"), _("Exited"), _("Error")];


### PR DESCRIPTION
During restart container's State is still "running" and console was getting disconnected but not reconnected. Additional flag was added to keep information about restart and connect channels again.

Closes #1089