### PR TITLE
test: drop test extended timeout for testCreatePodUser

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -2339,9 +2339,6 @@ class TestApplication(testlib.MachineCase):
     def testCreatePodSystem(self):
         self._createPod(True)
 
-    # HACK: give podman time to kill the pod containers, can be removed if we
-    # have podman 4.0 everywhere and can use podman pod rm -t0
-    @testlib.timeout(300)
     @testlib.nondestructive
     def testCreatePodUser(self):
         self._createPod(False)


### PR DESCRIPTION
In 3779bb5fc32fb80f4c1bb3 we now start containers with --stop-timeout 0, so this can be dropped.

But let's let the bot check!