### PR TITLE
.github: Fix typo in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
       # https://github.blog/2022-04-12-git-security-vulnerability-announced/
       - name: Pacify git's permission check
-        run: git config --global --add safe.directory /__w/cockpit-machines/cockpit-podman
+        run: git config --global --add safe.directory /__w/cockpit-podman/cockpit-podman
 
       - name: Workaround for https://github.com/actions/checkout/pull/697
         run: git fetch --force origin $(git describe --tags):refs/tags/$(git describe --tags)


### PR DESCRIPTION
Copy pasta from commit e6edcb6a8.