### PR TITLE
test: debug check if pods are really not started yet

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -380,6 +380,7 @@ class Application extends React.Component {
     }
 
     handleContainerEvent(event, system) {
+        console.log("container event", event, system);
         switch (event.Action) {
         /* The following events do not need to trigger any state updates */
         case 'attach':
@@ -441,6 +442,7 @@ class Application extends React.Component {
     }
 
     handlePodEvent(event, system) {
+        console.log("pod event", event, system);
         switch (event.Action) {
         case 'create':
         case 'kill':


### PR DESCRIPTION
We should probably do:

```
             if not isinstance(state, list):
                 state = [state]
-            b.wait(lambda: b.text(sel + " td[data-label=State]") in state)
+            with b.wait_timeout(10):
+                b.wait(lambda: b.text(sel + " td[data-label=State]") in state)
```

But let's verify.