### PR TITLE
Decode Uint8Array into a string and extract the error message

### DIFF
--- a/src/ContainerLogs.jsx
+++ b/src/ContainerLogs.jsx
@@ -121,8 +121,9 @@ class ContainerLogs extends React.Component {
         connection.monitor(options, this.onStreamMessage, this.props.system, true)
                 .then(this.onStreamClose)
                 .catch(e => {
+                    const error = JSON.parse(new TextDecoder().decode(e.message));
                     this.setState({
-                        errorMessage: e.message,
+                        errorMessage: error.message,
                         streamer: null,
                     });
                 });

--- a/test/check-application
+++ b/test/check-application
@@ -2366,6 +2366,18 @@ class TestApplication(testlib.MachineCase):
             b.set_val("#containers-containers-filter", "all")
             self.waitPodContainer(pod_name, [])
 
+    @testlib.skipImage("passthrough log driver not supported", "ubuntu-*")
+    def testLogErrors(self):
+        b = self.browser
+        container_name = "logissue"
+        self.login()
+
+        self.execute(False, f"podman run --log-driver=passthrough --name {container_name} -d alpine sleep inf </dev/null")
+        self.waitContainerRow(container_name)
+        self.toggleExpandedContainer(container_name)
+        b.click(".pf-m-expanded button:contains('Logs')")
+        b.wait_in_text(".pf-m-expanded .pf-c-empty-state__content", "failed to obtain logs for Container")
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
Since we use a binary channel for the rest API the errors are not strings so we have to decode them and extract the error message.

Closes: #1237

![Screenshot from 2023-03-22 17-23-57](https://user-images.githubusercontent.com/67428/226973441-ce83b1f5-e704-495a-80cd-fb4d6d64daa2.png)
