### PR TITLE
Keep 'Hide images' toggle even when filtering out all images

### DIFF
--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -297,7 +297,7 @@ class Images extends React.Component {
                     </Flex>
                 </CardHeader>
                 <CardBody>
-                    {filtered.length
+                    {this.props.images && Object.keys(this.props.images).length
                         ? <ExpandableSection toggleText={this.state.isExpanded ? _("Hide images") : _("Show images")}
                                              onToggle={() => this.setState({ isExpanded: !this.state.isExpanded })}
                                              isExpanded={this.state.isExpanded}>


### PR DESCRIPTION
This has two advantages - it is less jumpy when filter hides all images as well as it fixes highlighting on newly added images.