### PR TITLE
Skip mobile layout where pixel testing overview as it's flaky

### DIFF
--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -178,7 +178,7 @@ class Images extends React.Component {
         const columnTitles = [
             { title: _("Image"), transforms: [cellWidth(20)] },
             { title: _("Owner"), props: { className: "ignore-pixels" } },
-            { title: _("Created"), props: { className: "ignore-pixels" } },
+            { title: _("Created"), props: { className: "ignore-pixels", width: 15 } },
             { title: _("ID"), props: { className: "ignore-pixels" } },
             { title: _("Disk space"), props: { className: "ignore-pixels" } },
             { title: _("Used by"), props: { className: "ignore-pixels" } },

--- a/test/check-application
+++ b/test/check-application
@@ -707,7 +707,7 @@ class TestApplication(testlib.MachineCase):
         self.execute(auth, f"podman run -d --name test-sh4 --stop-timeout 0 {IMG_ALPINE} sh")
         self.waitContainerRow("test-sh4")
         if auth:
-            b.assert_pixels('#app', "overview", ignore=[".ignore-pixels"], skip_layouts=["rtl"])
+            b.assert_pixels('#app', "overview", ignore=[".ignore-pixels"], skip_layouts=["rtl", "mobile"])
         alpine_sel = f"#containers-images tbody tr[data-row-id={images[IMG_ALPINE_LATEST]}{auth}]".lower()
         b.wait_visible(alpine_sel)
         b.click(alpine_sel + " td.pf-c-table__toggle button")


### PR DESCRIPTION
The image creation dates vary between test runs, and their wrapping is neither reliably broken into one nor two lines. Since this is not possible to ignore with a selector as it shifts the UI let's just skip the mobile layout which makes these dates wrap.