### PR TITLE
packaging: Declare bundled NPM dependencies in spec file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,9 +81,9 @@ po/LINGUAS:
 #
 # Build/Install/dist
 #
-
-%.spec: packaging/%.spec.in
-	sed -e 's/%{VERSION}/$(VERSION)/g' $< > $@
+$(SPEC): packaging/$(SPEC).in $(NODE_MODULES_TEST)
+	provides=$$(npm ls --omit dev --package-lock-only --depth=Infinity | grep -Eo '[^[:space:]]+@[^[:space:]]+' | sort -u | sed 's/^/Provides: bundled(npm(/; s/\(.*\)@/\1)) = /'); \
+	awk -v p="$$provides" '{gsub(/%{VERSION}/, "$(VERSION)"); gsub(/%{NPM_PROVIDES}/, p)}1' $< > $@
 
 packaging/arch/PKGBUILD: packaging/arch/PKGBUILD.in
 	sed 's/VERSION/$(VERSION)/; s/SOURCE/$(TARFILE)/' $< > $@

--- a/packaging/cockpit-podman.spec.in
+++ b/packaging/cockpit-podman.spec.in
@@ -38,6 +38,8 @@ Requires:       podman >= 2.0.4
 Requires:       criu-libs
 %endif
 
+%{NPM_PROVIDES}
+
 %description
 The Cockpit user interface for Podman containers.
 


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=2180520

Turn the pattern make rule into an explicit one, as pattern rules don't support dependencies. We only need it for our single spec file anyway.

Cherry-picked from starter-kit commit 8817969d1.