### PR TITLE
build.js: support flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ $(DIST_TEST): $(COCKPIT_REPO_STAMP) $(shell find src/ -type f) package.json buil
 	$(MAKE) package-lock.json && NODE_ENV=$(NODE_ENV) ./build.js
 
 watch: $(NODE_MODULES_TEST)
-	NODE_ENV=$(NODE_ENV) ESBUILD_WATCH=true ./build.js
+	NODE_ENV=$(NODE_ENV) ./build.js -w
 
 clean:
 	rm -rf dist/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "LGPL-2.1",
   "scripts": {
-    "watch": "ESBUILD_WATCH='true' ./build.js",
+    "watch": "./build.js -w",
     "build": "./build.js",
     "eslint": "eslint --ext .jsx --ext .js src/",
     "eslint:fix": "eslint --fix --ext .jsx --ext .js src/",


### PR DESCRIPTION
Adds flags to build.js to use rsync, disable linting and use watch mode.