### PR TITLE
workflows: Update to ubuntu-latest, set explicit permissions for cockpit-lib-update

### DIFF
--- a/.github/workflows/cockpit-lib-update.yml
+++ b/.github/workflows/cockpit-lib-update.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   cockpit-lib-update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      statuses: write
     steps:
       - name: Set up dependencies
         run: |

--- a/.github/workflows/npm-update-pf.yml
+++ b/.github/workflows/npm-update-pf.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Clone repository
         uses: actions/checkout@v3

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Clone repository
         uses: actions/checkout@v3

--- a/.github/workflows/reposchutz.yml
+++ b/.github/workflows/reposchutz.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check:
     name: Protection checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/weblate-sync-po.yml
+++ b/.github/workflows/weblate-sync-po.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
       pull-requests: write
       statuses: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up dependencies
         run: |

--- a/.github/workflows/weblate-sync-pot.yml
+++ b/.github/workflows/weblate-sync-pot.yml
@@ -11,7 +11,7 @@ jobs:
     environment: cockpit-podman-weblate
     permissions:
       pull-requests: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up dependencies
         run: |


### PR DESCRIPTION
Like https://github.com/cockpit-project/starter-kit/pull/643 and https://github.com/cockpit-project/cockpit/pull/18668 . The newer ubuntu platform already got tested in cockpit and starter-kit, and most workflows here already had `permissions:`. 

I added `statuses: write`, as the PO workflows have it, too. I'm not sure that we really need it, but it's harmless enough.

I restricted the default token permissions to read-only now. Let's test the lib-update workflow here. [workflow run](https://github.com/cockpit-project/cockpit-podman/actions/runs/4752855378) generated #1275 which looks correct.