### PR TITLE
test: Add hack to avoid losing focus on #containers-filter

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -373,6 +373,12 @@ class TestApplication(testlib.MachineCase):
         b.click(".pf-v5-c-modal-box button:contains('Force delete')")
         self.waitPodRow("pod-1", False)
 
+        # HACK: there is some race here which steals the focus from the filter input and selects the page text instead
+        for _ in range(3):
+            b.focus('#containers-filter')
+            time.sleep(1)
+            if b.eval_js('document.activeElement == document.querySelector("#containers-filter")'):
+                break
         b.set_input_text('#containers-filter', '')
         self.machine.execute("podman pod create --infra=false --name pod-2")
         self.waitPodContainer("pod-2", [])


### PR DESCRIPTION
For some reason, .focus() sometimes does not take effect, and the element immediately loses the focus again. This causes set_input_text() to select the whole page text instead of the input element, and failing to set the intended value.

----

This fixes [this common flake](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1324-20230706-080945-2272c7a4-fedora-38/log.html#36), [another example](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1324-20230714-145100-6a267367-arch/log.html). So far this breaks pretty much every PR which runs tests three times (affected).

I realize this is a rather lame workaround, not a true fix. I investigated that in https://github.com/cockpit-project/cockpit-podman/pull/1324#issuecomment-1623250094 and attempted a better fix, but it didn't work, and I gave up after some hours ("pick your battles"). If someone is interested in tracking this down, please do!

I stress-tested this in #1324, and it passed 15 times in *all* operating systems at the first try (I amplified the test)