### PR TITLE
Make containers table sortable

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -6,7 +6,7 @@ const _ = cockpit.gettext;
 
 // https://github.com/containers/podman/blob/main/libpod/define/containerstate.go
 // "Restarting" comes from special handling of restart case in Application.updateContainerAfterEvent()
-export const states = [_("Configured"), _("Created"), _("Running"), _("Stopped"), _("Paused"), _("Exited"), _("Removing"), _("Restarting")];
+export const states = [_("Exited"), _("Paused"), _("Stopped"), _("Removing"), _("Configured"), _("Created"), _("Restart"), _("Running")];
 
 // https://github.com/containers/podman/blob/main/libpod/define/podstate.go
 export const podStates = [_("Created"), _("Running"), _("Stopped"), _("Paused"), _("Exited"), _("Error")];

--- a/test/check-application
+++ b/test/check-application
@@ -616,10 +616,11 @@ class TestApplication(testlib.MachineCase):
             self.confirm_modal("Cancel")
 
         # Checked order of containers
-        expected = "swamped-crate-usertest-sh-user"
+        expected = ["swamped-crate-user", "test-sh-user"]
         if auth:
-            expected += "swamped-crate-systemtest-sh-system"
-        b.wait_collected_text("#containers-containers .container-name", expected + expected_ws)
+            expected.extend(["swamped-crate-system", "test-sh-system"])
+        expected.extend([expected_ws])
+        b.wait_collected_text("#containers-containers .container-name", ''.join(sorted(expected)))
 
         # show running container
         self.filter_containers('running')
@@ -724,9 +725,9 @@ class TestApplication(testlib.MachineCase):
 
         self.execute(False, f"podman run -d --name b --stop-timeout 0 {IMG_REGISTRY} sh")
         if auth:
-            b.wait_collected_text("#containers-containers .container-name", "bac" + expected_ws)
+            b.wait_collected_text("#containers-containers .container-name", "abc" + expected_ws)
             self.execute(False, f"podman run -d --name doremi --stop-timeout 0 {IMG_REGISTRY} sh")
-            b.wait_collected_text("#containers-containers .container-name", "bdoremiac" + expected_ws)
+            b.wait_collected_text("#containers-containers .container-name", "abcdoremi" + expected_ws)
             b.wait(lambda: self.getContainerAttr("doremi", "State") in NOT_RUNNING)
         else:
             b.wait_collected_text("#containers-containers .container-name", "abc")
@@ -2109,15 +2110,15 @@ class TestApplication(testlib.MachineCase):
         expected_ws = ""
         if auth and self.machine.ostree_image:
             expected_ws = "ws"
-        b.wait_collected_text("#containers-containers .container-name", "sickhealthy" + expected_ws)
+        b.wait_collected_text("#containers-containers .container-name", "healthysick" + expected_ws)
 
         self.toggleExpandedContainer("sick")
         b.click(".pf-m-expanded button:contains('Health check')")
         b.wait_visible(".pf-m-expanded .ct-listing-panel-body tbody tr:nth-child(1)")
         b.wait_visible(".pf-m-expanded .ct-listing-panel-body tbody tr:nth-child(4)")
         b.wait_visible(".pf-m-expanded .ct-listing-panel-body tbody tr:nth-child(2) svg.red")
-        b.wait_visible('#container-details-healthcheck dt:contains("Failing streak")')
-        self.assertGreater(int(b.text('#container-details-healthcheck dt:contains("Failing streak") + dd')), 3)
+        b.wait_visible('.pf-m-expanded #container-details-healthcheck dt:contains("Failing streak")')
+        self.assertGreater(int(b.text('.pf-m-expanded #container-details-healthcheck dt:contains("Failing streak") + dd')), 3)
         if auth:
             b.wait_js_func("ph_count_check", ".pf-m-expanded table[aria-label=Logs] tbody tr", 5)
             b.assert_pixels(".pf-m-expanded .pf-c-table__expandable-row-content",


### PR DESCRIPTION
Allow the sorting of the container name, owner, cpu, memory and state. This makes containers sortable and leaves pods unsorted but containers in pods can be sorted. Allowing pods to be sorted with containers would be undesired.

---

# Sort containers

The podman container section now allows a user to sort on name, owner, CPU, memory and state.

![image](https://user-images.githubusercontent.com/67428/225910985-f029f4e3-9309-4820-8449-4390b22added.png)
