### PR TITLE
fix: Popover broken issue

### DIFF
--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -699,9 +699,9 @@ export class ImageRunModal extends React.Component {
                 <Tabs activeKey={activeTabKey} onSelect={this.handleTabClick}>
                     <Tab eventKey={0} title={<TabTitleText>{_("Details")}</TabTitleText>} className="pf-c-form pf-m-horizontal">
                         { this.props.userServiceAvailable && this.props.systemServiceAvailable &&
-                        <FormGroup isInline hasNoPaddingTop fieldId='run-image-dialog-owner' label={_("Owner")}
+                        <FormGroup isInline hasNoPaddingTop fieldId='run-image-dialog-owner' label={_("Owner")} style={{ zIndex: "1" }}
                                    labelIcon={
-                                       <Popover aria-label={_("Owner help")}
+                                       <Popover aria-label={_("Owner help")} minWidth='0'
                                           enableFlip
                                           bodyContent={
                                               <>


### PR DESCRIPTION
Closes #1302 

Giving the owner div z-index and removing the `min-width: "revert"` property from popover component should fix this issue.

Although, I am not really able to remove the `min-width` property, feels like there is some issue at patternfly upstream.

https://github.com/cockpit-project/node-cache/blob/b3aed397c0415407d9b4b4d21e71fcc5f2160d05/%40patternfly/react-core/src/components/Popover/Popover.tsx#L467

Is `min-width: "revert"` hardcoded here?