### PR TITLE
Eliminate redundant getContainers/inspectContainer calls

### DIFF
--- a/src/ContainerCheckpointModal.jsx
+++ b/src/ContainerCheckpointModal.jsx
@@ -25,7 +25,7 @@ const ContainerCheckpointModal = ({ containerWillCheckpoint, onAddNotification }
             tcpEstablished,
         })
                 .catch(ex => {
-                    const error = cockpit.format(_("Failed to checkpoint container $0"), containerWillCheckpoint.Names);
+                    const error = cockpit.format(_("Failed to checkpoint container $0"), containerWillCheckpoint.Name);
                     onAddNotification({ type: 'danger', error, errorDetail: ex.message });
                     setProgress(false);
                 })
@@ -38,7 +38,7 @@ const ContainerCheckpointModal = ({ containerWillCheckpoint, onAddNotification }
         <Modal isOpen
                showClose={false}
                position="top" variant="medium"
-               title={cockpit.format(_("Checkpoint container $0"), containerWillCheckpoint.Names)}
+               title={cockpit.format(_("Checkpoint container $0"), containerWillCheckpoint.Name)}
                footer={<>
                    <Button variant="primary" isDisabled={inProgress}
                            isLoading={inProgress}

--- a/src/ContainerCheckpointModal.jsx
+++ b/src/ContainerCheckpointModal.jsx
@@ -25,7 +25,7 @@ const ContainerCheckpointModal = ({ containerWillCheckpoint, onAddNotification }
             tcpEstablished,
         })
                 .catch(ex => {
-                    const error = cockpit.format(_("Failed to checkpoint container $0"), containerWillCheckpoint.Name);
+                    const error = cockpit.format(_("Failed to checkpoint container $0"), containerWillCheckpoint.Name); // not-covered: OS error
                     onAddNotification({ type: 'danger', error, errorDetail: ex.message });
                     setProgress(false);
                 })

--- a/src/ContainerCommitModal.jsx
+++ b/src/ContainerCommitModal.jsx
@@ -21,7 +21,7 @@ const ContainerCommitModal = ({ container, localImages }) => {
     const [imageName, setImageName] = useState("");
     const [tag, setTag] = useState("");
     const [author, setAuthor] = useState("");
-    const [command, setCommand] = useState(container.Command ? utils.quote_cmdline(container.Command) : "");
+    const [command, setCommand] = useState(container.Config.Cmd ? utils.quote_cmdline(container.Config.Cmd) : "");
     const [pause, setPause] = useState(false);
     const [useDocker, setUseDocker] = useState(false);
 
@@ -78,7 +78,7 @@ const ContainerCommitModal = ({ container, localImages }) => {
         client.commitContainer(container.isSystem, commitData)
                 .then(() => Dialogs.close())
                 .catch(ex => {
-                    setDialogError(cockpit.format(_("Failed to commit container $0"), container.Names));
+                    setDialogError(cockpit.format(_("Failed to commit container $0"), container.Name));
                     setDialogErrorDetail(cockpit.format("$0: $1", ex.message, ex.reason));
                     setCommitInProgress(false);
                 });
@@ -134,7 +134,7 @@ const ContainerCommitModal = ({ container, localImages }) => {
                  showClose={false}
                  position="top" variant="medium"
                  title={_("Commit container")}
-                 description={fmt_to_fragments(_("Create a new image based on the current state of the $0 container."), <b>{container.Names}</b>)}
+                 description={fmt_to_fragments(_("Create a new image based on the current state of the $0 container."), <b>{container.Name}</b>)}
                  footer={<>
                      <Button variant="primary"
                              className="btn-ctr-commit"

--- a/src/ContainerCommitModal.jsx
+++ b/src/ContainerCommitModal.jsx
@@ -21,7 +21,7 @@ const ContainerCommitModal = ({ container, localImages }) => {
     const [imageName, setImageName] = useState("");
     const [tag, setTag] = useState("");
     const [author, setAuthor] = useState("");
-    const [command, setCommand] = useState(container.Config.Cmd ? utils.quote_cmdline(container.Config.Cmd) : "");
+    const [command, setCommand] = useState(utils.quote_cmdline(container.Config.Cmd));
     const [pause, setPause] = useState(false);
     const [useDocker, setUseDocker] = useState(false);
 

--- a/src/ContainerDeleteModal.jsx
+++ b/src/ContainerDeleteModal.jsx
@@ -18,7 +18,7 @@ const ContainerDeleteModal = ({ containerWillDelete, onAddNotification }) => {
         Dialogs.close();
         client.delContainer(container.isSystem, id, false)
                 .catch(ex => {
-                    const error = cockpit.format(_("Failed to remove container $0"), container.Names);
+                    const error = cockpit.format(_("Failed to remove container $0"), container.Name);
                     onAddNotification({ type: 'danger', error, errorDetail: ex.message });
                 });
     };
@@ -28,7 +28,7 @@ const ContainerDeleteModal = ({ containerWillDelete, onAddNotification }) => {
                position="top" variant="medium"
                titleIconVariant="warning"
                onClose={Dialogs.close}
-               title={cockpit.format(_("Delete $0?"), containerWillDelete.Names)}
+               title={cockpit.format(_("Delete $0?"), containerWillDelete.Name)}
                footer={<>
                    <Button variant="danger" className="btn-ctr-delete" onClick={handleRemoveContainer}>{_("Delete")}</Button>{' '}
                    <Button variant="link" onClick={Dialogs.close}>{_("Cancel")}</Button>

--- a/src/ContainerDeleteModal.jsx
+++ b/src/ContainerDeleteModal.jsx
@@ -18,7 +18,7 @@ const ContainerDeleteModal = ({ containerWillDelete, onAddNotification }) => {
         Dialogs.close();
         client.delContainer(container.isSystem, id, false)
                 .catch(ex => {
-                    const error = cockpit.format(_("Failed to remove container $0"), container.Name);
+                    const error = cockpit.format(_("Failed to remove container $0"), container.Name); // not-covered: OS error
                     onAddNotification({ type: 'danger', error, errorDetail: ex.message });
                 });
     };

--- a/src/ContainerDetails.jsx
+++ b/src/ContainerDetails.jsx
@@ -8,19 +8,18 @@ import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
 const _ = cockpit.gettext;
 
 const render_container_state = (container) => {
-    if (container.State === "running") {
-        return cockpit.format(_("Up since $0"), utils.localize_time(container.StartedAt));
+    if (container.State.Status === "running") {
+        return cockpit.format(_("Up since $0"), utils.localize_time(Date.parse(container.State.StartedAt) / 1000));
     }
     return cockpit.format(_("Exited"));
 };
 
-const ContainerDetails = ({ container, containerDetail }) => {
+const ContainerDetails = ({ container }) => {
     const networkOptions = (
-        containerDetail &&
         [
-            containerDetail.NetworkSettings.IPAddress,
-            containerDetail.NetworkSettings.Gateway,
-            containerDetail.NetworkSettings.MacAddress,
+            container.NetworkSettings?.IPAddress,
+            container.NetworkSettings?.Gateway,
+            container.NetworkSettings?.MacAddress,
         ].some(itm => !!itm)
     );
 
@@ -34,27 +33,27 @@ const ContainerDetails = ({ container, containerDetail }) => {
                     </DescriptionListGroup>
                     <DescriptionListGroup>
                         <DescriptionListTerm>{_("Image")}</DescriptionListTerm>
-                        <DescriptionListDescription>{container.Image}</DescriptionListDescription>
+                        <DescriptionListDescription>{container.ImageName}</DescriptionListDescription>
                     </DescriptionListGroup>
                     <DescriptionListGroup>
                         <DescriptionListTerm>{_("Command")}</DescriptionListTerm>
-                        <DescriptionListDescription>{container.Command ? utils.quote_cmdline(container.Command) : ""}</DescriptionListDescription>
+                        <DescriptionListDescription>{container.Config?.Cmd ? utils.quote_cmdline(container.Config.Cmd) : ""}</DescriptionListDescription>
                     </DescriptionListGroup>
                 </DescriptionList>
             </FlexItem>
             <FlexItem>
                 {networkOptions && <DescriptionList columnModifier={{ default: '2Col' }} className='container-details-networking'>
-                    {containerDetail && containerDetail.NetworkSettings.IPAddress && <DescriptionListGroup>
+                    {container.NetworkSettings?.IPAddress && <DescriptionListGroup>
                         <DescriptionListTerm>{_("IP address")}</DescriptionListTerm>
-                        <DescriptionListDescription>{containerDetail.NetworkSettings.IPAddress}</DescriptionListDescription>
+                        <DescriptionListDescription>{container.NetworkSettings.IPAddress}</DescriptionListDescription>
                     </DescriptionListGroup>}
-                    {containerDetail && containerDetail.NetworkSettings.Gateway && <DescriptionListGroup>
+                    {container.NetworkSettings?.Gateway && <DescriptionListGroup>
                         <DescriptionListTerm>{_("Gateway")}</DescriptionListTerm>
-                        <DescriptionListDescription>{containerDetail.NetworkSettings.Gateway}</DescriptionListDescription>
+                        <DescriptionListDescription>{container.NetworkSettings.Gateway}</DescriptionListDescription>
                     </DescriptionListGroup>}
-                    {containerDetail && containerDetail.NetworkSettings.MacAddress && <DescriptionListGroup>
+                    {container.NetworkSettings?.MacAddress && <DescriptionListGroup>
                         <DescriptionListTerm>{_("MAC address")}</DescriptionListTerm>
-                        <DescriptionListDescription>{containerDetail.NetworkSettings.MacAddress}</DescriptionListDescription>
+                        <DescriptionListDescription>{container.NetworkSettings.MacAddress}</DescriptionListDescription>
                     </DescriptionListGroup>}
                 </DescriptionList>}
             </FlexItem>

--- a/src/ContainerDetails.jsx
+++ b/src/ContainerDetails.jsx
@@ -37,7 +37,7 @@ const ContainerDetails = ({ container }) => {
                     </DescriptionListGroup>
                     <DescriptionListGroup>
                         <DescriptionListTerm>{_("Command")}</DescriptionListTerm>
-                        <DescriptionListDescription>{container.Config?.Cmd ? utils.quote_cmdline(container.Config.Cmd) : ""}</DescriptionListDescription>
+                        <DescriptionListDescription>{utils.quote_cmdline(container.Config?.Cmd)}</DescriptionListDescription>
                     </DescriptionListGroup>
                 </DescriptionList>
             </FlexItem>

--- a/src/ContainerHealthLogs.jsx
+++ b/src/ContainerHealthLogs.jsx
@@ -91,7 +91,7 @@ const ContainerHealthLogs = ({ container, onAddNotification, state }) => {
                         <Button variant="secondary" onClick={() => {
                             client.runHealthcheck(container.isSystem, container.Id)
                                     .catch(ex => {
-                                        const error = cockpit.format(_("Failed to run health check on container $0"), container.Name);
+                                        const error = cockpit.format(_("Failed to run health check on container $0"), container.Name); // not-covered: OS error
                                         onAddNotification({ type: 'danger', error, errorDetail: ex.message });
                                     });
                         }}>

--- a/src/ContainerHealthLogs.jsx
+++ b/src/ContainerHealthLogs.jsx
@@ -43,9 +43,9 @@ const HealthcheckOnFailureActionText = {
 };
 
 const ContainerHealthLogs = ({ container, onAddNotification, state }) => {
-    const healthCheck = container.Config?.Healthcheck ?? container.Config?.Health ?? {};
-    const healthState = container.State?.Healthcheck ?? container.State?.Health ?? {};
-    const logs = [...(healthState.Log || [])].reverse();
+    const healthCheck = container.Config?.Healthcheck ?? container.Config?.Health ?? {}; // not-covered: only on old version
+    const healthState = container.State?.Healthcheck ?? container.State?.Health ?? {}; // not-covered: only on old version
+    const logs = [...(healthState.Log || [])].reverse(); // not-covered: Log should always exist, belt-and-suspenders
 
     return (
         <>

--- a/src/ContainerIntegration.jsx
+++ b/src/ContainerIntegration.jsx
@@ -98,7 +98,7 @@ const ContainerIntegration = ({ container, localImages }) => {
     const volumes = renderContainerVolumes(container.Mounts);
 
     const image = localImages.filter(img => img.Id === container.Image)[0];
-    const env = <ContainerEnv containerEnv={container.Config.Env} imageEnv={image.Env || []} />;
+    const env = <ContainerEnv containerEnv={container.Config.Env} imageEnv={image.Env} />;
 
     return (
         <DescriptionList isAutoColumnWidths columnModifier={{ md: '3Col' }} className='container-integration'>

--- a/src/ContainerIntegration.jsx
+++ b/src/ContainerIntegration.jsx
@@ -17,7 +17,7 @@ export const renderContainerPublishedPorts = ports => {
 
     const items = [];
     Object.entries(ports).forEach(([containerPort, hostBindings]) => {
-        (hostBindings ?? []).forEach(binding => {
+        (hostBindings ?? []).forEach(binding => { // not-covered: null was observed in the wild, but unknown how to reproduce
             items.push(
                 <ListItem key={ containerPort + binding.HostIp + binding.HostPort }>
                     { binding.HostIp || "0.0.0.0" }:{ binding.HostPort } &rarr; { containerPort }
@@ -88,7 +88,7 @@ const ContainerEnv = ({ containerEnv, imageEnv }) => {
 };
 
 const ContainerIntegration = ({ container, localImages }) => {
-    if (localImages === null) {
+    if (localImages === null) { // not-covered: not a stable UI state
         return (
             <EmptyStatePanel title={_("Loading details...")} loading />
         );

--- a/src/ContainerRenameModal.jsx
+++ b/src/ContainerRenameModal.jsx
@@ -50,7 +50,7 @@ const ContainerRenameModal = ({ container, version, updateContainer }) => {
                     }
                 })
                 .catch(ex => {
-                    setDialogError(cockpit.format(_("Failed to rename container $0"), container.Name));
+                    setDialogError(cockpit.format(_("Failed to rename container $0"), container.Name)); // not-covered: OS error
                     setDialogErrorDetail(cockpit.format("$0: $1", ex.message, ex.reason));
                 });
     };

--- a/src/ContainerRenameModal.jsx
+++ b/src/ContainerRenameModal.jsx
@@ -15,7 +15,7 @@ const _ = cockpit.gettext;
 
 const ContainerRenameModal = ({ container, version, updateContainer }) => {
     const Dialogs = useDialogs();
-    const [name, setName] = useState(container.Names[0]);
+    const [name, setName] = useState(container.Name);
     const [nameError, setNameError] = useState(null);
     const [dialogError, setDialogError] = useState(null);
     const [dialogErrorDetail, setDialogErrorDetail] = useState(null);
@@ -50,7 +50,7 @@ const ContainerRenameModal = ({ container, version, updateContainer }) => {
                     }
                 })
                 .catch(ex => {
-                    setDialogError(cockpit.format(_("Failed to rename container $0"), container.Names[0]));
+                    setDialogError(cockpit.format(_("Failed to rename container $0"), container.Name));
                     setDialogErrorDetail(cockpit.format("$0: $1", ex.message, ex.reason));
                 });
     };
@@ -81,7 +81,7 @@ const ContainerRenameModal = ({ container, version, updateContainer }) => {
             position="top" variant="medium"
             onClose={Dialogs.close}
             onKeyDown={handleKeyDown}
-            title={cockpit.format(_("Rename container $0"), container.Names[0])}
+            title={cockpit.format(_("Rename container $0"), container.Name)}
             footer={<>
                 <Button variant="primary"
                         className="btn-ctr-rename"

--- a/src/ContainerRestoreModal.jsx
+++ b/src/ContainerRestoreModal.jsx
@@ -28,7 +28,7 @@ const ContainerRestoreModal = ({ containerWillRestore, onAddNotification }) => {
             ignoreStaticMAC,
         })
                 .catch(ex => {
-                    const error = cockpit.format(_("Failed to restore container $0"), containerWillRestore.Names);
+                    const error = cockpit.format(_("Failed to restore container $0"), containerWillRestore.Name);
                     onAddNotification({ type: 'danger', error, errorDetail: ex.message });
                     setInProgress(false);
                 })
@@ -41,7 +41,7 @@ const ContainerRestoreModal = ({ containerWillRestore, onAddNotification }) => {
         <Modal isOpen
                showClose={false}
                position="top" variant="medium"
-               title={cockpit.format(_("Restore container $0"), containerWillRestore.Names)}
+               title={cockpit.format(_("Restore container $0"), containerWillRestore.Name)}
                footer={<>
                    <Button variant="primary" isDisabled={inProgress}
                            isLoading={inProgress}

--- a/src/ContainerRestoreModal.jsx
+++ b/src/ContainerRestoreModal.jsx
@@ -28,7 +28,7 @@ const ContainerRestoreModal = ({ containerWillRestore, onAddNotification }) => {
             ignoreStaticMAC,
         })
                 .catch(ex => {
-                    const error = cockpit.format(_("Failed to restore container $0"), containerWillRestore.Name);
+                    const error = cockpit.format(_("Failed to restore container $0"), containerWillRestore.Name); // not-covered: OS error
                     onAddNotification({ type: 'danger', error, errorDetail: ex.message });
                     setInProgress(false);
                 })

--- a/src/ContainerTerminal.jsx
+++ b/src/ContainerTerminal.jsx
@@ -91,7 +91,6 @@ class ContainerTerminal extends React.Component {
 
     componentDidUpdate(prevProps, prevState) {
         // Connect channel when there is none and either container started or tty was resolved
-        // tty is being read as part of containerDetails and it is asynchronous so we need to wait for it
         if (!this.state.channel && (
             (this.props.containerStatus === "running" && prevProps.containerStatus !== "running") ||
             (this.props.tty !== undefined && prevProps.tty === undefined)))

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -380,12 +380,12 @@ class Containers extends React.Component {
         // this needs to get along with stub containers from image run dialog, where most properties don't exist yet
         // HACK: Podman renamed `Healthcheck` to `Health` randomly
         // https://github.com/containers/podman/commit/119973375
-        const healthcheck = container.State?.Health?.Status ?? container.State?.Healthcheck?.Status;
-        const status = container.State?.Status ?? "";
+        const healthcheck = container.State?.Health?.Status ?? container.State?.Healthcheck?.Status; // not-covered: only on old version
+        const status = container.State?.Status ?? ""; // not-covered: race condition
 
         let proc = "";
         let mem = "";
-        if (this.props.cgroupVersion == 'v1' && !container.isSystem && status == 'running') {
+        if (this.props.cgroupVersion == 'v1' && !container.isSystem && status == 'running') { // not-covered: only on old version
             proc = <div><abbr title={_("not available")}>{_("n/a")}</abbr></div>;
             mem = <div><abbr title={_("not available")}>{_("n/a")}</abbr></div>;
         }
@@ -641,8 +641,8 @@ class Containers extends React.Component {
             filtered.sort((a, b) => {
                 // Show unhealthy containers first
                 if (this.props.containers[a] && this.props.containers[b]) {
-                    const a_health = this.props.containers[a].State.Health || this.props.containers[a].State.Healthcheck;
-                    const b_health = this.props.containers[b].State.Health || this.props.containers[b].State.Healthcheck;
+                    const a_health = this.props.containers[a].State.Health || this.props.containers[a].State.Healthcheck; // not-covered: only on old version
+                    const b_health = this.props.containers[b].State.Health || this.props.containers[b].State.Healthcheck; // not-covered: only on old version
                     if (a_health.Status !== b_health.Status) {
                         if (a_health.Status === "unhealthy")
                             return -1;

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -56,7 +56,7 @@ const ContainerActions = ({ container, healthcheck, onAddNotification, version, 
 
                 return client.delContainer(container.isSystem, id, true)
                         .catch(ex => {
-                            const error = cockpit.format(_("Failed to force remove container $0"), container.Name);
+                            const error = cockpit.format(_("Failed to force remove container $0"), container.Name); // not-covered: OS error
                             onAddNotification({ type: 'danger', error, errorDetail: ex.message });
                             throw ex;
                         })
@@ -83,7 +83,7 @@ const ContainerActions = ({ container, healthcheck, onAddNotification, version, 
             args.t = 0;
         client.postContainer(container.isSystem, "stop", container.Id, args)
                 .catch(ex => {
-                    const error = cockpit.format(_("Failed to stop container $0"), container.Name);
+                    const error = cockpit.format(_("Failed to stop container $0"), container.Name); // not-covered: OS error
                     onAddNotification({ type: 'danger', error, errorDetail: ex.message });
                 });
     };
@@ -93,7 +93,7 @@ const ContainerActions = ({ container, healthcheck, onAddNotification, version, 
 
         client.postContainer(container.isSystem, "start", container.Id, {})
                 .catch(ex => {
-                    const error = cockpit.format(_("Failed to start container $0"), container.Name);
+                    const error = cockpit.format(_("Failed to start container $0"), container.Name); // not-covered: OS error
                     onAddNotification({ type: 'danger', error, errorDetail: ex.message });
                 });
     };
@@ -103,7 +103,7 @@ const ContainerActions = ({ container, healthcheck, onAddNotification, version, 
 
         client.postContainer(container.isSystem, "unpause", container.Id, {})
                 .catch(ex => {
-                    const error = cockpit.format(_("Failed to resume container $0"), container.Name);
+                    const error = cockpit.format(_("Failed to resume container $0"), container.Name); // not-covered: OS error
                     onAddNotification({ type: 'danger', error, errorDetail: ex.message });
                 });
     };
@@ -113,7 +113,7 @@ const ContainerActions = ({ container, healthcheck, onAddNotification, version, 
 
         client.postContainer(container.isSystem, "pause", container.Id, {})
                 .catch(ex => {
-                    const error = cockpit.format(_("Failed to pause container $0"), container.Name);
+                    const error = cockpit.format(_("Failed to pause container $0"), container.Name); // not-covered: OS error
                     onAddNotification({ type: 'danger', error, errorDetail: ex.message });
                 });
     };
@@ -130,7 +130,7 @@ const ContainerActions = ({ container, healthcheck, onAddNotification, version, 
 
         client.runHealthcheck(container.isSystem, container.Id)
                 .catch(ex => {
-                    const error = cockpit.format(_("Failed to run health check on container $0"), container.Name);
+                    const error = cockpit.format(_("Failed to run health check on container $0"), container.Name); // not-covered: OS error
                     onAddNotification({ type: 'danger', error, errorDetail: ex.message });
                 });
     };
@@ -144,7 +144,7 @@ const ContainerActions = ({ container, healthcheck, onAddNotification, version, 
             args.t = 0;
         client.postContainer(container.isSystem, "restart", container.Id, args)
                 .catch(ex => {
-                    const error = cockpit.format(_("Failed to restart container $0"), container.Name);
+                    const error = cockpit.format(_("Failed to restart container $0"), container.Name); // not-covered: OS error
                     onAddNotification({ type: 'danger', error, errorDetail: ex.message });
                 });
     };

--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -331,7 +331,7 @@ export class ImageRunModal extends React.Component {
             // Assign temporary properties to allow rendering
             tempImage.Id = tempImage.name;
             tempImage.isSystem = isSystem;
-            tempImage.State = _("downloading");
+            tempImage.State = { Status: _("downloading") };
             tempImage.Created = new Date();
             tempImage.Names = [tempImage.name];
             tempImage.Image = createConfig.image;

--- a/src/ImageUsedBy.jsx
+++ b/src/ImageUsedBy.jsx
@@ -17,7 +17,7 @@ const ImageUsedBy = ({ containers, showAll }) => {
         <List isPlain>
             {containers.map(c => {
                 const container = c.container;
-                const isRunning = container.State == "running";
+                const isRunning = container.State?.Status === "running";
                 return (
                     <ListItem key={container.Id}>
                         <Flex>
@@ -30,7 +30,7 @@ const ImageUsedBy = ({ containers, showAll }) => {
                                         if (!isRunning)
                                             showAll();
                                     }}>
-                                {container.Names}
+                                {container.Name}
                             </Button>
                             {isRunning && <Badge className="ct-badge-container-running">{_("Running")}</Badge>}
                         </Flex>

--- a/src/client.js
+++ b/src/client.js
@@ -51,13 +51,7 @@ export function getInfo(system) {
     });
 }
 
-export function getContainers(system, id) {
-    const options = { all: true };
-    if (id)
-        options.filters = JSON.stringify({ id: [id] });
-
-    return podmanJson("libpod/containers/json", "GET", options, system);
-}
+export const getContainers = system => podmanJson("libpod/containers/json", "GET", { all: true }, system);
 
 export const streamContainerStats = (system, callback) => podmanMonitor("libpod/containers/stats", "GET", { stream: true }, callback, system);
 


### PR DESCRIPTION
Both the initial container scan and each update called getContainers() once and inspectContainer() twice (!!). But this is very redundant: The objects returned by getContainers() and inspectContainer() have a very similar structure. The latter does not have `Pid` and `PodName`, but we don't use these properties anyway. The others map in a straightforward way:

 * `Names[]` → single `Name`
 * `Ports` list → `NetworkSettings.Ports` map
 * `Mounts` (simple target dir list) →  list of objects with lots of info; direct translation is `.Destination`
 * `Started/Exited...At` → `State.*`
 * `State` → `State.Status`
 * `Command` → `Config.Cmd`
 * `Labels` → `Config.Labels`
 * `ImageID` → `Image`
 * `Image` → `ImageName`

So change the state keeping to call getContainers() only once at initialization, and from then on only a single inspectContainer() for each state update. Adjust the code for the above property structure changes.

---

Another big outcome from #1324, and stress-tested there.