### PR TITLE
Adjust large size of pod ram/cpu stats

### DIFF
--- a/src/Containers.scss
+++ b/src/Containers.scss
@@ -47,6 +47,12 @@
     }
 }
 
+// override ct-card font size, so cpu/ram don't look absurdly big
+#app .pf-v5-c-card.container-pod div.pf-v5-c-card__title-text {
+    font-weight: normal;
+    font-size: var(--pf-v5-global--FontSize--md);
+}
+
 .pod-stat {
     @media (max-width: $pf-v5-global--breakpoint--sm - 1) {
         // Place each pod stat on its own row


### PR DESCRIPTION
The last PF and Cockpit lib update introduced a rather large 24px pod group text.

Closes: #1342

Now looks like:
![image](https://github.com/cockpit-project/cockpit-podman/assets/67428/c67ae85f-2bd8-4bd6-8ce5-918b9c370b92)
