### PR TITLE
.github: update release action workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: make dist
 
       - name: Publish GitHub release
-        uses: cockpit-project/action-release@62db9d9850a1adec300500d84035c4f523fd5290
+        uses: cockpit-project/action-release@88d994da62d1451c7073e26748c18413fcdf46e9
         with:
           filename: "cockpit-podman-${{ github.ref_name }}.tar.xz"
 


### PR DESCRIPTION
Our latest action-release workflow no longer uses a deprecated github-script version.

Tested on my own fork:

https://github.com/jelly/cockpit-podman/actions/runs/4124178960/jobs/7123118769

Release created successfully

https://github.com/jelly/cockpit-podman/releases/tag/999