### PR TITLE
fix: show dialog error at the top

### DIFF
--- a/src/ContainerCommitModal.jsx
+++ b/src/ContainerCommitModal.jsx
@@ -3,7 +3,6 @@ import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
-import { Stack, StackItem } from "@patternfly/react-core/dist/esm/layouts/Stack";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import cockpit from 'cockpit';
 
@@ -86,6 +85,7 @@ const ContainerCommitModal = ({ container, localImages }) => {
 
     const commitContent = (
         <Form isHorizontal>
+            {dialogError && <ErrorNotification errorMessage={dialogError} errorDetail={dialogErrorDetail} onDismiss={() => setDialogError("")} />}
             <FormGroup fieldId="commit-dialog-image-name" label={_("New image name")}
                        validated={nameError ? "error" : "default"}
                        helperTextInvalid={nameError}>
@@ -158,12 +158,7 @@ const ContainerCommitModal = ({ container, localImages }) => {
                      </Button>
                  </>}
         >
-            <Stack hasGutter>
-                {dialogError && <ErrorNotification errorMessage={dialogError} errorDetail={dialogErrorDetail} onDismiss={() => setDialogError("")} />}
-                <StackItem>
-                    {commitContent}
-                </StackItem>
-            </Stack>
+            {commitContent}
         </Modal>
     );
 };

--- a/src/ContainerCommitModal.jsx
+++ b/src/ContainerCommitModal.jsx
@@ -3,6 +3,7 @@ import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
+import { Stack, StackItem } from "@patternfly/react-core/dist/esm/layouts/Stack";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import cockpit from 'cockpit';
 
@@ -135,7 +136,6 @@ const ContainerCommitModal = ({ container, localImages }) => {
                  title={_("Commit container")}
                  description={fmt_to_fragments(_("Create a new image based on the current state of the $0 container."), <b>{container.Names}</b>)}
                  footer={<>
-                     {dialogError && <ErrorNotification errorMessage={dialogError} errorDetail={dialogErrorDetail} onDismiss={() => setDialogError("")} />}
                      <Button variant="primary"
                              className="btn-ctr-commit"
                              isLoading={commitInProgress && !nameError}
@@ -158,7 +158,12 @@ const ContainerCommitModal = ({ container, localImages }) => {
                      </Button>
                  </>}
         >
-            {commitContent}
+            <Stack hasGutter>
+                {dialogError && <ErrorNotification errorMessage={dialogError} errorDetail={dialogErrorDetail} onDismiss={() => setDialogError("")} />}
+                <StackItem>
+                    {commitContent}
+                </StackItem>
+            </Stack>
         </Modal>
     );
 };

--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -15,6 +15,7 @@ import { Text } from "@patternfly/react-core/dist/esm/components/Text";
 import { ToggleGroup, ToggleGroupItem } from "@patternfly/react-core/dist/esm/components/ToggleGroup";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
+import { Stack, StackItem } from "@patternfly/react-core/dist/esm/layouts/Stack";
 import { MinusIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import * as dockerNames from 'docker-names';
 
@@ -1030,7 +1031,6 @@ export class ImageRunModal extends React.Component {
                    }}
                    title={this.props.pod ? cockpit.format(_("Create container in $0"), this.props.pod.Name) : _("Create container")}
                    footer={<>
-                       {this.state.dialogError && <ErrorNotification errorMessage={this.state.dialogError} errorDetail={this.state.dialogErrorDetail} />}
                        <Button variant='primary' id="create-image-create-run-btn" onClick={() => this.onCreateClicked(true)} isDisabled={!image && selectedImage === ""}>
                            {_("Create and run")}
                        </Button>
@@ -1042,7 +1042,12 @@ export class ImageRunModal extends React.Component {
                        </Button>
                    </>}
             >
-                {defaultBody}
+                <Stack hasGutter>
+                    {this.state.dialogError && <ErrorNotification errorMessage={this.state.dialogError} errorDetail={this.state.dialogErrorDetail} />}
+                    <StackItem>
+                        {defaultBody}
+                    </StackItem>
+                </Stack>
             </Modal>
         );
     }

--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -15,7 +15,6 @@ import { Text } from "@patternfly/react-core/dist/esm/components/Text";
 import { ToggleGroup, ToggleGroupItem } from "@patternfly/react-core/dist/esm/components/ToggleGroup";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
-import { Stack, StackItem } from "@patternfly/react-core/dist/esm/layouts/Stack";
 import { MinusIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import * as dockerNames from 'docker-names';
 
@@ -678,6 +677,7 @@ export class ImageRunModal extends React.Component {
 
         const defaultBody = (
             <Form>
+                {this.state.dialogError && <ErrorNotification errorMessage={this.state.dialogError} errorDetail={this.state.dialogErrorDetail} />}
                 <FormGroup fieldId='run-image-dialog-name' label={_("Name")} className="ct-m-horizontal">
                     <TextInput id='run-image-dialog-name'
                            className="image-name"
@@ -1042,12 +1042,7 @@ export class ImageRunModal extends React.Component {
                        </Button>
                    </>}
             >
-                <Stack hasGutter>
-                    {this.state.dialogError && <ErrorNotification errorMessage={this.state.dialogError} errorDetail={this.state.dialogErrorDetail} />}
-                    <StackItem>
-                        {defaultBody}
-                    </StackItem>
-                </Stack>
+                {defaultBody}
             </Modal>
         );
     }

--- a/src/ImageSearchModal.jsx
+++ b/src/ImageSearchModal.jsx
@@ -6,7 +6,6 @@ import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form
 import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
-import { Stack, StackItem } from "@patternfly/react-core/dist/esm/layouts/Stack";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
@@ -158,6 +157,7 @@ export class ImageSearchModal extends React.Component {
         const defaultBody = (
             <>
                 <Form isHorizontal>
+                    {this.state.dialogError && <ErrorNotification errorMessage={this.state.dialogError} errorDetail={this.state.dialogErrorDetail} />}
                     { this.props.userServiceAvailable && this.props.systemServiceAvailable &&
                     <FormGroup id="as-user" label={_("Owner")} isInline>
                         <Radio name="user" value="system" id="system" onChange={this.onToggleUser} isChecked={this.state.isSystem} label={_("system")} />
@@ -245,12 +245,7 @@ export class ImageSearchModal extends React.Component {
                        </Button>
                    </>}
             >
-                <Stack hasGutter>
-                    {this.state.dialogError && <ErrorNotification errorMessage={this.state.dialogError} errorDetail={this.state.dialogErrorDetail} />}
-                    <StackItem>
-                        {defaultBody}
-                    </StackItem>
-                </Stack>
+                {defaultBody}
             </Modal>
         );
     }

--- a/src/ImageSearchModal.jsx
+++ b/src/ImageSearchModal.jsx
@@ -6,6 +6,7 @@ import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form
 import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
+import { Stack, StackItem } from "@patternfly/react-core/dist/esm/layouts/Stack";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
@@ -226,7 +227,6 @@ export class ImageSearchModal extends React.Component {
                    onClose={Dialogs.close}
                    title={_("Search for an image")}
                    footer={<>
-                       {this.state.dialogError && <ErrorNotification errorMessage={this.state.dialogError} errorDetail={this.state.dialogErrorDetail} />}
                        <Form isHorizontal className="image-search-tag-form">
                            <FormGroup fieldId="image-search-tag" label={_("Tag")}>
                                <TextInput className="image-tag-entry"
@@ -245,7 +245,12 @@ export class ImageSearchModal extends React.Component {
                        </Button>
                    </>}
             >
-                {defaultBody}
+                <Stack hasGutter>
+                    {this.state.dialogError && <ErrorNotification errorMessage={this.state.dialogError} errorDetail={this.state.dialogErrorDetail} />}
+                    <StackItem>
+                        {defaultBody}
+                    </StackItem>
+                </Stack>
             </Modal>
         );
     }

--- a/src/PodCreateModal.jsx
+++ b/src/PodCreateModal.jsx
@@ -3,6 +3,7 @@ import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
+import { Stack, StackItem } from "@patternfly/react-core/dist/esm/layouts/Stack";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import * as dockerNames from 'docker-names';
 
@@ -147,7 +148,6 @@ export const PodCreateModal = ({ user, selinuxAvailable, systemServiceAvailable,
                 onEscapePress={Dialogs.close}
                 title={_("Create pod")}
                 footer={<>
-                    {dialogError && <ErrorNotification errorMessage={dialogError} errorDetail={dialogErrorDetail} />}
                     <Button variant='primary' id="create-pod-create-btn" onClick={() => onCreateClicked()}
                             isDisabled={nameError}>
                         {_("Create")}
@@ -157,7 +157,12 @@ export const PodCreateModal = ({ user, selinuxAvailable, systemServiceAvailable,
                     </Button>
                 </>}
         >
-            {defaultBody}
+            <Stack hasGutter>
+                {dialogError && <ErrorNotification errorMessage={dialogError} errorDetail={dialogErrorDetail} />}
+                <StackItem>
+                    {defaultBody}
+                </StackItem>
+            </Stack>
         </Modal>
     );
 };

--- a/src/PodCreateModal.jsx
+++ b/src/PodCreateModal.jsx
@@ -3,7 +3,6 @@ import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
-import { Stack, StackItem } from "@patternfly/react-core/dist/esm/layouts/Stack";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import * as dockerNames from 'docker-names';
 
@@ -92,6 +91,7 @@ export const PodCreateModal = ({ user, selinuxAvailable, systemServiceAvailable,
 
     const defaultBody = (
         <Form>
+            {dialogError && <ErrorNotification errorMessage={dialogError} errorDetail={dialogErrorDetail} />}
             <FormGroup fieldId='create-pod-dialog-name' label={_("Name")} className="ct-m-horizontal"
                     validated={nameError ? "error" : "default"}
                     helperTextInvalid={nameError}>
@@ -157,12 +157,7 @@ export const PodCreateModal = ({ user, selinuxAvailable, systemServiceAvailable,
                     </Button>
                 </>}
         >
-            <Stack hasGutter>
-                {dialogError && <ErrorNotification errorMessage={dialogError} errorDetail={dialogErrorDetail} />}
-                <StackItem>
-                    {defaultBody}
-                </StackItem>
-            </Stack>
+            {defaultBody}
         </Modal>
     );
 };


### PR DESCRIPTION
Fixes #1221

Moved dialog errors at the top in these components.
1. ImageRunModal
2. PodCreateModal
3. ImageSearchModal
4. ContainerCommitModal