### PR TITLE
test: Use bots' podman-images.setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,15 +165,18 @@ VM_CUSTOMIZE_FLAGS = --install $(COCKPIT_WHEEL)
 endif
 
 # build a VM with locally built distro pkgs installed
-# HACK: Once all our VMs have the new container images, make this --no-network again
+# HACK: Once all our VMs have the new container images, make this --no-network again and drop the podman-images.setup upload
 $(VM_IMAGE): $(TARFILE) packaging/debian/rules packaging/debian/control packaging/arch/PKGBUILD bots $(VM_DEPENDS)
 	# HACK for ostree images: skip the rpm build/install
 	if [ "$$TEST_OS" = "fedora-coreos" ] || [ "$$TEST_OS" = "rhel4edge" ]; then \
 	    bots/image-customize --verbose --fresh --run-command 'mkdir -p /usr/local/share/cockpit' \
+	                         --upload bots/images/scripts/lib/podman-images.setup:/var/tmp/podman-images.setup \
 	                         --upload dist/:/usr/local/share/cockpit/podman \
 	                         --script $(CURDIR)/test/vm.install $(TEST_OS); \
 	else \
-	    bots/image-customize --verbose --fresh $(VM_CUSTOMIZE_FLAGS) --build $(TARFILE) --script $(CURDIR)/test/vm.install $(TEST_OS); \
+	    bots/image-customize --verbose --fresh $(VM_CUSTOMIZE_FLAGS) --build $(TARFILE) \
+	                         --upload bots/images/scripts/lib/podman-images.setup:/var/tmp/podman-images.setup \
+	                         --script $(CURDIR)/test/vm.install $(TEST_OS); \
 	fi
 
 # convenience target for the above

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -60,19 +60,8 @@ echo core > /proc/sys/kernel/core_pattern
 # grab a few images to play with; tests run offline, so they cannot download images
 podman rmi --all
 
-# HACK: call https://github.com/cockpit-project/bots/blob/main/images/scripts/lib/podman-images.setup once that is updated to the
-# new images
-# use images which support multiple architectures
-podman pull quay.io/prometheus/busybox
-podman pull quay.io/jitesoft/alpine
-podman pull quay.io/libpod/registry:2.8
-# the tests expect the image to be called differently, so re-tag them
-podman tag quay.io/prometheus/busybox localhost/test-busybox
-podman rmi quay.io/prometheus/busybox
-podman tag quay.io/jitesoft/alpine localhost/test-alpine
-podman rmi quay.io/jitesoft/alpine
-podman tag quay.io/libpod/registry:2.8 localhost/test-registry
-podman rmi quay.io/libpod/registry:2.8
+# set up our expected images, in the same way that we do for upstream CI
+curl https://raw.githubusercontent.com/cockpit-project/bots/main/images/scripts/lib/podman-images.setup | sh -eux
 
 # copy images for user podman tests; podman insists on user session
 loginctl enable-linger $(id -u admin)

--- a/test/vm.install
+++ b/test/vm.install
@@ -26,19 +26,11 @@ fi
 
 . /usr/lib/os-release
 
-# HACK: this eventually goes into https://github.com/cockpit-project/bots/blob/main/images/scripts/lib/podman-images.setup; remove
-# this once all our images are rebuilt
-
-podman pull quay.io/prometheus/busybox
-podman pull quay.io/jitesoft/alpine
-podman pull quay.io/libpod/registry:2.8
-# the tests expect the image to be called differently, so re-tag them
-podman tag quay.io/prometheus/busybox localhost/test-busybox
-podman rmi quay.io/prometheus/busybox
-podman tag quay.io/jitesoft/alpine localhost/test-alpine
-podman rmi quay.io/jitesoft/alpine
-podman tag quay.io/libpod/registry:2.8 localhost/test-registry
-podman rmi quay.io/libpod/registry:2.8
+# HACK: https://github.com/cockpit-project/bots/pull/4585 started to change the container images
+# on our VM images to the ones we expect; until all of them get rebuild, pull them during image setup
+if ! podman image exists localhost/test-busybox; then
+    /var/tmp/podman-images.setup
+fi
 
 # Remove extra images, tests assume our specific set
 # Since 4.0 podman now ships the pause image


### PR DESCRIPTION
Replace the duplication of image setup with calling podman-images.setup from bots.

In vm.installll, also check if the expected images are already present, to avoid pulling them again on images which are already rebuilt. Once they all are, we can drop this again, and go back to preparing the VM offline.

See https://github.com/cockpit-project/bots/pull/4585

---

I set myself a calendar event in two weeks to check if all images got rebuilt, and drop the container image fetching agian.
