### PR TITLE
test: bump reference-image to fedora-37

### DIFF
--- a/test/reference-image
+++ b/test/reference-image
@@ -1,1 +1,1 @@
-fedora-36
+fedora-37


### PR DESCRIPTION
The tasks container is Fedora 37 already.