### PR TITLE
Checkpoint restore fixes

### DIFF
--- a/src/ContainerCheckpointModal.jsx
+++ b/src/ContainerCheckpointModal.jsx
@@ -13,7 +13,6 @@ const ContainerCheckpointModal = ({ containerWillCheckpoint, onAddNotification }
     const [keep, setKeep] = useState(false);
     const [leaveRunning, setLeaveRunning] = useState(false);
     const [tcpEstablished, setTcpEstablished] = useState(false);
-    const [ignoreRootFS, setIgnoreRootFS] = useState(false);
 
     const handleCheckpointContainer = () => {
         setProgress(true);
@@ -21,7 +20,6 @@ const ContainerCheckpointModal = ({ containerWillCheckpoint, onAddNotification }
             keep,
             leaveRunning,
             tcpEstablished,
-            ignoreRootFS,
         })
                 .catch(ex => {
                     const error = cockpit.format(_("Failed to checkpoint container $0"), containerWillCheckpoint.Names);
@@ -59,9 +57,6 @@ const ContainerCheckpointModal = ({ containerWillCheckpoint, onAddNotification }
                 <Checkbox label={_("Support preserving established TCP connections")}
                               id="checkpoint-dialog-tcpEstablished" name="tcpEstablished"
                               isChecked={tcpEstablished} onChange={setTcpEstablished} />
-                <Checkbox label={_("Do not include root file-system changes when exporting")}
-                              id="checkpoint-dialog-ignoreRootFS" name="ignoreRootFS"
-                              isChecked={ignoreRootFS} onChange={setIgnoreRootFS} />
             </Form>
         </Modal>
     );

--- a/src/ContainerRestoreModal.jsx
+++ b/src/ContainerRestoreModal.jsx
@@ -16,9 +16,14 @@ const ContainerRestoreModal = ({ containerWillRestore, onAddNotification }) => {
     const [ignoreStaticIP, setIgnoreStaticIP] = useState(false);
     const [ignoreStaticMAC, setIgnoreStaticMAC] = useState(false);
 
-    const handleRestoreContainer = (args) => {
+    const handleRestoreContainer = () => {
         setInProgress(true);
-        client.postContainer(containerWillRestore.isSystem, "restore", containerWillRestore.Id, args)
+        client.postContainer(containerWillRestore.isSystem, "restore", containerWillRestore.Id, {
+            keep,
+            tcpEstablished,
+            ignoreStaticIP,
+            ignoreStaticMAC,
+        })
                 .catch(ex => {
                     const error = cockpit.format(_("Failed to restore container $0"), containerWillRestore.Names);
                     onAddNotification({ type: 'danger', error, errorDetail: ex.message });
@@ -37,12 +42,7 @@ const ContainerRestoreModal = ({ containerWillRestore, onAddNotification }) => {
                footer={<>
                    <Button variant="primary" isDisabled={inProgress}
                            isLoading={inProgress}
-                           onClick={() => {
-                               handleRestoreContainer({
-                                   keep: keep,
-                                   tcpEstablished: tcpEstablished,
-                               });
-                           }}>
+                           onClick={handleRestoreContainer}>
                        {_("Restore")}
                    </Button>
                    <Button variant="link" isDisabled={inProgress}

--- a/src/ContainerRestoreModal.jsx
+++ b/src/ContainerRestoreModal.jsx
@@ -1,90 +1,71 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Button, Checkbox, Form, Modal } from '@patternfly/react-core';
-import { DialogsContext } from "dialogs.jsx";
+import { useDialogs } from "dialogs.jsx";
 import cockpit from 'cockpit';
 
 import * as client from './client.js';
 
 const _ = cockpit.gettext;
 
-class ContainerRestoreModal extends React.Component {
-    static contextType = DialogsContext;
+const ContainerRestoreModal = ({ containerWillRestore, onAddNotification }) => {
+    const Dialogs = useDialogs();
 
-    constructor(props) {
-        super(props);
-        this.state = {
-            inProgress: false,
-            keep: false,
-            tcpEstablished: false,
-            ignoreRootFS: false,
-            ignoreStaticIP: false,
-            ignoreStaticMAC: false
-        };
-        this.handleChange = this.handleChange.bind(this);
-    }
+    const [inProgress, setInProgress] = useState(false);
+    const [keep, setKeep] = useState(false);
+    const [tcpEstablished, setTcpEstablished] = useState(false);
+    const [ignoreStaticIP, setIgnoreStaticIP] = useState(false);
+    const [ignoreStaticMAC, setIgnoreStaticMAC] = useState(false);
 
-    handleChange(checked, event) {
-        if (event.target.type === "checkbox")
-            this.setState({ [event.target.name]: event.target.checked });
-    }
-
-    handleRestoreContainer(args) {
-        const Dialogs = this.context;
-        const container = this.props.containerWillRestore;
-        this.setState({ inProgress: true });
-        client.postContainer(container.isSystem, "restore", container.Id, args)
+    const handleRestoreContainer = (args) => {
+        setInProgress(true);
+        client.postContainer(containerWillRestore.isSystem, "restore", containerWillRestore.Id, args)
                 .catch(ex => {
-                    const error = cockpit.format(_("Failed to restore container $0"), container.Names);
-                    this.props.onAddNotification({ type: 'danger', error, errorDetail: ex.message });
-                    this.setState({ inProgress: false });
+                    const error = cockpit.format(_("Failed to restore container $0"), containerWillRestore.Names);
+                    onAddNotification({ type: 'danger', error, errorDetail: ex.message });
+                    setInProgress(false);
                 })
                 .finally(() => {
                     Dialogs.close();
                 });
-    }
+    };
 
-    render() {
-        const Dialogs = this.context;
-        return (
-            <Modal isOpen
-                   showClose={false}
-                   position="top" variant="medium"
-                   title={cockpit.format(_("Restore container $0"), this.props.containerWillRestore.Names)}
-                   footer={<>
-                       <Button variant="primary" isDisabled={this.state.inProgress}
-                               isLoading={this.state.inProgress}
-                               onClick={() => {
-                                   this.handleRestoreContainer({
-                                       keep: this.state.keep,
-                                       leaveRunning: this.state.leaveRunning,
-                                       tcpEstablished: this.state.tcpEstablished,
-                                       ignoreRootFS: this.state.ignoreRootFS
-                                   });
-                               }}>
-                           {_("Restore")}
-                       </Button>
-                       <Button variant="link" isDisabled={this.state.inProgress}
-                               onClick={Dialogs.close}>
-                           {_("Cancel")}
-                       </Button>
-                   </>}
-            >
-                <Form isHorizontal>
-                    <Checkbox label={_("Keep all temporary checkpoint files")} id="restore-dialog-keep" name="keep"
-                              isChecked={this.state.keep} onChange={this.handleChange} />
-                    <Checkbox label={_("Restore with established TCP connections")}
-                              id="restore-dialog-tcpEstablished" name="tcpEstablished"
-                              isChecked={this.state.tcpEstablished} onChange={this.handleChange} />
-                    <Checkbox label={_("Ignore IP address if set statically")} id="restore-dialog-ignoreStaticIP"
-                              name="ignoreStaticIP" isChecked={this.state.ignoreStaticIP}
-                              onChange={this.handleChange} />
-                    <Checkbox label={_("Ignore MAC address if set statically")} id="restore-dialog-ignoreStaticMAC"
-                              name="ignoreStaticMAC" isChecked={this.state.ignoreStaticMAC}
-                              onChange={this.handleChange} />
-                </Form>
-            </Modal>
-        );
-    }
-}
+    return (
+        <Modal isOpen
+               showClose={false}
+               position="top" variant="medium"
+               title={cockpit.format(_("Restore container $0"), containerWillRestore.Names)}
+               footer={<>
+                   <Button variant="primary" isDisabled={inProgress}
+                           isLoading={inProgress}
+                           onClick={() => {
+                               handleRestoreContainer({
+                                   keep: keep,
+                                   tcpEstablished: tcpEstablished,
+                               });
+                           }}>
+                       {_("Restore")}
+                   </Button>
+                   <Button variant="link" isDisabled={inProgress}
+                           onClick={Dialogs.close}>
+                       {_("Cancel")}
+                   </Button>
+               </>}
+        >
+            <Form isHorizontal>
+                <Checkbox label={_("Keep all temporary checkpoint files")} id="restore-dialog-keep" name="keep"
+                          isChecked={keep} onChange={setKeep} />
+                <Checkbox label={_("Restore with established TCP connections")}
+                          id="restore-dialog-tcpEstablished" name="tcpEstablished"
+                          isChecked={tcpEstablished} onChange={setTcpEstablished} />
+                <Checkbox label={_("Ignore IP address if set statically")} id="restore-dialog-ignoreStaticIP"
+                          name="ignoreStaticIP" isChecked={ignoreStaticIP}
+                          onChange={setIgnoreStaticIP} />
+                <Checkbox label={_("Ignore MAC address if set statically")} id="restore-dialog-ignoreStaticMAC"
+                          name="ignoreStaticMAC" isChecked={ignoreStaticMAC}
+                          onChange={setIgnoreStaticMAC} />
+            </Form>
+        </Modal>
+    );
+};
 
 export default ContainerRestoreModal;

--- a/test/check-application
+++ b/test/check-application
@@ -1132,7 +1132,6 @@ class TestApplication(testlib.MachineCase):
         self.performContainerAction("busybox:latest", "Checkpoint")
         b.set_checked('.pf-c-modal-box input#checkpoint-dialog-keep', True)
         b.set_checked('.pf-c-modal-box input#checkpoint-dialog-tcpEstablished', True)
-        b.set_checked('.pf-c-modal-box input#checkpoint-dialog-ignoreRootFS', True)
         b.click('.pf-c-modal-box button:contains(Checkpoint)')
         b.wait_not_present('.modal_dialog')
 
@@ -1175,7 +1174,6 @@ class TestApplication(testlib.MachineCase):
         self.performContainerAction("swamped-crate", "Checkpoint")
         b.set_checked('.pf-c-modal-box input#checkpoint-dialog-keep', True)
         b.set_checked('.pf-c-modal-box input#checkpoint-dialog-tcpEstablished', True)
-        b.set_checked('.pf-c-modal-box input#checkpoint-dialog-ignoreRootFS', True)
         b.click('.pf-c-modal-box button:contains(Checkpoint)')
 
         with b.wait_timeout(300):


### PR DESCRIPTION
Ideally we would also test the TCP connection / MAC and IP related checkboxes on restore, but from a small test:

```
cat /sys/class/net/*/address
```

The MAC address does not really change, and we can't change it with the alpineimage as it has no.

Turns out while making this PR I realised we have a busybox image which has `ip`

But reading the man page.. we need to create a container with `--mac-address` and `--ip` to test this functionality. This can be done but from my testing it seems to be broken?!

```
podman run -dit --mac-address 92:d0:c6:0a:29:38 --name fo busybox:latest sh
```

```
podman container checkpoint fo
```

```
podman container restore --ignore-static-mac fo
```

```
podman inspect --format '{{.NetworkSettings.MacAddress}}' fo
```

```
[root@fedora-37-127-0-0-2-2201 ~]# podman inspect --format '{{.NetworkSettings.MacAddress}}' fo
92:d0:c6:0a:29:38
```

So this sounds like a podman bug, and I don't see any tests for it in their repository. Reported it here https://github.com/containers/podman/issues/16666
