### PR TITLE
tests.speed++

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -2003,6 +2003,7 @@ class TestApplication(testlib.MachineCase):
         b.click("#image-actions-dropdown")
         b.wait_visible("button:contains(Prune unused images).pf-m-disabled")
 
+    @testlib.nondestructive
     def testPruneUnusedImagesSystemSelections(self):
         ''' Test the prune unused images selection options'''
         b = self.browser
@@ -2042,6 +2043,7 @@ class TestApplication(testlib.MachineCase):
         b.click("#image-actions-dropdown")
         b.wait_visible("button:contains(Prune unused images).pf-m-disabled")
 
+    @testlib.nondestructive
     def testCreateContainerValidation(self):
         ''' Test the validation errors'''
         b = self.browser
@@ -2151,17 +2153,21 @@ class TestApplication(testlib.MachineCase):
                             ignore=["thead", "#container-details-healthcheck dt:contains('Failing streak') + dd",
                                     "td[data-label='Started at']"])
 
+    @testlib.nondestructive
     def testHealthcheckSystem(self):
         self._testHealthcheck(True)
 
     @testlib.skipImage("Ubuntu-stable does not get health check run signals", "ubuntu-stable")
+    @testlib.nondestructive
     def testHealthcheckUser(self):
         self._testHealthcheck(False)
 
     @testlib.skipImage("podman-restart not available in debian/ubuntu", *DISTROS_WITHOUT_PODMAN_USER_RESTART)
+    @testlib.nondestructive
     def testPodmanRestartEnabledUser(self):
         self._testPodmanRestartEnabled(False)
 
+    @testlib.nondestructive
     def testPodmanRestartEnabledSystem(self):
         self._testPodmanRestartEnabled(True)
 
@@ -2244,15 +2250,19 @@ class TestApplication(testlib.MachineCase):
             b.wait_visible("#run-image-dialog-owner-user:disabled")
             b.wait_visible("#run-image-dialog-owner-system:disabled")
 
+    @testlib.nondestructive
     def testCreateContainerInPodSystem(self):
         self._testCreateContainerInPod(True)
 
+    @testlib.nondestructive
     def testCreateContainerInPodUser(self):
         self._testCreateContainerInPod(False)
 
+    @testlib.nondestructive
     def testPauseResumeContainerSystem(self):
         self._testPauseResumeContainer(True)
 
+    @testlib.nondestructive
     def testPauseResumeContainerUser(self):
         # rootless cgroupv1 containers do not support pausing
         if not self.has_cgroupsV2:
@@ -2279,9 +2289,11 @@ class TestApplication(testlib.MachineCase):
         self.performContainerAction(container_name, "Resume")
         b.wait(lambda: self.getContainerAttr(container_name, "State") == "Running")
 
+    @testlib.nondestructive
     def testRenameContainerSystem(self):
         self._testRenameContainer(True)
 
+    @testlib.nondestructive
     def testRenameContainerUser(self):
         self._testRenameContainer(False)
 
@@ -2309,6 +2321,7 @@ class TestApplication(testlib.MachineCase):
         self.execute(auth, f"podman inspect --format '{{{{.Id}}}}' {container_name_new}").strip()
         self.waitContainerRow(container_name_new)
 
+    @testlib.nondestructive
     def testMultipleContainers(self):
         self.login()
 
@@ -2322,12 +2335,14 @@ class TestApplication(testlib.MachineCase):
         for i in range(31):
             self.execute(True, f"podman rm -f container{i}")
 
+    @testlib.nondestructive
     def testCreatePodSystem(self):
         self._createPod(True)
 
     # HACK: give podman time to kill the pod containers, can be removed if we
     # have podman 4.0 everywhere and can use podman pod rm -t0
     @testlib.timeout(300)
+    @testlib.nondestructive
     def testCreatePodUser(self):
         self._createPod(False)
 

--- a/test/check-application
+++ b/test/check-application
@@ -1063,7 +1063,7 @@ class TestApplication(testlib.MachineCase):
         self.filter_containers('all')
 
         # run a container
-        self.execute(auth, "podman run -dit --name swamped-crate --stop-timeout 0 busybox:latest sh; podman stop swamped-crate")
+        self.execute(auth, "podman run -d --name swamped-crate --stop-timeout 0 busybox:latest sh -c 'echo 123; sleep infinity'; podman stop swamped-crate")
         b.wait(lambda: self.execute(auth, "podman ps --all | grep -e swamped-crate -e Exited"))
 
         b.wait_visible("#containers-containers")
@@ -1086,7 +1086,7 @@ class TestApplication(testlib.MachineCase):
         container_sha = self.execute(auth, "podman inspect --format '{{.Id}}' swamped-crate").strip()
 
         with b.wait_timeout(5):
-            self.waitContainer(container_sha, auth, name='swamped-crate', image='busybox:latest', cmd='sh',
+            self.waitContainer(container_sha, auth, name='swamped-crate', image='busybox:latest',
                                state='Running', owner="system" if auth else "admin")
 
         def get_cpu_usage(sel):
@@ -1123,7 +1123,7 @@ class TestApplication(testlib.MachineCase):
         b.wait(lambda: old_pid != self.execute(auth, "podman inspect --format '{{.State.Pid}}' swamped-crate".strip()))
 
         with b.wait_timeout(5):
-            self.waitContainer(container_sha, auth, name='swamped-crate', image='busybox:latest', cmd='sh', state='Running')
+            self.waitContainer(container_sha, auth, name='swamped-crate', image='busybox:latest', state='Running')
 
         self.filter_containers('all')
         b.wait_visible("#containers-containers")
@@ -1137,10 +1137,37 @@ class TestApplication(testlib.MachineCase):
         # Stop the container
         self.performContainerAction("busybox:latest", "Force stop")
 
-        self.waitContainer(container_sha, auth, name='swamped-crate', image='busybox:latest', cmd='sh')
+        self.waitContainer(container_sha, auth, name='swamped-crate', image='busybox:latest')
         b.wait(lambda: self.getContainerAttr("swamped-crate", "State") in NOT_RUNNING)
         b.wait(lambda: self.getContainerAttr("swamped-crate", "CPU") == "")
         b.wait(lambda: self.getContainerAttr("swamped-crate", "Memory") == "")
+
+        # Check that console reconnects when container starts
+        self.toggleExpandedContainer("swamped-crate")
+        b.click(".pf-m-expanded button:contains('Console')")
+        b.wait_text(".pf-m-expanded .pf-c-title", "Container is not running")
+        self.performContainerAction("swamped-crate", "Start")
+        b.wait_text(".pf-m-expanded .xterm-accessibility-tree > div:nth-child(1)", "/ # ")
+        b.focus(".pf-m-expanded .xterm-helper-textarea")
+        b.key_press('echo hello\r')
+        b.wait_text(".pf-m-expanded .xterm-accessibility-tree > div:nth-child(2)", "hello")
+        b.wait_text(".pf-m-expanded .xterm-accessibility-tree > div:nth-child(3)", "/ # ")
+        self.performContainerAction("swamped-crate", "Stop")
+        b.wait_text(".pf-m-expanded .xterm-accessibility-tree > div:nth-child(3)", "/ #  disconnected ")
+        sha = self.execute(auth, "podman inspect --format '{{.Id}}' swamped-crate").strip()
+        self.waitContainer(sha, auth, name='swamped-crate', image='busybox:latest', state=NOT_RUNNING)
+        self.performContainerAction("swamped-crate", "Start")
+        self.waitContainer(sha, auth, state='Running')
+        b.wait_text(".pf-m-expanded .xterm-accessibility-tree > div:nth-child(1)", "/ # ")
+        b.wait_not_in_text(".pf-m-expanded .xterm-accessibility-tree > div:nth-child(2)", "hello")
+
+        # Check that logs reconnect when container starts
+        b.click(".pf-m-expanded button:contains('Logs')")
+        self.performContainerAction("swamped-crate", "Stop")
+        self.waitContainer(sha, auth, state=NOT_RUNNING)
+        b.wait_in_text(".pf-m-expanded .container-logs .xterm-accessibility-tree", "Streaming disconnected")
+        self.performContainerAction("swamped-crate", "Start")
+        b.wait_in_text(".pf-m-expanded .container-logs .xterm-accessibility-tree", "Streaming disconnected123")
 
     @testlib.nondestructive
     def testCheckpointRestoreCGroupsV2(self):
@@ -1796,25 +1823,6 @@ class TestApplication(testlib.MachineCase):
         b.wait_text(".pf-m-expanded .xterm-accessibility-tree > div:nth-child(2)", "hello")
         b.wait_text(".pf-m-expanded .xterm-accessibility-tree > div:nth-child(3)", "/ # ")
         b.wait_text(".pf-m-expanded .xterm-accessibility-tree > div:nth-child(1)", "/ # echo hello")
-        self.performContainerAction("busybox-without-publish", "Stop")
-        b.wait_text(".pf-m-expanded .xterm-accessibility-tree > div:nth-child(3)", "/ #  disconnected ")
-        sha = self.execute(auth, "podman inspect --format '{{.Id}}' busybox-without-publish").strip()
-        self.waitContainer(sha, auth, name='busybox-without-publish', image='busybox:latest', state=NOT_RUNNING)
-        self.performContainerAction("busybox-without-publish", "Start")
-        self.waitContainer(sha, auth, state='Running')
-        b.wait_text(".pf-m-expanded .xterm-accessibility-tree > div:nth-child(1)", "/ # ")
-
-        # Check that logs reconnect when container starts
-        b.click(".pf-m-expanded button:contains('Logs')")
-        b.wait_in_text(".pf-m-expanded .container-logs .xterm-accessibility-tree", "2")
-        self.performContainerAction("busybox-without-publish", "Stop")
-        self.waitContainer(sha, auth, state=NOT_RUNNING)
-        b.wait_in_text(".pf-m-expanded .container-logs .xterm-accessibility-tree", "Streaming disconnected")
-        self.performContainerAction("busybox-without-publish", "Start")
-        b.wait_in_text(".pf-m-expanded .container-logs .xterm-accessibility-tree", "Streaming disconnected1")
-
-        self.performContainerAction("busybox-without-publish", "Stop")
-        b.click('#containers-containers tr:contains("busybox-without-publish")')
 
         b.go("#/?name=tty")
         self.check_containers(["busybox-with-tty"], ["busybox-without-publish"])
@@ -1837,15 +1845,8 @@ class TestApplication(testlib.MachineCase):
         self.check_images(["busybox:latest", "alpine:latest", "registry:2"], [])
         b.wait_js_cond('window.location.hash === "#/"')
 
-        b.set_val("#containers-containers-filter", "all")
-        self.waitContainer(sha, auth, name='busybox-without-publish', image='busybox:latest', state=NOT_RUNNING)
-        b.click(".pf-m-expanded button:contains('Console')")
-        b.wait_text(".pf-m-expanded .pf-c-title", "Container is not running")
-
         self.filter_containers("running")
-        b.wait_not_in_text("#containers-containers", "busybox-without-publish")
         id_with_tty = self.execute(auth, "podman inspect --format '{{.Id}}' busybox-with-tty").strip()
-        id_without_publish = self.execute(auth, "podman inspect --format '{{.Id}}' busybox-without-publish").strip()
 
         b.click('#containers-images tbody tr:contains("busybox:latest") td.pf-c-table__toggle button')
         # running container, just selects it, but leaves "Only running" alone
@@ -1855,17 +1856,9 @@ class TestApplication(testlib.MachineCase):
         # FIXME: expanding running container details does not actually work right now
         # b.wait_in_text("#containers-containers tr.pf-m-expanded .container-details", "sleep infinity")
         # stopped container, switches to showing all containers
-        b.click("#containers-images tbody tr:contains('busybox:latest') + tr div.ct-listing-panel-body dt:contains('Used by') + dd button:contains('busybox-without-publish')")
-        b.wait_js_cond('window.location.hash === "#' + id_without_publish + '"')
-        b.wait_val("#containers-containers-filter", "all")
-        b.wait_in_text("#containers-containers", "busybox-without-publish")
-        # auto-expands container details
-        b.wait_in_text("#containers-containers tr.pf-m-expanded .container-details-basic", "sleep infinity")
-
-        b.click('#containers-images tbody tr:contains("alpine:latest") td.pf-c-table__toggle button')
-        b.wait_in_text("#containers-images tbody tr:contains('alpine:latest') td[data-label='Used by']", 'unused')
 
         # Create a container without starting it
+        self.filter_containers("all")
         container_name = "busybox-not-started"
         b.wait_visible('#containers-images td[data-label="Image"]:contains("busybox:latest")')
         b.click('#containers-images tbody tr:contains("busybox:latest") .ct-container-create')
@@ -1873,13 +1866,25 @@ class TestApplication(testlib.MachineCase):
 
         b.wait_val("#create-image-image-select-typeahead", "quay.io/libpod/busybox:latest")
         b.set_input_text("#run-image-dialog-name", container_name)
+        b.set_input_text("#run-image-dialog-command", "sh -c sleep infinity")
 
         b.click('.pf-c-modal-box__footer #create-image-create-btn')
         b.wait_not_present("div.pf-c-modal-box")
 
-        b.wait_val("#containers-containers-filter", "all")
         sha = self.execute(auth, "podman inspect --format '{{.Id}}' " + container_name).strip()
         self.waitContainer(sha, auth, name=container_name, image='busybox:latest', state=['Configured', 'Created'])
+
+        self.filter_containers("running")
+        b.wait_not_in_text("#containers-containers", "busybox-not-started")
+        b.click("#containers-images tbody tr:contains('busybox:latest') + tr div.ct-listing-panel-body dt:contains('Used by') + dd button:contains('busybox-not-started')")
+        b.wait_js_cond(f"window.location.hash === '#{sha}'")
+        b.wait_val("#containers-containers-filter", "all")
+        b.wait_in_text("#containers-containers", "busybox-not-started")
+        # auto-expands container details
+        b.wait_in_text("#containers-containers tbody tr:contains('busybox-not-started') + tr", "sleep infinity")
+
+        b.click('#containers-images tbody tr:contains("alpine:latest") td.pf-c-table__toggle button')
+        b.wait_in_text("#containers-images tbody tr:contains('alpine:latest') td[data-label='Used by']", 'unused')
 
         b.set_input_text('#containers-filter', 'foobar')
         b.wait_in_text('#containers-containers .pf-c-empty-state', 'No containers that match the current filter')

--- a/test/check-application
+++ b/test/check-application
@@ -239,7 +239,7 @@ class TestApplication(testlib.MachineCase):
             self.assertIn(unit, ["GB", "MB", "KB"])
             return float(memory)
 
-        containerId = self.machine.execute("podman run -d --pod pod-1 --name test-pod-1-system alpine sleep 100").strip()
+        containerId = self.machine.execute("podman run -d --pod pod-1 --name test-pod-1-system --stop-timeout 0 alpine sleep 100").strip()
         self.waitPodContainer("pod-1", [{"name": "test-pod-1-system", "image": "alpine", "command": "sleep 100", "state": "Running", "id": containerId}])
         cpu = get_pod_cpu_usage("pod-1")
         b.wait(lambda: get_pod_memory("pod-1") > 0)
@@ -290,7 +290,7 @@ class TestApplication(testlib.MachineCase):
         b.set_input_text('#containers-filter', '')
         self.machine.execute("podman pod create --infra=false --name pod-2")
         self.waitPodContainer("pod-2", [])
-        containerId = self.machine.execute("podman run -d --pod pod-2 --name test-pod-2-system alpine sleep 100").strip()
+        containerId = self.machine.execute("podman run -d --pod pod-2 --name test-pod-2-system --stop-timeout 0 alpine sleep 100").strip()
         self.waitPodContainer("pod-2", [{"name": "test-pod-2-system", "image": "alpine", "command": "sleep 100", "state": "Running", "id": containerId}])
         self.machine.execute("podman rm --force -t0 test-pod-2-system")
         self.waitPodContainer("pod-2", [])
@@ -544,12 +544,12 @@ class TestApplication(testlib.MachineCase):
 
         if auth:
             # Run two containers as system (first exits immediately)
-            self.execute(auth, "podman run -d --name test-sh-system alpine:latest sh")
-            self.execute(auth, "podman run -d --name swamped-crate-system busybox:latest sleep 1000")
+            self.execute(auth, "podman run -d --name test-sh-system --stop-timeout 0 alpine:latest sh")
+            self.execute(auth, "podman run -d --name swamped-crate-system --stop-timeout 0 busybox:latest sleep 1000")
 
         # Run two containers as admin (first exits immediately)
-        self.execute(False, "podman run -d --name test-sh-user alpine:latest sh")
-        self.execute(False, "podman run -d --name swamped-crate-user busybox:latest sleep 1000")
+        self.execute(False, "podman run -d --name test-sh-user --stop-timeout 0 alpine:latest sh")
+        self.execute(False, "podman run -d --name swamped-crate-user --stop-timeout 0 busybox:latest sleep 1000")
 
         # Test owner filtering
         if auth:
@@ -707,7 +707,7 @@ class TestApplication(testlib.MachineCase):
         # Check that we correctly show networking information
         # Rootless don't have this info
         if auth:
-            self.execute(auth, "podman run -dt --name net_check alpine")
+            self.execute(auth, "podman run -dt --name net_check --stop-timeout 0 alpine")
             self.toggleExpandedContainer("net_check")
             b.wait_in_text(".pf-m-expanded .container-details-networking", self.execute(auth, "podman inspect --format '{{.NetworkSettings.Gateway}}' net_check").strip())
             b.wait_in_text(".pf-m-expanded .container-details-networking", self.execute(auth, "podman inspect --format '{{.NetworkSettings.IPAddress}}' net_check").strip())
@@ -717,7 +717,7 @@ class TestApplication(testlib.MachineCase):
             self.toggleExpandedContainer("net_check")
 
         # delete image alpine that has been used by a container
-        self.execute(auth, "podman run -d --name test-sh4 alpine sh")
+        self.execute(auth, "podman run -d --name test-sh4 --stop-timeout 0 alpine sh")
         self.waitContainerRow("test-sh4")
         if auth:
             b.assert_pixels('#app', "overview", ignore=[".ignore-pixels"])
@@ -731,15 +731,15 @@ class TestApplication(testlib.MachineCase):
         b.wait_not_in_text("#containers-images", alpine_sel)
 
         b.wait_collected_text("#containers-containers .container-name", expected_ws)
-        self.execute(auth, "podman run -d --name c quay.io/cockpit/registry:2 sh")
+        self.execute(auth, "podman run -d --name c --stop-timeout 0 quay.io/cockpit/registry:2 sh")
         b.wait_collected_text("#containers-containers .container-name", "c" + expected_ws)
-        self.execute(auth, "podman run -d --name a quay.io/cockpit/registry:2 sh")
+        self.execute(auth, "podman run -d --name a --stop-timeout 0 quay.io/cockpit/registry:2 sh")
         b.wait_collected_text("#containers-containers .container-name", "ac" + expected_ws)
 
-        self.execute(False, "podman run -d --name b quay.io/cockpit/registry:2 sh")
+        self.execute(False, "podman run -d --name b --stop-timeout 0 quay.io/cockpit/registry:2 sh")
         if auth:
             b.wait_collected_text("#containers-containers .container-name", "bac" + expected_ws)
-            self.execute(False, "podman run -d --name doremi quay.io/cockpit/registry:2 sh")
+            self.execute(False, "podman run -d --name doremi --stop-timeout 0 quay.io/cockpit/registry:2 sh")
             b.wait_collected_text("#containers-containers .container-name", "bdoremiac" + expected_ws)
             b.wait(lambda: self.getContainerAttr("doremi", "State") in NOT_RUNNING)
         else:
@@ -780,7 +780,7 @@ class TestApplication(testlib.MachineCase):
         self.login(auth)
 
         # run a container (will exit immediately) and test the display of commit modal
-        self.execute(auth, "podman run -d --name test-sh0 alpine sh -c 'ls -a'")
+        self.execute(auth, "podman run -d --name test-sh0 --stop-timeout 0 alpine sh -c 'ls -a'")
 
         self.filter_containers("all")
         self.waitContainerRow("test-sh0")
@@ -864,7 +864,7 @@ class TestApplication(testlib.MachineCase):
         self.assertIn("vnd.oci.image.manifest", self.execute(auth, "podman inspect --format '{{.ManifestType}}' newname:24").strip())
 
         # Test commit of running container
-        self.execute(auth, "podman run -d --name test-sh2 busybox sleep 1000")
+        self.execute(auth, "podman run -d --name test-sh2 --stop-timeout 0 busybox sleep 1000")
         self.performContainerAction("test-sh2", "Commit")
         b.wait_visible(".pf-c-modal-box")
         b.set_input_text("#commit-dialog-image-name", "newname")
@@ -890,8 +890,8 @@ class TestApplication(testlib.MachineCase):
 
         def prepare():
             # Create and start registry containers
-            self.execute(True, "podman run -d -p 5000:5000 --name registry quay.io/cockpit/registry:2")
-            self.execute(True, "podman run -d -p 6000:5000 --name registry_alt quay.io/cockpit/registry:2")
+            self.execute(True, "podman run -d -p 5000:5000 --name registry --stop-timeout 0 quay.io/cockpit/registry:2")
+            self.execute(True, "podman run -d -p 6000:5000 --name registry_alt --stop-timeout 0 quay.io/cockpit/registry:2")
             # Add local insecure registry into registries conf
             self.machine.write("/etc/containers/registries.conf", REGISTRIES_CONF)
             self.execute(True, "systemctl stop podman.service")
@@ -1063,7 +1063,7 @@ class TestApplication(testlib.MachineCase):
         self.filter_containers('all')
 
         # run a container
-        self.execute(auth, "podman run -dit --name swamped-crate busybox:latest sh; podman stop swamped-crate")
+        self.execute(auth, "podman run -dit --name swamped-crate --stop-timeout 0 busybox:latest sh; podman stop swamped-crate")
         b.wait(lambda: self.execute(auth, "podman ps --all | grep -e swamped-crate -e Exited"))
 
         b.wait_visible("#containers-containers")
@@ -1158,7 +1158,7 @@ class TestApplication(testlib.MachineCase):
         self.filter_containers('all')
 
         # Run a container
-        self.execute(True, "podman run -dit --name swamped-crate busybox:latest sh")
+        self.execute(True, "podman run -dit --name swamped-crate --stop-timeout 0 busybox:latest sh")
         b.wait(lambda: self.execute(True, "podman ps --all | grep -e swamped-crate"))
 
         # Checkpoint the container
@@ -1191,7 +1191,7 @@ class TestApplication(testlib.MachineCase):
         self.filter_containers('all')
 
         # Run a container
-        self.execute(True, "podman run -dit --name swamped-crate busybox:latest sh; podman stop swamped-crate")
+        self.execute(True, "podman run -dit --name swamped-crate --stop-timeout 0 busybox:latest sh; podman stop swamped-crate")
         b.wait(lambda: self.execute(True, "podman ps --all | grep -e swamped-crate -e Exited"))
 
         # Check that the restore option is not present (i.e. start is a regular button)
@@ -1377,12 +1377,12 @@ class TestApplication(testlib.MachineCase):
 
     def _testCreateContainer(self, auth):
         new_container = 'new-container'
-        self.execute(True, f"podman run -d --name {new_container} quay.io/libpod/busybox touch /latest")
+        self.execute(True, f"podman run -d --name {new_container} --stop-timeout 0 quay.io/libpod/busybox touch /latest")
         self.execute(True, f"podman commit {new_container} newimage")
         new_image_sha = self.execute(True, "podman inspect --format '{{.Id}}' newimage").strip()
 
-        self.execute(True, "podman run -d -p 5000:5000 --name registry quay.io/cockpit/registry:2")
-        self.execute(True, "podman run -d -p 6000:5000 --name registry_alt quay.io/cockpit/registry:2")
+        self.execute(True, "podman run -d -p 5000:5000 --name registry --stop-timeout 0 quay.io/cockpit/registry:2")
+        self.execute(True, "podman run -d -p 6000:5000 --name registry_alt --stop-timeout 0 quay.io/cockpit/registry:2")
         # Add local insecure registry into registries conf
         self.machine.write("/etc/containers/registries.conf", REGISTRIES_CONF)
         self.execute(True, "systemctl stop podman.service")
@@ -1967,7 +1967,7 @@ class TestApplication(testlib.MachineCase):
             leftover_images += 1
 
         # By default we have 3 unused images, start one.
-        self.execute(auth or root, "podman run -d --name used_image alpine:latest sh")
+        self.execute(auth or root, "podman run -d --name used_image --stop-timeout 0 alpine:latest sh")
         b.click("#image-actions-dropdown")
         b.click("button:contains(Prune unused images)")
 
@@ -2040,7 +2040,7 @@ class TestApplication(testlib.MachineCase):
         container_name = 'portused'
 
         # Start a podman container which uses a port
-        self.execute(False, "podman run -d -p 5000:5000 --name registry quay.io/cockpit/registry:2")
+        self.execute(False, "podman run -d -p 5000:5000 --name registry --stop-timeout 0 quay.io/cockpit/registry:2")
         b.click("#containers-images button.pf-c-expandable-section__toggle")
 
         b.wait_visible('#containers-images td[data-label="Image"]:contains("busybox:latest")')
@@ -2254,7 +2254,7 @@ class TestApplication(testlib.MachineCase):
         b = self.browser
         container_name = "pauseresume"
 
-        self.execute(auth, f"podman run -dt --name {container_name} alpine")
+        self.execute(auth, f"podman run -dt --name {container_name} --stop-timeout 0 alpine")
         self.login(auth)
 
         self.waitContainerRow(container_name)
@@ -2305,7 +2305,7 @@ class TestApplication(testlib.MachineCase):
 
         # Create 31 containers
         for i in range(31):
-            self.execute(True, f"podman run -dt --name container{i} quay.io/libpod/busybox:latest")
+            self.execute(True, f"podman run -dt --name container{i} --stop-timeout 0 quay.io/libpod/busybox:latest")
 
         self.waitContainerRow("container30")
 
@@ -2374,7 +2374,7 @@ class TestApplication(testlib.MachineCase):
         self.waitPodContainer(pod_name, [])
 
         container_name = 'test-pod-1-system' if auth else 'test-pod-1'
-        containerId = self.execute(auth, f"podman run -d --pod {pod_name} --name {container_name} alpine sleep 500").strip()
+        containerId = self.execute(auth, f"podman run -d --pod {pod_name} --name {container_name} --stop-timeout 0 alpine sleep 500").strip()
         self.waitPodContainer(pod_name, [{"name": container_name, "image": "alpine", "command": "sleep 500", "state": "Running", "id": containerId}], auth)
 
         self.toggleExpandedContainer(container_name)

--- a/test/check-application
+++ b/test/check-application
@@ -1892,6 +1892,10 @@ class TestApplication(testlib.MachineCase):
         b.set_input_text('#containers-filter', '')
 
         if not auth or not self.machine.ostree_image:  # don't kill ws container
+            # Ubuntu has old podman that does not know about --time
+            if not m.image.startswith("ubuntu"):
+                # Remove all containers first as it is not possible to set --time 0 to rmi command
+                self.execute(auth, "podman rm --all --force --time 0")
             self.execute(auth, "podman rmi -af")
             b.wait_in_text('#containers-containers .pf-c-empty-state', 'No containers')
             b.set_val("#containers-containers-filter", "running")


### PR DESCRIPTION
We see in tests often messages like:
`WARNING: Waiting for !ph_is_present("#table-pod-1") took 10.6 seconds, which is 70% of the timeout.`

In current run there are 18 of those, which means we wait for 3 minutes longer than we need to.

[test run before these changes](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1155-20230116-102954-0f64fa41-fedora-37/log)