### PR TITLE
package.json: Bump most modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   "devDependencies": {
     "argparse": "^2.0.1",
     "chrome-remote-interface": "^0.32.1",
-    "esbuild": "^0.17.16",
+    "esbuild": "^0.18.14",
     "esbuild-plugin-copy": "^2.0.2",
     "esbuild-plugin-replace": "^1.3.0",
-    "esbuild-sass-plugin": "2.6.0",
-    "esbuild-wasm": "^0.17.16",
-    "eslint": "^8.29.0",
+    "esbuild-sass-plugin": "^2.10.0",
+    "esbuild-wasm": "^0.18.14",
+    "eslint": "^8.45.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-config-standard-jsx": "^11.0.0",
     "eslint-config-standard-react": "^13.0.0",
@@ -33,7 +33,7 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-standard": "^5.0.0",
-    "gettext-parser": "^2.0.0",
+    "gettext-parser": "^3.0.0",
     "htmlparser": "^1.7.7",
     "jed": "^1.1.1",
     "sass": "^1.59.3",
@@ -49,12 +49,13 @@
     "@patternfly/react-styles": "5.0.0-alpha.10",
     "@patternfly/react-table": "5.0.0-alpha.100",
     "@patternfly/react-tokens": "5.0.0-alpha.9",
-    "date-fns": "2.28.0",
+    "date-fns": "2.30.0",
     "docker-names": "1.2.1",
     "prop-types": "15.8.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "throttle-debounce": "2.3.0",
-    "xterm": "4.18.0"
+    "throttle-debounce": "5.0.0",
+    "xterm": "5.1.0",
+    "xterm-addon-canvas": "0.4.0"
   }
 }

--- a/src/ContainerLogs.jsx
+++ b/src/ContainerLogs.jsx
@@ -20,6 +20,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Terminal } from "xterm";
+import { CanvasAddon } from 'xterm-addon-canvas';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import cockpit from 'cockpit';
@@ -82,7 +83,7 @@ class ContainerLogs extends React.Component {
         // 21 inner padding of xterm.js
         // xterm.js scrollbar 20
         const padding = 24 * 4 + 3 + 21 + 20;
-        const realWidth = this.view._core._renderService.dimensions.actualCellWidth;
+        const realWidth = this.view._core._renderService.dimensions.css.cell.width;
         const cols = Math.floor((width - padding) / realWidth);
         this.view.resize(cols, 24);
     }
@@ -101,6 +102,7 @@ class ContainerLogs extends React.Component {
         // Show the terminal. Once it was shown, do not show it again but reuse the previous one
         if (!this.state.opened) {
             this.view.open(this.logRef.current);
+            this.view.loadAddon(new CanvasAddon());
             this.setState({ opened: true });
         }
         this.resize(this.props.width);


### PR DESCRIPTION
For XTerm 5, use the canvas renderer addon, which was previously built in. The
default renderer uses inline styles and does not work with our strict
C-S-P. Also stop making the Terminal object state. It's completely unnecessary
and may cause unnecessary renders. Adapted from
https://github.com/cockpit-project/cockpit/commit/65471fd9fcb
Don't update to the latest 5.2, as that breaks the a11y tree
(https://github.com/xtermjs/xterm.js/issues/4571). 5.1 works fine.

Note that gettext-parser's current version is 7, but versions ≥ 4 don't
work with our cockpit plugin. That needs to be updated in Cockpit first.