### PR TITLE
Add ability to prune unused containers

### DIFF
--- a/src/Containers.scss
+++ b/src/Containers.scss
@@ -81,3 +81,8 @@
 .containers-containers .pf-c-toolbar__content-section {
     gap: var(--pf-global--spacer--sm);
 }
+
+/* Drop the excessive margin for a Dropdown button */
+.containers-containers .pf-c-toolbar__content-section > :nth-last-child(2) {
+    margin-right: 0;
+}

--- a/src/PruneUnusedContainersModal.jsx
+++ b/src/PruneUnusedContainersModal.jsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
+import { SortByDirection } from "@patternfly/react-table";
+import cockpit from 'cockpit';
+import { ListingTable } from 'cockpit-components-table.jsx';
+
+import * as client from './client.js';
+import * as utils from './util.js';
+
+const _ = cockpit.gettext;
+
+const getContainerRow = (container, userSystemServiceAvailable, user, selected) => {
+    const columns = [
+        {
+            title: container.name,
+            sortKey: container.name,
+            props: { width: 25, },
+        },
+        {
+            title: utils.localize_time(Date.parse(container.created) / 1000),
+            props: { width: 20, },
+        },
+    ];
+
+    if (userSystemServiceAvailable)
+        columns.push({
+            title: container.system ? _("system") : <div><span className="ct-grey-text">{_("user:")} </span>{user}</div>,
+            sortKey: container.system.toString(),
+            props: {
+                className: "ignore-pixels",
+                modifier: "nowrap"
+            }
+        });
+
+    return { columns, selected, props: { key: container.id } };
+};
+
+const PruneUnusedContainersModal = ({ close, unusedContainers, onAddNotification, userSystemServiceAvailable, user }) => {
+    const [isPruning, setPruning] = useState(false);
+    const [selectedContainerIds, setSelectedContainerIds] = React.useState(unusedContainers.map(u => u.id));
+
+    const handlePruneUnusedContainers = () => {
+        setPruning(true);
+
+        const actions = [];
+
+        for (const id of selectedContainerIds) {
+            if (id.endsWith("true")) {
+                actions.push(client.delContainer(true, id.replace(/true$/, ""), true));
+            } else {
+                actions.push(client.delContainer(false, id.replace(/false$/, ""), true));
+            }
+        }
+        Promise.all(actions).then(close)
+                .catch(ex => {
+                    const error = _("Failed to prune unused containers");
+                    onAddNotification({ type: 'danger', error, errorDetail: ex.message });
+                    close();
+                });
+    };
+
+    const columns = [
+        { title: _("Name"), sortable: true },
+        { title: _("Created"), sortable: true },
+    ];
+
+    if (userSystemServiceAvailable)
+        columns.push({ title: _("Owner"), sortable: true });
+
+    const selectAllContainers = isSelecting => setSelectedContainerIds(isSelecting ? unusedContainers.map(c => c.id) : []);
+    const isContainerSelected = container => selectedContainerIds.includes(container.id);
+    const setContainerSelected = (container, isSelecting) => setSelectedContainerIds(prevSelected => {
+        const otherSelectedContainerNames = prevSelected.filter(r => r !== container.id);
+        return isSelecting ? [...otherSelectedContainerNames, container.id] : otherSelectedContainerNames;
+    });
+
+    const onSelectContainer = (id, _rowIndex, isSelecting) => {
+        const container = unusedContainers.filter(u => u.id === id)[0];
+        setContainerSelected(container, isSelecting);
+    };
+
+    return (
+        <Modal isOpen
+               onClose={close}
+               position="top" variant="medium"
+               title={cockpit.format(_("Prune unused containers"))}
+               footer={<>
+                   <Button id="btn-img-delete" variant="danger"
+                           spinnerAriaValueText={isPruning ? _("Pruning containers") : undefined}
+                           isLoading={isPruning}
+                           isDisabled={isPruning || selectedContainerIds.length === 0}
+                           onClick={handlePruneUnusedContainers}>
+                       {isPruning ? _("Pruning containers") : _("Prune")}
+                   </Button>
+                   <Button variant="link" onClick={() => close()}>{_("Cancel")}</Button>
+               </>}
+        >
+            <p>{_("Removes selected non-running containers")}</p>
+            <ListingTable columns={columns}
+                          onSelect={(_event, isSelecting, rowIndex, rowData) => onSelectContainer(rowData.props.id, rowIndex, isSelecting)}
+                          onHeaderSelect={(_event, isSelecting) => selectAllContainers(isSelecting)}
+                          id="unused-container-list"
+                          rows={unusedContainers.map(container => getContainerRow(container, userSystemServiceAvailable, user, isContainerSelected(container))) }
+                          variant="compact" sortBy={{ index: 0, direction: SortByDirection.asc }} />
+        </Modal>
+    );
+};
+
+export default PruneUnusedContainersModal;

--- a/test/check-application
+++ b/test/check-application
@@ -2039,6 +2039,56 @@ class TestApplication(testlib.MachineCase):
         b.click("#image-actions-dropdown")
         b.wait_visible("button:contains(Prune unused images).pf-m-disabled")
 
+    def testPruneUnusedContainersSystem(self):
+        self._testPruneUnusedContainersSystem(True)
+
+    def testPruneUnusedContainersUser(self):
+        self._testPruneUnusedContainersSystem(False)
+
+    def _testPruneUnusedContainersSystem(self, auth):
+        '''Test the prune unused container image dialog'''
+
+        b = self.browser
+        self.login(auth)
+
+        # Create running and non-running containers
+        self.execute(auth, "podman pod create --name pod")
+        notrunninginpodId = self.execute(auth, f"podman run --name inpod --pod pod -tid {IMG_BUSYBOX} sh -c 'exit 1'").strip()
+        runninginpodId = self.execute(auth, f"podman run --name inpodrunning --pod pod -tid {IMG_BUSYBOX} sh -c 'sleep infinity'").strip()
+
+        self.execute(auth, f"podman run --name notrunning -tid {IMG_BUSYBOX} sh -c  'exit 1'")
+        self.execute(auth, f"podman run --name containerrunning -tid {IMG_BUSYBOX} sh -c 'sleep infinity'")
+
+        # Create containers for the opposite of what we are, admin or super admin
+        if auth:
+            self.execute(False, f"podman run --name adminnotrunning -tid {IMG_BUSYBOX} sh 'exit 1'")
+            b.wait(lambda: self.getContainerAttr("adminnotrunning", "State") in NOT_RUNNING)
+            self.execute(False, f"podman run --name adminrunning -tid {IMG_BUSYBOX} sh -c 'sleep infinity'")
+            b.wait(lambda: self.getContainerAttr("adminrunning", "State") == "Running")
+
+        b.click("#containers-actions-dropdown")
+        b.click("button:contains(Prune unused containers)")
+
+        if auth:
+            b.wait_in_text(".pf-c-modal-box__body tbody tr:nth-child(1) td[data-label=Name]", "adminnotrunning")
+            b.wait_in_text(".pf-c-modal-box__body tbody tr:nth-child(2) td[data-label=Name]", "notrunning")
+        else:
+            b.wait_in_text(".pf-c-modal-box__body tbody td[data-label=Name]", "notrunning")
+
+        b.click(".pf-c-modal-box button:contains(Prune)")
+        b.wait_not_present(".pf-c-modal-box__body")
+
+        if auth:
+            self.waitContainerRow("notrunning", False)
+            self.waitContainerRow("adminnotrunning", False)
+        else:
+            self.waitContainerRow("notrunning", False)
+
+        # Verify running containers still exists
+        self.waitContainerRow("containerrunning")
+        self.waitPodContainer("pod", [{"name": "inpod", "state": "Exited", "id": notrunninginpodId, "image": IMG_BUSYBOX, "command": 'sh -c "exit 1"'},
+                                      {"name": "inpodrunning", "state": "Running", "id": runninginpodId, "image": IMG_BUSYBOX, "command": 'sh -c "sleep infinity"'}], auth)
+
     def testCreateContainerValidation(self):
         ''' Test the validation errors'''
         b = self.browser


### PR DESCRIPTION
Podman lacked the ability to mass delete stopped or exited containers until recently it introduced `podman container prune`. Podman exposes no new API for this so we filter all containers and display them in a new dialog. The name, created and optionally owner is shown of a container when the user and system session is available.

---

## Podman: Support for pruning unused containers

Cockpit-Podman's latest release features a new "prune" dialog for bulk deletion of stopped and exited containers, similar to `podman container prune`. This dialog provides the option to unselect containers while displaying container names, creation dates, and owner information to help ensure the intended containers are selected for deletion.

![image](https://user-images.githubusercontent.com/67428/226667346-a0a25781-9e8f-42d6-ab48-d24e8a21fd3f.png)


