### PR TITLE
build.js: esbuild-wasm, build duration, fix sourcemap & no-useless-escape eslint warnings

### DIFF
--- a/build.js
+++ b/build.js
@@ -44,8 +44,8 @@ const context = await esbuild.context({
         cleanPlugin(),
         ...lint
             ? [
-                stylelintPlugin({ filter: new RegExp(cwd + '\/src\/.*\.(css?|scss?)$') }),
-                eslintPlugin({ filter: new RegExp(cwd + '\/src\/.*\.(jsx?|js?)$') })
+                stylelintPlugin({ filter: new RegExp(cwd + '/src/.*\\.(css?|scss?)$') }),
+                eslintPlugin({ filter: new RegExp(cwd + '/src/.*\\.(jsx?|js?)$') })
             ]
             : [],
         // Esbuild will only copy assets that are explicitly imported and used

--- a/build.js
+++ b/build.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import fs from 'fs';
+import fs from 'node:fs';
 
 import copy from 'esbuild-plugin-copy';
 import esbuild from "esbuild";

--- a/build.js
+++ b/build.js
@@ -30,7 +30,7 @@ const getTime = () => new Date().toTimeString()
 const cwd = process.cwd();
 
 const context = await esbuild.context({
-    ...!production ? { sourcemap: "external" } : {},
+    ...!production ? { sourcemap: "linked" } : {},
     bundle: true,
     entryPoints: ["./src/index.js"],
     external: ['*.woff', '*.woff2', '*.jpg', '*.svg', '../../assets*'], // Allow external font files which live in ../../static/fonts

--- a/build.js
+++ b/build.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs';
+import os from 'node:os';
 
 import copy from 'esbuild-plugin-copy';
-import esbuild from "esbuild";
 
 import { cockpitCompressPlugin } from './pkg/lib/esbuild-compress-plugin.js';
 import { cockpitPoEsbuildPlugin } from './pkg/lib/cockpit-po-plugin.js';
@@ -12,6 +12,9 @@ import { cleanPlugin } from './pkg/lib/esbuild-cleanup-plugin.js';
 import { eslintPlugin } from './pkg/lib/esbuild-eslint-plugin.js';
 import { stylelintPlugin } from './pkg/lib/esbuild-stylelint-plugin.js';
 import { esbuildStylesPlugins } from './pkg/lib/esbuild-common.js';
+
+const useWasm = os.arch() !== 'x64';
+const esbuild = (await import(useWasm ? 'esbuild-wasm' : 'esbuild'));
 
 const production = process.env.NODE_ENV === 'production';
 const watchMode = process.env.ESBUILD_WATCH === "true" || false;

--- a/build.js
+++ b/build.js
@@ -24,8 +24,24 @@ const outdir = 'dist';
 // Obtain package name from package.json
 const packageJson = JSON.parse(fs.readFileSync('package.json'));
 
-const getTime = () => new Date().toTimeString()
-        .split(' ')[0];
+function notifyEndPlugin() {
+    return {
+        name: 'notify-end',
+        setup(build) {
+            let startTime;
+
+            build.onStart(() => {
+                startTime = new Date();
+            });
+
+            build.onEnd(() => {
+                const endTime = new Date();
+                const timeStamp = endTime.toTimeString().split(' ')[0];
+                console.log(`${timeStamp}: Build finished in ${endTime - startTime} ms`);
+            });
+        }
+    };
+}
 
 const cwd = process.cwd();
 
@@ -62,12 +78,7 @@ const context = await esbuild.context({
         ...production ? [cockpitCompressPlugin()] : [],
         cockpitRsyncEsbuildPlugin({ dest: packageJson.name }),
 
-        {
-            name: 'notify-end',
-            setup(build) {
-                build.onEnd(() => console.log(`${getTime()}: Build finished`));
-            }
-        },
+        notifyEndPlugin(),
     ]
 });
 

--- a/package.json
+++ b/package.json
@@ -17,10 +17,11 @@
   "devDependencies": {
     "argparse": "^2.0.1",
     "chrome-remote-interface": "^0.32.1",
-    "esbuild": "0.17.10",
+    "esbuild": "^0.17.16",
     "esbuild-plugin-copy": "^2.0.2",
     "esbuild-plugin-replace": "^1.3.0",
     "esbuild-sass-plugin": "2.6.0",
+    "esbuild-wasm": "^0.17.16",
     "eslint": "^8.29.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-config-standard-jsx": "^11.0.0",


### PR DESCRIPTION
Sync with cockpit-machines (https://github.com/cockpit-project/cockpit-machines/commit/00f191f45e2990c861230e79b33e92135b388bb5).

Also fixed no-useless-escape eslint warnings. Taken from https://github.com/cockpit-project/cockpit-machines/commit/e2f0e9fbda60e1adf29b24d764486ec96262f224.