### PR TITLE
.github: run protection checks on Ubuntu 20.04

### DIFF
--- a/.github/workflows/reposchutz.yml
+++ b/.github/workflows/reposchutz.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check:
     name: Protection checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
The podman version (3.4.4) on Ubuntu 22.04 has issues with pipes and stops before piping the full tarball over (at ~ 25M of ~ 250M). This makes the protection checks fail, which means we can't land node_modules updates. For now pin it to 20.04 until we figured out the issue on 22.04.

Tested this on my own fork but already nuked the main branch. Run can be observed here:
https://github.com/jelly/cockpit-podman/actions/runs/3649718893/jobs/6164758702#step:3:404