### PR TITLE
Don't show CPU stats for exited containers

### DIFF
--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -365,7 +365,7 @@ class Containers extends React.Component {
             proc = <div><abbr title={_("not available")}>{_("n/a")}</abbr></div>;
             mem = <div><abbr title={_("not available")}>{_("n/a")}</abbr></div>;
         }
-        if (containerStats) {
+        if (containerStats && container.State === "running") {
             if (containerStats.CPU != undefined)
                 proc = containerStats.CPU.toFixed(2) + "%";
             if (containerStats.MemUsage != undefined && containerStats.MemLimit != undefined)


### PR DESCRIPTION
Podman reports 0 CPU and ram back for non-running containers, due to our code we show 0.00% CPU and no ram. Make this experience consistent and just only show CPU/RAM for running containers, this also fixes a pixel flake where one container did show CPU and the other not.


Note: probably requires a pixel test update...