### PR TITLE
Update font class for PF5

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -29,7 +29,7 @@ along with this package; If not, see <http://www.gnu.org/licenses/>.
     <script type="text/javascript" src="../manifests.js"></script>
 </head>
 
-<body class="pf-m-redhat-font pf-m-tabular-nums">
+<body class="pf-m-redhat-font pf-v5-m-tabular-nums">
     <div class="ct-page-fill" id="app">
     </div>
 </body>


### PR DESCRIPTION
In the last PF5, we forgot to update the tabular number class.

Pixel test updates https://cockpit-logs.us-east-1.linodeobjects.com/pull-1326-20230703-093916-959ebbfc-fedora-37/log.html