### PR TITLE
test: Add expected message for Python bridge

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -1335,6 +1335,7 @@ class TestApplication(testlib.MachineCase):
 
         self.allow_restart_journal_messages()
         self.allow_journal_messages(".*podman/podman.sock/.*: couldn't connect:.*")
+        self.allow_journal_messages(".*podman/podman.sock: .*ConnectionRefusedError.*")
         self.allow_journal_messages(".*podman/podman.sock/.*/events.*: received truncated HTTP response.*")
 
     def testCreateContainerSystem(self):


### PR DESCRIPTION
The journal error in `testNotRunning` looks a little different with the
Python bridge.

----

Investigating the remaining failures. Locally, the tests now by and large pass for me.

 - [x] https://github.com/cockpit-project/cockpit/pull/18272
 - [x] https://bodhi.fedoraproject.org/updates/FEDORA-2023-7bc8f746cd
 - [x] Refresh fedora-37 image to pick up cockpit 284: https://github.com/cockpit-project/bots/issues/4345
 - [x] #1199
 - [x] https://github.com/cockpit-project/cockpit/pull/18283