### PR TITLE
test: don't lower test timeouts to 5

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -1056,10 +1056,8 @@ class TestApplication(testlib.MachineCase):
         self.performContainerAction("busybox:latest", "Start")
 
         container_sha = self.execute(auth, "podman inspect --format '{{.Id}}' swamped-crate").strip()
-
-        with b.wait_timeout(5):
-            self.waitContainer(container_sha, auth, name='swamped-crate', image='busybox:latest',
-                               state='Running', owner="system" if auth else "admin")
+        self.waitContainer(container_sha, auth, name='swamped-crate', image='busybox:latest',
+                           state='Running', owner="system" if auth else "admin")
 
         def get_cpu_usage(sel):
             cpu = self.getContainerAttr(sel, "CPU")
@@ -1094,9 +1092,7 @@ class TestApplication(testlib.MachineCase):
         old_pid = self.execute(auth, "podman inspect --format '{{.State.Pid}}' swamped-crate")
         self.performContainerAction("busybox:latest", "Force restart")
         b.wait(lambda: old_pid != self.execute(auth, "podman inspect --format '{{.State.Pid}}' swamped-crate".strip()))
-
-        with b.wait_timeout(5):
-            self.waitContainer(container_sha, auth, name='swamped-crate', image='busybox:latest', state='Running')
+        self.waitContainer(container_sha, auth, name='swamped-crate', image='busybox:latest', state='Running')
 
         self.filter_containers('all')
         b.wait_visible("#containers-containers")


### PR DESCRIPTION
Our normal test timeout is 15, for restarting containers the timeout of 5 is not enough and it flakes occasionally.

context: https://github.com/cockpit-project/cockpit-podman/pull/1241#issuecomment-1488363794

Be aware, we have more flakes, but let's tackle them off one by one