### PR TITLE
workflows: Use deploy key for cockpit-lib-update and weblate-sync-po

### DIFF
--- a/.github/workflows/cockpit-lib-update.yml
+++ b/.github/workflows/cockpit-lib-update.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
 jobs:
   cockpit-lib-update:
+    environment: self
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       pull-requests: write
       statuses: write
     steps:
@@ -24,6 +24,8 @@ jobs:
 
       - name: Clone repository
         uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Run cockpit-lib-update
         run: |

--- a/.github/workflows/weblate-sync-po.yml
+++ b/.github/workflows/weblate-sync-po.yml
@@ -9,8 +9,8 @@ on:
 
 jobs:
   po-refresh:
+    environment: self
     permissions:
-      contents: write
       pull-requests: write
       statuses: write
     runs-on: ubuntu-latest
@@ -23,6 +23,7 @@ jobs:
       - name: Clone source repository
         uses: actions/checkout@v3
         with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
           path: src
 
       - name: Clone weblate repository


### PR DESCRIPTION
Pushing the branch with the default GitHub token prevents the "Protection checks" workflow from running, as the default token can't trigger workflows. Do what we do in c-machines and cockpit and use the new `self` environment [1] to pull/push with SSH instead.

[1] https://github.com/cockpit-project/bots/pull/4720

---

I had to land the last few PO updates like PR #1264 with some "sudo" github force, to skip the required "protection checks" run. Same in PR #1278.

 - [x] Requires https://github.com/cockpit-project/bots/pull/4720 (does not technically block on it, as I already deployed it, but let's be correct)
 - [x] Test po refresh run: [workflow](https://github.com/cockpit-project/cockpit-podman/actions/runs/4860013466/jobs/8663341342), produced #1281 with working "protection checks"
 - [x] Test lib refresh run: [workflow](https://github.com/cockpit-project/cockpit-podman/actions/runs/4860045102), produced #1282 with working "protection checks"