### PR TITLE
Use whole path in patternfly imports

### DIFF
--- a/src/ContainerCheckpointModal.jsx
+++ b/src/ContainerCheckpointModal.jsx
@@ -1,5 +1,8 @@
 import React, { useState } from 'react';
-import { Button, Checkbox, Form, Modal } from '@patternfly/react-core';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
+import { Form } from "@patternfly/react-core/dist/esm/components/Form";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { useDialogs } from "dialogs.jsx";
 import cockpit from 'cockpit';
 

--- a/src/ContainerCommitModal.jsx
+++ b/src/ContainerCommitModal.jsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
-import {
-    Button, Checkbox,
-    Form, FormGroup,
-    Modal, TextInput
-} from '@patternfly/react-core';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
+import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import cockpit from 'cockpit';
 
 import * as utils from './util.js';

--- a/src/ContainerDeleteModal.jsx
+++ b/src/ContainerDeleteModal.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, Modal } from '@patternfly/react-core';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { useDialogs } from "dialogs.jsx";
 import cockpit from 'cockpit';
 

--- a/src/ContainerDetails.jsx
+++ b/src/ContainerDetails.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import cockpit from 'cockpit';
 import * as utils from './util.js';
 
-import { DescriptionList, DescriptionListTerm, DescriptionListDescription, DescriptionListGroup, Flex, FlexItem } from "@patternfly/react-core";
+import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from "@patternfly/react-core/dist/esm/components/DescriptionList";
+import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
 
 const _ = cockpit.gettext;
 

--- a/src/ContainerHeader.jsx
+++ b/src/ContainerHeader.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import cockpit from 'cockpit';
-import {
-    FormSelect, FormSelectOption,
-    TextInput, Toolbar, ToolbarContent, ToolbarItem,
-} from '@patternfly/react-core';
+import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
+import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core/dist/esm/components/Toolbar";
 const _ = cockpit.gettext;
 
 const ContainerHeader = ({ user, twoOwners, ownerFilter, handleOwnerChanged, textFilter, handleFilterChanged }) => {

--- a/src/ContainerHealthLogs.jsx
+++ b/src/ContainerHealthLogs.jsx
@@ -23,11 +23,9 @@ import * as utils from './util.js';
 import * as client from './client.js';
 
 import { ListingTable } from "cockpit-components-table.jsx";
-import {
-    Button,
-    DescriptionList, DescriptionListGroup, DescriptionListTerm, DescriptionListDescription,
-    Flex, FlexItem,
-} from '@patternfly/react-core';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from "@patternfly/react-core/dist/esm/components/DescriptionList";
+import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
 import { CheckCircleIcon, ErrorCircleOIcon } from "@patternfly/react-icons";
 
 const _ = cockpit.gettext;

--- a/src/ContainerIntegration.jsx
+++ b/src/ContainerIntegration.jsx
@@ -1,7 +1,10 @@
 import React, { useState } from 'react';
 import cockpit from 'cockpit';
 
-import { Button, DescriptionList, DescriptionListTerm, DescriptionListDescription, DescriptionListGroup, List, ListItem, Tooltip } from "@patternfly/react-core";
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from "@patternfly/react-core/dist/esm/components/DescriptionList";
+import { List, ListItem } from "@patternfly/react-core/dist/esm/components/List";
+import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip";
 
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 

--- a/src/ContainerRenameModal.jsx
+++ b/src/ContainerRenameModal.jsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
-import {
-    Button,
-    Form, FormGroup,
-    Modal, TextInput
-} from '@patternfly/react-core';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import cockpit from 'cockpit';
 
 import * as client from './client.js';

--- a/src/ContainerRestoreModal.jsx
+++ b/src/ContainerRestoreModal.jsx
@@ -1,5 +1,8 @@
 import React, { useState } from 'react';
-import { Button, Checkbox, Form, Modal } from '@patternfly/react-core';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
+import { Form } from "@patternfly/react-core/dist/esm/components/Form";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { useDialogs } from "dialogs.jsx";
 import cockpit from 'cockpit';
 

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -1,17 +1,16 @@
 import React, { useState } from 'react';
-import {
-    Badge,
-    Button,
-    Card, CardBody, CardHeader, CardTitle, CardActions,
-    Divider,
-    Dropdown, DropdownItem, DropdownSeparator,
-    Flex,
-    KebabToggle,
-    Popover,
-    LabelGroup,
-    Text, TextVariants, FormSelect, FormSelectOption,
-    Tooltip, Toolbar, ToolbarContent, ToolbarItem,
-} from '@patternfly/react-core';
+import { Badge } from "@patternfly/react-core/dist/esm/components/Badge";
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Card, CardActions, CardBody, CardHeader, CardTitle } from "@patternfly/react-core/dist/esm/components/Card";
+import { Divider } from "@patternfly/react-core/dist/esm/components/Divider";
+import { Dropdown, DropdownItem, DropdownSeparator, KebabToggle } from "@patternfly/react-core/dist/esm/components/Dropdown";
+import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex";
+import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
+import { LabelGroup } from "@patternfly/react-core/dist/esm/components/LabelGroup";
+import { Text, TextVariants } from "@patternfly/react-core/dist/esm/components/Text";
+import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
+import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip";
+import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core/dist/esm/components/Toolbar";
 import { cellWidth } from '@patternfly/react-table';
 import { MicrochipIcon, MemoryIcon, PortIcon, VolumeIcon, } from '@patternfly/react-icons';
 

--- a/src/Dropdown.jsx
+++ b/src/Dropdown.jsx
@@ -1,10 +1,5 @@
 import React, { useState } from 'react';
-import {
-    Dropdown,
-    DropdownToggle,
-    DropdownToggleAction,
-    DropdownItem,
-} from '@patternfly/react-core';
+import { Dropdown, DropdownItem, DropdownToggle, DropdownToggleAction } from "@patternfly/react-core/dist/esm/components/Dropdown";
 
 export const DropDown = ({ actions }) => {
     const [isOpen, setIsOpen] = useState(false);

--- a/src/DynamicListForm.jsx
+++ b/src/DynamicListForm.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-    Button,
-    EmptyState, EmptyStateBody,
-    FormFieldGroup, FormFieldGroupHeader,
-    HelperText, HelperTextItem,
-} from '@patternfly/react-core';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { EmptyState, EmptyStateBody } from "@patternfly/react-core/dist/esm/components/EmptyState";
+import { FormFieldGroup, FormFieldGroupHeader } from "@patternfly/react-core/dist/esm/components/Form";
+import { HelperText, HelperTextItem } from "@patternfly/react-core/dist/esm/components/HelperText";
 
 import './DynamicListForm.scss';
 

--- a/src/ForceRemoveModal.jsx
+++ b/src/ForceRemoveModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { Button, Modal } from '@patternfly/react-core';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { useDialogs } from "dialogs.jsx";
 import cockpit from 'cockpit';
 

--- a/src/ImageDeleteModal.jsx
+++ b/src/ImageDeleteModal.jsx
@@ -1,5 +1,8 @@
 import React, { useState } from 'react';
-import { Button, Checkbox, Modal, Stack, StackItem } from '@patternfly/react-core';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
+import { Stack, StackItem } from "@patternfly/react-core/dist/esm/layouts/Stack";
 import { useDialogs } from "dialogs.jsx";
 
 import cockpit from 'cockpit';

--- a/src/ImageDetails.jsx
+++ b/src/ImageDetails.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import cockpit from 'cockpit';
 import * as utils from './util.js';
 
-import { DescriptionList, DescriptionListTerm, DescriptionListDescription, DescriptionListGroup } from "@patternfly/react-core";
+import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from "@patternfly/react-core/dist/esm/components/DescriptionList";
 
 import ImageUsedBy from './ImageUsedBy.jsx';
 const _ = cockpit.gettext;

--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -1,18 +1,20 @@
 import React from 'react';
-import {
-    Button, Checkbox,
-    Form, FormGroup,
-    FormSelect, FormSelectOption,
-    Grid, GridItem,
-    Modal, Radio, Select, SelectVariant,
-    NumberInput, InputGroupTextVariant,
-    InputGroup, InputGroupText,
-    SelectOption, SelectGroup,
-    TextInput, Tabs, Tab, TabTitleText, Text,
-    ToggleGroup, ToggleGroupItem,
-    Flex, FlexItem,
-    Popover,
-} from '@patternfly/react-core';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
+import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
+import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
+import { Grid, GridItem } from "@patternfly/react-core/dist/esm/layouts/Grid";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
+import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
+import { Select, SelectGroup, SelectOption, SelectVariant } from "@patternfly/react-core/dist/esm/components/Select";
+import { NumberInput } from "@patternfly/react-core/dist/esm/components/NumberInput";
+import { InputGroup, InputGroupText, InputGroupTextVariant } from "@patternfly/react-core/dist/esm/components/InputGroup";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
+import { Tab, TabTitleText, Tabs } from "@patternfly/react-core/dist/esm/components/Tabs";
+import { Text } from "@patternfly/react-core/dist/esm/components/Text";
+import { ToggleGroup, ToggleGroupItem } from "@patternfly/react-core/dist/esm/components/ToggleGroup";
+import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
+import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
 import { MinusIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import * as dockerNames from 'docker-names';
 

--- a/src/ImageSearchModal.jsx
+++ b/src/ImageSearchModal.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
-import {
-    Button, DataList, DataListItem, DataListItemRow, DataListCell, DataListItemCells,
-    Flex, Form, FormGroup, FormSelect, FormSelectOption, Modal, Radio, TextInput
-} from '@patternfly/react-core';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { DataList, DataListCell, DataListItem, DataListItemCells, DataListItemRow } from "@patternfly/react-core/dist/esm/components/DataList";
+import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex";
+import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
+import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
+import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";

--- a/src/ImageUsedBy.jsx
+++ b/src/ImageUsedBy.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import cockpit from 'cockpit';
-import { Button, Badge, Flex, List, ListItem } from "@patternfly/react-core";
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Badge } from "@patternfly/react-core/dist/esm/components/Badge";
+import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex";
+import { List, ListItem } from "@patternfly/react-core/dist/esm/components/List";
 
 const _ = cockpit.gettext;
 

--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -1,13 +1,10 @@
 import React, { useState } from 'react';
-import {
-    Button,
-    Card, CardBody, CardHeader, CardFooter, CardTitle,
-    Dropdown, DropdownItem,
-    Flex, FlexItem,
-    ExpandableSection,
-    KebabToggle,
-    Text, TextVariants
-} from '@patternfly/react-core';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Card, CardBody, CardFooter, CardHeader, CardTitle } from "@patternfly/react-core/dist/esm/components/Card";
+import { Dropdown, DropdownItem, KebabToggle } from "@patternfly/react-core/dist/esm/components/Dropdown";
+import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
+import { ExpandableSection } from "@patternfly/react-core/dist/esm/components/ExpandableSection";
+import { Text, TextVariants } from "@patternfly/react-core/dist/esm/components/Text";
 import { cellWidth } from '@patternfly/react-table';
 
 import cockpit from 'cockpit';

--- a/src/Notification.jsx
+++ b/src/Notification.jsx
@@ -17,7 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 import React from 'react';
-import { Alert, AlertActionCloseButton } from '@patternfly/react-core';
+import { Alert, AlertActionCloseButton } from "@patternfly/react-core/dist/esm/components/Alert";
 
 import cockpit from 'cockpit';
 

--- a/src/PodActions.jsx
+++ b/src/PodActions.jsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 
 import * as client from './client.js';
-import {
-    Button, Alert, Modal,
-    Dropdown, DropdownPosition, DropdownItem, DropdownSeparator,
-    KebabToggle, List, ListItem,
-    Stack,
-} from '@patternfly/react-core';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Alert } from "@patternfly/react-core/dist/esm/components/Alert";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
+import { Dropdown, DropdownItem, DropdownPosition, DropdownSeparator, KebabToggle } from "@patternfly/react-core/dist/esm/components/Dropdown";
+import { List, ListItem } from "@patternfly/react-core/dist/esm/components/List";
+import { Stack } from "@patternfly/react-core/dist/esm/layouts/Stack";
 import { useDialogs } from "dialogs.jsx";
 
 import cockpit from 'cockpit';

--- a/src/PodCreateModal.jsx
+++ b/src/PodCreateModal.jsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
-import {
-    Button,
-    Form, FormGroup, Modal, Radio,
-    TextInput,
-} from '@patternfly/react-core';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
+import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import * as dockerNames from 'docker-names';
 
 import { ErrorNotification } from './Notification.jsx';

--- a/src/PruneUnusedImagesModal.jsx
+++ b/src/PruneUnusedImagesModal.jsx
@@ -1,5 +1,9 @@
 import React, { useState } from 'react';
-import { Button, Checkbox, Flex, List, ListItem, Modal, } from '@patternfly/react-core';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
+import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex";
+import { List, ListItem } from "@patternfly/react-core/dist/esm/components/List";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import cockpit from 'cockpit';
 
 import * as client from './client.js';

--- a/src/PublishPort.jsx
+++ b/src/PublishPort.jsx
@@ -1,12 +1,10 @@
 import React from 'react';
-import {
-    Button,
-    FormGroup,
-    FormSelect, FormSelectOption,
-    Grid,
-    TextInput,
-    Popover,
-} from '@patternfly/react-core';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
+import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
+import { Grid } from "@patternfly/react-core/dist/esm/layouts/Grid";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
+import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
 import { MinusIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import cockpit from 'cockpit';
 

--- a/src/Volume.jsx
+++ b/src/Volume.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import {
-    Button, Checkbox,
-    FormGroup,
-    FormSelect, FormSelectOption,
-    Grid,
-    TextInput,
-} from '@patternfly/react-core';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
+import { FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
+import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
+import { Grid } from "@patternfly/react-core/dist/esm/layouts/Grid";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import { MinusIcon } from '@patternfly/react-icons';
 import { FileAutoComplete } from 'cockpit-components-file-autocomplete.jsx';
 import cockpit from 'cockpit';

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -18,13 +18,14 @@
  */
 
 import React from 'react';
-import {
-    Page, PageSection, PageSectionVariants,
-    Alert, AlertActionLink, AlertActionCloseButton, AlertGroup,
-    Button, Checkbox, Title,
-    EmptyState, EmptyStateVariant, EmptyStateIcon, EmptyStateSecondaryActions,
-    Stack,
-} from '@patternfly/react-core';
+import { Page, PageSection, PageSectionVariants } from "@patternfly/react-core/dist/esm/components/Page";
+import { Alert, AlertActionCloseButton, AlertActionLink } from "@patternfly/react-core/dist/esm/components/Alert";
+import { AlertGroup } from "@patternfly/react-core/dist/esm/components/AlertGroup";
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
+import { Title } from "@patternfly/react-core/dist/esm/components/Title";
+import { EmptyState, EmptyStateIcon, EmptyStateSecondaryActions, EmptyStateVariant } from "@patternfly/react-core/dist/esm/components/EmptyState";
+import { Stack } from "@patternfly/react-core/dist/esm/layouts/Stack";
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { WithDialogs } from "dialogs.jsx";
 


### PR DESCRIPTION
Otherwise we rely on treeshaking mechanisms to remove unused code, thus making our bundle size more vulnerable to bundler's ability to drop dead code.