### PR TITLE
Open /logs in binary mode

### DIFF
--- a/src/ContainerLogs.jsx
+++ b/src/ContainerLogs.jsx
@@ -110,6 +110,7 @@ class ContainerLogs extends React.Component {
             method: "GET",
             path: client.VERSION + "libpod/containers/" + this.props.containerId + "/logs",
             body: "",
+            binary: true,
             params: {
                 follow: true,
                 stdout: true,
@@ -140,7 +141,7 @@ class ContainerLogs extends React.Component {
             }
             // First 8 bytes encode information about stream and frame
             // See 'Stream format' on https://docs.docker.com/engine/api/v1.40/#operation/ContainerAttach
-            this.view.writeln(data.substring(8));
+            this.view.writeln(data.slice(8));
         }
     }
 


### PR DESCRIPTION
This endpoint sends binary data -- at least the 8 byte header (which the code strips off), but also the console logs could very well have ASCII control characters and such. The Python bridge decodes text channels a little differently than the C bridge; this fixes container logs with current Python bridge.

---

This does not fully fix the pybridge tests yet, but it fixes [four failures](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1196-20230201-130504-b48aaae7-fedora-37-pybridge/log.html); the last one is `testNotRunning` ("only" unexpected messages), but I'm investigating that in #1196