### PR TITLE
Fix:issue#1216 allow the search filters to be cleared or reset to the default

### DIFF
--- a/src/ContainerHeader.jsx
+++ b/src/ContainerHeader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import cockpit from 'cockpit';
 import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
-import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
+import { SearchInput } from "@patternfly/react-core/dist/esm/components/SearchInput";
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core/dist/esm/components/Toolbar";
 const _ = cockpit.gettext;
 
@@ -24,10 +24,11 @@ const ContainerHeader = ({ user, twoOwners, ownerFilter, handleOwnerChanged, tex
                     </>
                 }
                 <ToolbarItem>
-                    <TextInput id="containers-filter"
+                    <SearchInput id="containers-filter"
                                    placeholder={_("Type to filter…")}
                                    value={textFilter}
-                                   onChange={handleFilterChanged} />
+                                   onChange={(_event, value) => handleFilterChanged(value)}
+                                   onClear={() => handleFilterChanged('')} />
                 </ToolbarItem>
             </ToolbarContent>
         </Toolbar>


### PR DESCRIPTION
Fixes #1216 

- Change owner filter, from `FormSelect` to `Select` next component of patternfly alpha release. Old `Select` has been deprecated.
- Change the search field beside owner filter, from `TextInput` to `SearchInput`.
