### PR TITLE
test: correctly restore root login on ostree

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -432,7 +432,7 @@ class TestApplication(testlib.MachineCase):
         if self.machine.ostree_image:
             self.machine.execute("echo foobar | passwd --stdin root")
             self.write_file("/etc/ssh/sshd_config.d/99-root-password.conf", "PermitRootLogin yes",
-                            "systemctl try-restart sshd")
+                            post_restore_action="systemctl try-restart sshd")
             self.machine.execute("systemctl try-restart sshd")
 
         # Test that when root is logged in we don't present "user" and "system"


### PR DESCRIPTION
The third parameter of write_file is append but instead we want to invoke a post restore action.

