### PR TITLE
Fix management of containersDetails

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -317,7 +317,7 @@ class Application extends React.Component {
                         if (event && event.Action === "restart")
                             reply.State = "restarting";
                         this.updateState("containers", reply.Id + system.toString(), reply);
-                        if (reply.State == "running") {
+                        if (["running", "created", "exited", "paused", "stopped"].find(containerState => containerState === reply.State)) {
                             this.inspectContainerDetail(reply.Id, system);
                         } else {
                             this.setState(prevState => {

--- a/test/check-application
+++ b/test/check-application
@@ -1121,8 +1121,12 @@ class TestApplication(testlib.MachineCase):
         b.wait(lambda: self.getContainerAttr("swamped-crate", "CPU") == "")
         b.wait(lambda: self.getContainerAttr("swamped-crate", "Memory") == "")
 
-        # Check that console reconnects when container starts
+        # Check that container details are not lost when the container is stopped
         self.toggleExpandedContainer("swamped-crate")
+        b.click(".pf-m-expanded button:contains('Integration')")
+        b.wait_visible(f'#containers-containers tr:contains("{IMG_BUSYBOX}") dt:contains("Environment variables")')
+
+        # Check that console reconnects when container starts
         b.click(".pf-m-expanded button:contains('Console')")
         b.wait_text(".pf-m-expanded .pf-c-title", "Container is not running")
         self.performContainerAction("swamped-crate", "Start")
@@ -2287,6 +2291,10 @@ class TestApplication(testlib.MachineCase):
 
         # show all containers and check status
         self.filter_containers('all')
+
+        # Check that container details are not lost when the container is paused
+        b.click(".pf-m-expanded button:contains('Integration')")
+        b.wait_visible(f'#containers-containers tr:contains("{IMG_ALPINE}") dt:contains("Environment variables")')
 
         b.wait(lambda: self.getContainerAttr(container_name, "State") == "Paused")
         b.wait_not_present(self.getContainerAction(container_name, 'Pause'))


### PR DESCRIPTION
Currently containerDetails are deleted when container reaches any other state than "running". Because of this when new container is created or is stopped the Integration tab shows infinite loading until the page is refreshed or the container is started again.