### PR TITLE
packaging: Migrate spec to SPDX license

### DIFF
--- a/packaging/cockpit-podman.spec.in
+++ b/packaging/cockpit-podman.spec.in
@@ -19,7 +19,7 @@ Name:           cockpit-podman
 Version:        %{VERSION}
 Release:        1%{?dist}
 Summary:        Cockpit component for Podman containers
-License:        LGPLv2+
+License:        LGPL-2.1-or-later
 URL:            https://github.com/cockpit-project/cockpit-podman
 
 Source0:        https://github.com/cockpit-project/%{name}/releases/download/%{version}/%{name}-%{version}.tar.xz


### PR DESCRIPTION
See https://fedoraproject.org/wiki/Changes/SPDX_Licenses_Phase_1

Also see 9bb49fe1c4d027a37eab61e8a2b187ffef168a2d in cockpit.