### PR TITLE
fmf: Retry pulling container images

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -61,7 +61,13 @@ echo core > /proc/sys/kernel/core_pattern
 podman rmi --all
 
 # set up our expected images, in the same way that we do for upstream CI
-curl https://raw.githubusercontent.com/cockpit-project/bots/main/images/scripts/lib/podman-images.setup | sh -eux
+# this sometimes runs into network issues, so retry a few times
+for retry in $(seq 5); do
+    if curl https://raw.githubusercontent.com/cockpit-project/bots/main/images/scripts/lib/podman-images.setup | sh -eux; then
+        break
+    fi
+    sleep $((5 * retry * retry))
+done
 
 # copy images for user podman tests; podman insists on user session
 loginctl enable-linger $(id -u admin)


### PR DESCRIPTION
This often runs into random DNS/network issues, so retry up to 5 times with exponential back-off.

----

This should alleviate failures like https://artifacts.dev.testing-farm.io/96a81aa0-5fc4-4a8b-80d8-f410310ed0b2/ or https://artifacts.dev.testing-farm.io/420cc043-aa44-4218-8072-bfcdc0179a78/