### PR TITLE
Don't re-fetch all containers for "cleanup" event

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -406,6 +406,7 @@ class Application extends React.Component {
         case 'died':
         case 'exec_died':
         case 'kill':
+        case 'cleanup':
         case 'mount':
         case 'pause':
         case 'prune':
@@ -419,7 +420,6 @@ class Application extends React.Component {
             this.updateContainerAfterEvent(event.Actor.ID, system, event);
             break;
         case 'remove':
-        case 'cleanup':
             // HACK: we don't get a pod event when a container in a pod is removed.
             // https://github.com/containers/podman/issues/15408
             if (event.Actor.Attributes.podId) {


### PR DESCRIPTION
This does not mean that the container goes away, that will only happen for the "remove" event. "cleanup" will also happen (twice!) between "died" and "init" for restarting a container.

This avoids two parallel getContainer() calls with possibly inconsistent information, and generally reduces the number of getContainer() calls.

---

This fixes testLifecycleOperations failures like [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1324-20230703-141527-37092ff0-fedora-38/log.html#26) and [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1324-20230703-141527-37092ff0-fedora-38-devel/log.html#24). [debugging notes](https://github.com/cockpit-project/cockpit-podman/pull/1324#issuecomment-1619493649), stress-tested in #1324