### PR TITLE
Prefill command from image

### DIFF
--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -103,7 +103,7 @@ export class ImageRunModal extends React.Component {
 
     constructor(props) {
         super(props);
-        let command = "sh";
+        let command = "";
         if (this.props.image && this.props.image.Command) {
             command = utils.quote_cmdline(this.props.image.Command);
         }
@@ -463,6 +463,11 @@ export class ImageRunModal extends React.Component {
     }
 
     clearImageSelection = () => {
+        // Reset command if it was prefilled
+        let command = this.state.command;
+        if (this.state.selectedImage && this.state.selectedImage.Command && this.state.command === utils.quote_cmdline(this.state.selectedImage.Command))
+            command = "";
+
         this.setState({
             selectedImage: "",
             image: "",
@@ -470,6 +475,7 @@ export class ImageRunModal extends React.Component {
             imageResults: {},
             searchText: "",
             searchFinished: false,
+            command: command,
         });
     }
 
@@ -483,9 +489,14 @@ export class ImageRunModal extends React.Component {
         if (event === undefined)
             return;
 
+        let command = this.state.command;
+        if (value.Command && !command)
+            command = utils.quote_cmdline(value.Command);
+
         this.setState({
             selectedImage: value,
             isImageSelectOpen: false,
+            command: command,
         });
     }
 

--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -8,7 +8,7 @@ import {
     NumberInput, InputGroupTextVariant,
     InputGroup, InputGroupText,
     SelectOption, SelectGroup,
-    TextInput, Tabs, Tab, TabTitleText,
+    TextInput, Tabs, Tab, TabTitleText, Text,
     ToggleGroup, ToggleGroupItem,
     Flex, FlexItem,
     Popover,
@@ -103,10 +103,14 @@ export class ImageRunModal extends React.Component {
 
     constructor(props) {
         super(props);
+
         let command = "";
         if (this.props.image && this.props.image.Command) {
             command = utils.quote_cmdline(this.props.image.Command);
         }
+
+        const entrypoint = utils.quote_cmdline(this.props.image?.Entrypoint);
+
         let selectedImage = "";
         if (this.props.image) {
             selectedImage = utils.image_name(this.props.image);
@@ -119,6 +123,7 @@ export class ImageRunModal extends React.Component {
         this.state = {
             command,
             containerName: dockerNames.getRandomName(),
+            entrypoint,
             env: [],
             hasTTY: true,
             publish: [],
@@ -465,7 +470,7 @@ export class ImageRunModal extends React.Component {
     clearImageSelection = () => {
         // Reset command if it was prefilled
         let command = this.state.command;
-        if (this.state.selectedImage && this.state.selectedImage.Command && this.state.command === utils.quote_cmdline(this.state.selectedImage.Command))
+        if (this.state.command === utils.quote_cmdline(this.state.selectedImage?.Command))
             command = "";
 
         this.setState({
@@ -476,6 +481,7 @@ export class ImageRunModal extends React.Component {
             searchText: "",
             searchFinished: false,
             command: command,
+            entrypoint: "",
         });
     }
 
@@ -493,10 +499,13 @@ export class ImageRunModal extends React.Component {
         if (value.Command && !command)
             command = utils.quote_cmdline(value.Command);
 
+        const entrypoint = utils.quote_cmdline(value?.Entrypoint);
+
         this.setState({
             selectedImage: value,
             isImageSelectOpen: false,
             command: command,
+            entrypoint: entrypoint,
         });
     }
 
@@ -739,6 +748,12 @@ export class ImageRunModal extends React.Component {
                             <Checkbox isChecked={this.state.pullLatestImage} id="run-image-dialog-pull-latest-image"
                                       onChange={value => this.onValueChanged('pullLatestImage', value)} label={_("Pull latest image")}
                             />
+                        </FormGroup>
+                        }
+
+                        {dialogValues.entrypoint &&
+                        <FormGroup fieldId='run-image-dialog-entrypoint' hasNoPaddingTop label={_("Entrypoint")}>
+                            <Text id="run-image-dialog-entrypoint">{dialogValues.entrypoint}</Text>
                         </FormGroup>
                         }
 

--- a/test/check-application
+++ b/test/check-application
@@ -425,6 +425,33 @@ class TestApplication(testlib.MachineCase):
         # Checking images is harder but if there would be more than one this would fail
         b.wait_visible("#containers-images:contains('quay.io/cockpit/registry:2')")
 
+        # Check showing of entrypoint
+        b.click("#containers-containers-create-container-btn")
+        b.click("#create-image-image-select-typeahead")
+        b.click('button.pf-c-select__menu-item:contains("registry:2")')
+        b.wait_val("#run-image-dialog-command", '/etc/docker/registry/config.yml')
+        b.wait_text("#run-image-dialog-entrypoint", '/entrypoint.sh')
+
+        # Deleting image will cleanup both command and entrypoint
+        b.click("button.pf-c-select__toggle-clear")
+        b.wait_val("#run-image-dialog-command", '')
+        b.wait_not_present("#run-image-dialog-entrypoint")
+
+        # Edited command will not be cleared
+        b.click("#create-image-image-select-typeahead")
+        b.click('button.pf-c-select__menu-item:contains("registry:2")')
+        b.wait_val("#run-image-dialog-command", '/etc/docker/registry/config.yml')
+        b.set_input_text("#run-image-dialog-command", '/etc/docker/registry/config.yaml')
+        b.click("button.pf-c-select__toggle-clear")
+        b.wait_not_present("#run-image-dialog-entrypoint")
+        b.wait_val("#run-image-dialog-command", '/etc/docker/registry/config.yaml')
+
+        # Setting a new image will still keep the old command and not prefill it
+        b.click("#create-image-image-select-typeahead")
+        b.click('button.pf-c-select__menu-item:contains("alpine")')
+        b.wait_visible("#run-image-dialog-pull-latest-image")
+        b.wait_val("#run-image-dialog-command", '/etc/docker/registry/config.yaml')
+
         b.logout()
 
         if self.machine.ostree_image:
@@ -449,6 +476,7 @@ class TestApplication(testlib.MachineCase):
         # https://github.com/cockpit-project/cockpit-podman/pull/891
         b.click("#containers-containers-create-container-btn")
         b.set_input_text("#create-image-image-select-typeahead", "registry")
+        b.wait_visible('button.pf-c-select__menu-item:contains("registry")')
 
     @testlib.nondestructive
     def testBasicUser(self):


### PR DESCRIPTION
We prefilled always `sh` as command for new containers but this is wrong. We should always use default command from image. There are multiple changes:
1. Don't offer 'sh', just leave the command field empty
2. If user selects local image prefill the command from image
3. If user selects remote image leave the command input empty
4. If we preffiled the input in 2. and user unselects the image with (x) remove the command if it is still the same
5. If user touches the command all of the above are not applied

Fixes #1126