### PR TITLE
build: Move to a webpack module, generalize bundler language/variable names

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -20,11 +20,11 @@ your browser.
 
 You can also use
 [watch mode](https://webpack.js.org/guides/development/#using-watch-mode) to
-automatically update the webpack on every code change with
+automatically update the bundle on every code change with
 
     $ make watch
 
-When developing against a virtual machine, webpack can also automatically upload
+When developing against a virtual machine, watch mode can also automatically upload
 the code changes by setting the `RSYNC` environment variable to
 the remote hostname.
 
@@ -41,7 +41,7 @@ set to upload code changes to `~/.local/share/cockpit/` instead of
 Cockpit Podman uses [ESLint](https://eslint.org/) to automatically check
 JavaScript code style in `.jsx` and `.js` files.
 
-The linter is executed within every build as a webpack preloader.
+eslint is executed within every build.
 
 For developer convenience, the ESLint can be started explicitly by:
 
@@ -58,7 +58,7 @@ Rules configuration can be found in the `.eslintrc.json` file.
 Cockpit uses [Stylelint](https://stylelint.io/) to automatically check CSS code
 style in `.css` and `scss` files.
 
-The linter is executed within every build as a webpack preloader.
+styleint is executed within every build.
 
 For developer convenience, the Stylelint can be started explicitly by:
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = 173bb62c36044f23092fbe1d30f6b21177a74980 # 285 + 173bb62c36044f23092fbe1d30f6b21177a74980
+COCKPIT_REPO_COMMIT = 54f2fd58a3645c4a222e2b1b9b5f1b9321bed998 # 285 + Move to a webpack module
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'
@@ -64,10 +64,10 @@ po/$(PACKAGE_NAME).js.pot:
 		--from-code=UTF-8 $$(find src/ -name '*.js' -o -name '*.jsx')
 
 po/$(PACKAGE_NAME).html.pot: $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP)
-	pkg/lib/html2po -o $@ $$(find src -name '*.html')
+	pkg/lib/html2po.js -o $@ $$(find src -name '*.html')
 
 po/$(PACKAGE_NAME).manifest.pot: $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP)
-	pkg/lib/manifest2po src/manifest.json -o $@
+	pkg/lib/manifest2po.js src/manifest.json -o $@
 
 po/$(PACKAGE_NAME).metainfo.pot: $(APPSTREAMFILE)
 	xgettext --default-domain=$(PACKAGE_NAME) --output=$@ $<

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ APPSTREAMFILE=org.cockpit-project.$(PACKAGE_NAME).metainfo.xml
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check for node_modules/
 NODE_MODULES_TEST=package-lock.json
-# one example file in dist/ from webpack to check if that already ran
-WEBPACK_TEST=dist/manifest.json
+# one example file in dist/ from bundler to check if that already ran
+DIST_TEST=dist/manifest.json
 # one example file in pkg/lib to check if it was already checked out
 COCKPIT_REPO_STAMP=pkg/lib/cockpit-po-plugin.js
 # common arguments for tar, mostly to make the generated tarballs reproducible
@@ -25,7 +25,7 @@ RUN_TESTS_OPTIONS+=--coverage
 NODE_ENV=development
 endif
 
-all: $(WEBPACK_TEST)
+all: $(DIST_TEST)
 
 # checkout common files from Cockpit repository required to build this project;
 # this has no API stability guarantee, so check out a stable tag when you start
@@ -91,7 +91,7 @@ packaging/arch/PKGBUILD: packaging/arch/PKGBUILD.in
 packaging/debian/changelog: packaging/debian/changelog.in
 	sed 's/VERSION/$(VERSION)/' $< > $@
 
-$(WEBPACK_TEST): $(COCKPIT_REPO_STAMP) $(shell find src/ -type f) package.json webpack.config.js
+$(DIST_TEST): $(COCKPIT_REPO_STAMP) $(shell find src/ -type f) package.json webpack.config.js
 	$(MAKE) package-lock.json && NODE_ENV=$(NODE_ENV) node_modules/.bin/webpack
 	# In development mode terser does not run and so no LICENSE.txt.gz is generated, so we explictly create it as it is required for building rpm's
 	if [ "$$NODE_ENV" = "development" ]; then \
@@ -99,14 +99,14 @@ $(WEBPACK_TEST): $(COCKPIT_REPO_STAMP) $(shell find src/ -type f) package.json w
 	fi
 
 watch:
-	NODE_ENV=$(NODE_ENV) node_modules/.bin/webpack --watch
+	NODE_ENV=$(NODE_ENV) npm run watch
 
 clean:
 	rm -rf dist/
 	rm -f $(SPEC) packaging/arch/PKGBUILD packaging/debian/changelog
 	rm -f po/LINGUAS
 
-install: $(WEBPACK_TEST) po/LINGUAS
+install: $(DIST_TEST) po/LINGUAS
 	mkdir -p $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)
 	cp -r dist/* $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)
 	mkdir -p $(DESTDIR)/usr/share/metainfo/
@@ -115,7 +115,7 @@ install: $(WEBPACK_TEST) po/LINGUAS
 		-o $(DESTDIR)/usr/share/metainfo/$(APPSTREAMFILE)
 
 # this requires a built source tree and avoids having to install anything system-wide
-devel-install: $(WEBPACK_TEST)
+devel-install: $(DIST_TEST)
 	mkdir -p ~/.local/share/cockpit
 	ln -s `pwd`/dist ~/.local/share/cockpit/$(PACKAGE_NAME)
 
@@ -138,11 +138,11 @@ TEST_NPMS = \
 dist: $(TARFILE)
 	@ls -1 $(TARFILE)
 
-# when building a distribution tarball, call webpack with a 'production' environment by default
+# when building a distribution tarball, call bundler with a 'production' environment by default
 # we don't ship most node_modules for license and compactness reasons, only the ones necessary for running tests
 # we ship a pre-built dist/ (so it's not necessary) and ship package-lock.json (so that node_modules/ can be reconstructed if necessary)
 $(TARFILE): export NODE_ENV ?= production
-$(TARFILE): $(WEBPACK_TEST) $(SPEC) packaging/arch/PKGBUILD packaging/debian/changelog
+$(TARFILE): $(DIST_TEST) $(SPEC) packaging/arch/PKGBUILD packaging/debian/changelog
 	if type appstream-util >/dev/null 2>&1; then appstream-util validate-relax --nonet *.metainfo.xml; fi
 	tar --xz $(TAR_ARGS) -cf $(TARFILE) --transform 's,^,$(RPM_NAME)/,' \
 		--exclude '*.in' --exclude test/reference \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "podman",
   "description": "Cockpit UI for Podman Containers",
+  "type": "module",
   "main": "index.js",
   "repository": "git@github.com:cockpit-project/cockpit-podman.git",
   "author": "",

--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -4,11 +4,11 @@ Source: https://github.com/cockpit-project/cockpit-podman
 Comment:
  This does not directly cover the files in dist/*. These are "minified" and
  compressed JavaScript/HTML files built from src/, lib/, po/, and node_modules/
- with node, npm, and webpack. node_modules/ is not shipped as part of the
+ with node, npm, and a bundler. node_modules/ is not shipped as part of the
  upstream release tarballs, but can be reconstructed precisely through the
  shipped package-lock.json with the command "npm install".  Rebuilding files in
  dist/ requires internet access as that process needs to download additional
- npm modules from the Internet, thus upstream ships the pre-minified webpacks
+ npm modules from the Internet, thus upstream ships the pre-minified bundles
  as part of the upstream release tarball so that the package can be built
  without internet access and lots of extra unpackaged build dependencies.
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,6 @@
 import cockpit from 'cockpit';
 
-import * as dfnlocales from 'date-fns/locale';
+import * as dfnlocales from 'date-fns/locale/index.js';
 import { formatRelative } from 'date-fns';
 const _ = cockpit.gettext;
 

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -18,6 +18,11 @@ chmod a+w "$LOGS"
 # we don't need the H.264 codec, and it is sometimes not available (rhbz#2005760)
 dnf install --disablerepo=fedora-cisco-openh264 -y --setopt=install_weak_deps=False firefox
 
+# nodejs 10 is too old for current Cockpit test API
+if grep -q platform:el8 /etc/os-release; then
+    dnf module switch-to -y nodejs:16
+fi
+
 # HACK: ensure that critical components are up to date: https://github.com/psss/tmt/issues/682
 dnf update -y podman crun conmon criu
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,15 +1,15 @@
-const fs = require("fs");
-const path = require("path");
+import fs from "fs";
 
-const copy = require("copy-webpack-plugin");
-const extract = require("mini-css-extract-plugin");
-const TerserJSPlugin = require('terser-webpack-plugin');
-const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
-const CompressionPlugin = require("compression-webpack-plugin");
-const ESLintPlugin = require('eslint-webpack-plugin');
-const CockpitPoPlugin = require("./pkg/lib/cockpit-po-plugin");
-const CockpitRsyncPlugin = require("./pkg/lib/cockpit-rsync-plugin");
-const StylelintPlugin = require('stylelint-webpack-plugin');
+import copy from "copy-webpack-plugin";
+import extract from "mini-css-extract-plugin";
+import TerserJSPlugin from 'terser-webpack-plugin';
+import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
+import CompressionPlugin from "compression-webpack-plugin";
+import ESLintPlugin from 'eslint-webpack-plugin';
+import StylelintPlugin from 'stylelint-webpack-plugin';
+
+import CockpitPoPlugin from "./pkg/lib/cockpit-po-plugin.js";
+import CockpitRsyncPlugin from "./pkg/lib/cockpit-rsync-plugin.js";
 
 /* A standard nodejs and webpack pattern */
 const production = process.env.NODE_ENV === 'production';
@@ -31,9 +31,9 @@ const copy_files = [
 
 const plugins = [
     new copy({ patterns: copy_files }),
-    new extract({filename: "[name].css"}),
+    new extract({ filename: "[name].css" }),
     new CockpitPoPlugin(),
-    new CockpitRsyncPlugin({dest: packageJson.name}),
+    new CockpitRsyncPlugin({ dest: packageJson.name }),
 ];
 
 if (eslint) {
@@ -42,7 +42,7 @@ if (eslint) {
 
 if (stylelint) {
     plugins.push(new StylelintPlugin({
-      context: "src/",
+        context: "src/",
     }));
 }
 
@@ -54,14 +54,14 @@ if (production) {
     }));
 }
 
-module.exports = {
+const config = {
     mode: production ? 'production' : 'development',
     resolve: {
-        modules: [ "node_modules", path.resolve(__dirname, 'pkg/lib') ],
+        modules: ['node_modules', 'pkg/lib'],
         alias: { 'font-awesome': 'font-awesome-sass/assets/stylesheets' },
     },
     resolveLoader: {
-        modules: [ "node_modules", path.resolve(__dirname, 'pkg/lib') ],
+        modules: ['node_modules', 'pkg/lib'],
     },
     watchOptions: {
         ignored: /node_modules/,
@@ -158,5 +158,7 @@ module.exports = {
             },
         ]
     },
-    plugins: plugins
-}
+    plugins
+};
+
+export default config;


### PR DESCRIPTION
Cockpit recently changed to an ESM build system [1]. Bump COCKPIT_REPO_COMMIT to that and follow suit.

This does not work with old node.js 10 any more which is still the default in RHEL 8. Install the newer version 16 instead.

[1] https://github.com/cockpit-project/cockpit/pull/18366

----

Pretty much identical to https://github.com/cockpit-project/starter-kit/pull/625 except for the node_modules submodule refresh.