### PR TITLE
test: fix test image calculations

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -1888,6 +1888,8 @@ class TestApplication(testlib.MachineCase):
 
         if auth:
             b.wait_js_func("ph_count_check", ".pf-c-modal-box__body .pf-c-list li", (self.user_images_count + self.system_images_count) - leftover_images)
+        elif root:
+            b.wait_js_func("ph_count_check", ".pf-c-modal-box__body .pf-c-list li", self.system_images_count - leftover_images)
         else:
             b.wait_js_func("ph_count_check", ".pf-c-modal-box__body .pf-c-list li", self.user_images_count - leftover_images)
         b.click(".pf-c-modal-box button:contains(Prune)")
@@ -1938,7 +1940,7 @@ class TestApplication(testlib.MachineCase):
         # Pruning again, should delete all system images
         b.click("#image-actions-dropdown")
         b.click("button:contains(Prune unused images)")
-        b.wait_js_func("ph_count_check", ".pf-c-modal-box__body .pf-c-list li", 3)
+        b.wait_js_func("ph_count_check", ".pf-c-modal-box__body .pf-c-list li", self.system_images_count - 1 if self.machine.ostree_image else self.system_images_count)
         b.click(".pf-c-modal-box button:contains(Prune)")
         self.waitNumImages(1 if self.machine.ostree_image else 0)
 


### PR DESCRIPTION
When pruning only root images, count the actual root images as root and user images are not always equal. When pruning a selection of images, don't hardcode the root images number.