### PR TITLE
Bump Cockpit lib for esbuild plugin updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = 6c53bff7a21c1558320d358fe7d0bef71f57e141 # 287 + ListingTable onHeaderSelect
+COCKPIT_REPO_COMMIT = cf8186ebf46ec3eda0e59509ce35124ffb9d8372 # 288 + esbuild plugin updates
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'


### PR DESCRIPTION
See https://github.com/cockpit-project/cockpit/pull/18550

This also brings in some PF cleanup to fix spacing between modal
footers. Adjust pixel tests accordingly.

---------

 - [x] Update to actual SHA on main after landing the above

[pixel test review](https://github.com/cockpit-project/pixel-test-reference/compare/df8b4183e267b5d1b92b420dbcbcf2d73cf3f690..d35af163f6f13123a1e95855481606f6aa92e354)