### PR TITLE
Show time of container's checkpoint, if any is present

### DIFF
--- a/src/ContainerDetails.jsx
+++ b/src/ContainerDetails.jsx
@@ -67,6 +67,10 @@ const ContainerDetails = ({ container }) => {
                         <DescriptionListTerm>{_("State")}</DescriptionListTerm>
                         <DescriptionListDescription>{render_container_state(container)}</DescriptionListDescription>
                     </DescriptionListGroup>
+                    {container?.State.Checkpointed && <DescriptionListGroup>
+                        <DescriptionListTerm>{_("Latest checkpoint")}</DescriptionListTerm>
+                        <DescriptionListDescription>{utils.localize_time(Date.parse(container.State.CheckpointedAt) / 1000)}</DescriptionListDescription>
+                    </DescriptionListGroup>}
                 </DescriptionList>
             </FlexItem>
         </Flex>

--- a/test/check-application
+++ b/test/check-application
@@ -1329,6 +1329,10 @@ class TestApplication(testlib.MachineCase):
         self.performContainerAction("swamped-crate", "Start")
         b.wait(lambda: self.getContainerAttr("swamped-crate", "State") in 'Running')
 
+        self.toggleExpandedContainer("swamped-crate")
+        b.wait_visible(".pf-m-expanded button:contains('Details')")
+        b.wait_not_present(f'#containers-containers tr:contains("{IMG_BUSYBOX}") dt:contains("Latest checkpoint")')
+
         # Checkpoint the container
         self.performContainerAction("swamped-crate", "Checkpoint")
         b.set_checked('.pf-v5-c-modal-box input#checkpoint-dialog-keep', True)
@@ -1340,6 +1344,10 @@ class TestApplication(testlib.MachineCase):
 
         if self.has_criu:
             b.wait(lambda: self.getContainerAttr("swamped-crate", "State") in NOT_RUNNING)
+            b.wait_in_text(
+                f'#containers-containers tr:contains("{IMG_BUSYBOX}") dt:contains("Latest checkpoint") + dd',
+                'today at'
+            )
         else:
             # expect proper error message
             b.wait_in_text(".pf-v5-c-alert.pf-m-danger", "Failed to checkpoint container swamped-crate")


### PR DESCRIPTION
Fixes https://github.com/cockpit-project/cockpit-podman/issues/1287

## Show time of container's latest checkpoint

![Screenshot from 2023-07-11 13-47-14](https://github.com/cockpit-project/cockpit-podman/assets/42733240/b0dcf7ba-0f14-42dc-a43a-01e40dc1a906)

