### PR TITLE
Drop obsolete versioned cockpit-bridge dependency

### DIFF
--- a/packaging/cockpit-podman.spec.in
+++ b/packaging/cockpit-podman.spec.in
@@ -31,7 +31,7 @@ BuildRequires: gettext
 BuildRequires: libappstream-glib-devel
 %endif
 
-Requires:       cockpit-bridge >= 138
+Requires:       cockpit-bridge
 Requires:       podman >= 2.0.4
 
 %description

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -14,7 +14,7 @@ Package: cockpit-podman
 Architecture: all
 Multi-Arch: foreign
 Depends: ${misc:Depends},
-         cockpit-bridge (>= 138),
+         cockpit-bridge,
          podman (>= 2.0.4),
 Description: Cockpit component for Podman containers
  The Cockpit Web Console enables users to administer GNU/Linux servers using a

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,8 +1,4 @@
 {
-    "requires": {
-        "cockpit": "137"
-    },
-
     "menu": {
         "index": {
             "label": "Podman containers",


### PR DESCRIPTION
Version 138 is more than 5 years old, none of the distributions that we support and backport to has a version that ancient.

----

Triggered by https://salsa.debian.org/debian/cockpit-podman/-/merge_requests/4