### PR TITLE
test: Increase wait timeout for Services page

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -1249,7 +1249,9 @@ class TestApplication(testlib.MachineCase):
         # Troubleshoot action
         b.click("#app .pf-c-empty-state button.pf-m-link")
         b.enter_page("/system/services")
-        b.wait_in_text("#service-details", "podman.socket")
+        # services page is too slow
+        with b.wait_timeout(60):
+            b.wait_in_text("#service-details", "podman.socket")
 
         # Start action, with enabling (by default)
         b.go("/podman")


### PR DESCRIPTION
The page is utterly slow, and sometimes takes longer than 15s to load on a busy machine.

---

See https://cockpit-logs.us-east-1.linodeobjects.com/pull-1169-20230103-181159-45c8d761-arch/log.html#20-2