### PR TITLE
packaging: Use GitHub API in debian/watch

### DIFF
--- a/packaging/debian/watch
+++ b/packaging/debian/watch
@@ -1,2 +1,5 @@
 version=4
-https://github.com/cockpit-project/cockpit-podman/releases/ .*/cockpit-podman-([\d\.]+)\.tar\.xz
+opts="searchmode=plain, \
+filenamemangle=s/.+\/@PACKAGE@-@ANY_VERSION@.tar.gz/@PACKAGE@-$1\.tar\.xz/" \
+https://api.github.com/repos/cockpit-project/@PACKAGE@/releases \
+https://github.com/cockpit-project/@PACKAGE@/releases/download/\d[\.\d]*/@PACKAGE@-@ANY_VERSION@.tar.xz


### PR DESCRIPTION
The /releases page has become JavaScript-y recently and thus unreadable by machines. Scan the API instead and construct a download URL.

----

Same change as in https://github.com/cockpit-project/cockpit/pull/18048 . I can use the exact same file, due to the handy `@PACKAGE@` macro.

```
$ uscan --report --verbose
uscan info: Found the following matching hrefs on the web page (newest first):
   https://github.com/cockpit-project/cockpit-podman/releases/download/58/cockpit-podman-58.tar.xz (58) index=58-4 
   https://github.com/cockpit-project/cockpit-podman/releases/download/57/cockpit-podman-57.tar.xz (57) index=57-4 
   https://github.com/cockpit-project/cockpit-podman/releases/download/56/cockpit-podman-56.tar.xz (56) index=56-4 
[...]
uscan: Newest version of cockpit-podman on remote site is 58, local version is 57
uscan:  => Newer package available from:
        => https://github.com/cockpit-project/cockpit-podman/releases/download/58/cockpit-podman-58.tar.xz
uscan info: Scan finished
```