### PR TITLE
fmf: Split into three plans

### DIFF
--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -1,6 +1,19 @@
-summary:
-    Run all tests
 discover:
     how: fmf
 execute:
     how: tmt
+
+/system:
+    summary: Run tests on system podman
+    discover+:
+        test: /test/browser/system
+
+/user:
+    summary: Run tests on user podman
+    discover+:
+        test: /test/browser/user
+
+/misc:
+    summary: Run other tests
+    discover+:
+        test: /test/browser/other

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -eux
 
+# test plan name, passed on to run-test.sh
+PLAN="$1"
+
 TESTS="$(realpath $(dirname "$0"))"
 if [ -d source ]; then
     # path for standard-test-source
@@ -70,7 +73,7 @@ loginctl disable-linger $(id -u admin)
 systemctl enable --now cockpit.socket podman.socket
 
 # Run tests as unprivileged user
-su - -c "env TEST_BROWSER=firefox SOURCE=$SOURCE LOGS=$LOGS $TESTS/run-test.sh" runtest
+su - -c "env TEST_BROWSER=firefox SOURCE=$SOURCE LOGS=$LOGS $TESTS/run-test.sh $PLAN" runtest
 
 RC=$(cat $LOGS/exitcode)
 exit ${RC:-1}

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -1,5 +1,3 @@
-summary:
-    Run browser integration tests on the host
 require:
   - cockpit-podman
   - cockpit-ws
@@ -10,5 +8,16 @@ require:
   - make
   - nodejs
   - python3
-test: ./browser.sh
-duration: 60m
+duration: 30m
+
+/system:
+    test: ./browser.sh system
+    summary: Run *System tests
+
+/user:
+    test: ./browser.sh user
+    summary: Run *User tests
+
+/other:
+    test: ./browser.sh other
+    summary: Run all other tests


### PR DESCRIPTION
A single run already takes half an hour if all tests pass, and a full hour if there are many failures. That's massively longer than the < 10 mins that they take on our upstream CI.

Split the tests into three parts and run them in parallel plans.

----

Comparison with recent single-plan runs: [c8s](https://artifacts.dev.testing-farm.io/7590103b-29d0-4deb-98c3-69f3f2a5010e/) took 29 min ; [F38](https://artifacts.dev.testing-farm.io/9584be6a-c8be-4063-ac93-85675fefe8c4/) took 27 min (pipeline.log) The tests here take between 16 and 21 mins, so about 33% to 50% less.