### PR TITLE
test: enable root login for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = 9814ec6a4d2a0276b0357c4f04d2ae59ea557487 # 279
+COCKPIT_REPO_COMMIT = 0096c3cb82452fec7576e223d7cb2f33162663d1 # 280 + disallowed-users test fix
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'

--- a/test/check-application
+++ b/test/check-application
@@ -428,7 +428,7 @@ class TestApplication(testlib.MachineCase):
             self.machine.execute("systemctl try-restart sshd")
 
         # Test that when root is logged in we don't present "user" and "system"
-        self.login_and_go("/podman", user="root")
+        self.login_and_go("/podman", user="root", enable_root_login=True)
         b.wait_visible("#app")
 
         # `User Service is also available` banner should not be present
@@ -1923,7 +1923,7 @@ class TestApplication(testlib.MachineCase):
     def _testPruneUnusedImagesSystem(self, auth, root=False):
         b = self.browser
         if root:
-            self.login_and_go("/podman", user="root")
+            self.login_and_go("/podman", user="root", enable_root_login=True)
             b.wait_visible("#app")
         else:
             self.login(auth)


### PR DESCRIPTION
Cockpit now disallows root login by default, to allow it in tests bump testlib and pass `enable_root_login` so the `disallowed-users` file is emptied.