### PR TITLE
package.json: drop deprecated eslint-plugin-standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-standard": "^5.0.0",
     "gettext-parser": "^3.0.0",
     "htmlparser": "^1.7.7",
     "jed": "^1.1.1",


### PR DESCRIPTION
eslint-config-standard no longer requires it since 16.0.0.

Same dance as in Cockpit :dancers: 