### PR TITLE
Fix testLifecycleOperationsUser restart test, add debug logging

### DIFF
--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -468,6 +468,8 @@ class Containers extends React.Component {
             props: {
                 key: container.Id + container.isSystem.toString(),
                 "data-row-id": container.Id + container.isSystem.toString(),
+                "data-pid": container.Pid,
+                "data-started-at": container.StartedAt,
             },
         };
     }

--- a/src/PodActions.jsx
+++ b/src/PodActions.jsx
@@ -1,15 +1,16 @@
 import React, { useState } from 'react';
 
-import * as client from './client.js';
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Alert } from "@patternfly/react-core/dist/esm/components/Alert";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { Dropdown, DropdownItem, DropdownPosition, DropdownSeparator, KebabToggle } from '@patternfly/react-core/dist/esm/deprecated/components/Dropdown/index.js';
 import { List, ListItem } from "@patternfly/react-core/dist/esm/components/List";
 import { Stack } from "@patternfly/react-core/dist/esm/layouts/Stack";
-import { useDialogs } from "dialogs.jsx";
 
 import cockpit from 'cockpit';
+import { useDialogs } from "dialogs.jsx";
+
+import * as client from './client.js';
 
 const _ = cockpit.gettext;
 

--- a/src/util.js
+++ b/src/util.js
@@ -13,6 +13,11 @@ export const podStates = [_("Created"), _("Running"), _("Stopped"), _("Paused"),
 
 export const fallbackRegistries = ["docker.io", "quay.io"];
 
+export function debug(system, ...args) {
+    if (window.debugging === "all" || window.debugging?.includes("podman"))
+        console.debug("podman", system ? "system" : "user", ...args);
+}
+
 export function truncate_id(id) {
     if (!id) {
         return "";

--- a/test/check-application
+++ b/test/check-application
@@ -1229,6 +1229,7 @@ class TestApplication(testlib.MachineCase):
         if not auth:
             # Check that the checkpoint option is not present for rootless
             b.click(f"#containers-containers tbody tr:contains('{IMG_BUSYBOX}') .pf-v5-c-dropdown__toggle")
+            b.wait_visible(self.getContainerAction(IMG_BUSYBOX, 'Force stop'))
             b.wait_not_present(self.getContainerAction(IMG_BUSYBOX, 'Checkpoint'))
             b.click(f"#containers-containers tbody tr:contains('{IMG_BUSYBOX}') .pf-v5-c-dropdown__toggle")
         # Stop the container

--- a/test/check-application
+++ b/test/check-application
@@ -1215,15 +1215,19 @@ class TestApplication(testlib.MachineCase):
             self.assertEqual(self.getContainerAttr(IMG_BUSYBOX, "CPU"), "n/a")
             self.assertEqual(memory, "n/a")
 
-        # Restart the container
-        old_pid = self.execute(auth, "podman inspect --format '{{.State.Pid}}' swamped-crate")
+        # Restart the container; there is no steady state change in the visible UI, so look for
+        # a changed data-pid attribute
+        old_pid = self.execute(auth, "podman inspect --format '{{.State.Pid}}' swamped-crate").strip()
+        b.wait_in_text(f'#containers-containers tr[data-pid="{old_pid}"]', "swamped-crate")
         self.performContainerAction(IMG_BUSYBOX, "Force restart")
-        b.wait(lambda: old_pid != self.execute(auth,
-                                               "podman inspect --format '{{.State.Pid}}' swamped-crate".strip()))
+        for _ in range(10):
+            new_pid = self.execute(auth, "podman inspect --format '{{.State.Pid}}' swamped-crate").strip()
+            if new_pid and new_pid != old_pid:
+                break
+        else:
+            self.fail("Timed out waiting for pid change")
+        b.wait_in_text(f'#containers-containers tr[data-pid="{new_pid}"]', "swamped-crate")
         self.waitContainer(container_sha, auth, name='swamped-crate', image=IMG_BUSYBOX, state='Running')
-
-        self.filter_containers('all')
-        b.wait_visible("#containers-containers")
 
         self.waitContainerRow(IMG_BUSYBOX)
         if not auth:


### PR DESCRIPTION
Broken out from PR #1324, as these are ready for landing and already help with debugging. That former PR stress-tests testLifecycleOperationsUser. I still saw a [different failure mode](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1324-20230703-134319-67b14112-fedora-37/log.html#26-1) of testLifecycleOperationsUser, but the [primary one](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1322-20230703-061633-7cc9e4bf-fedora-38/log.html#16-1) should be fixed now.