### PR TITLE
packit: Build COPR for main commits

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -26,7 +26,7 @@ jobs:
     - centos-stream-9-x86_64
     - centos-stream-9-aarch64
     - centos-stream-8-x86_64
-  
+
   - job: tests
     trigger: pull_request
     targets:
@@ -50,6 +50,13 @@ jobs:
       create-archive:
         - sh -exc "curl -L -O https://github.com/cockpit-project/cockpit-podman/releases/download/${PACKIT_PROJECT_VERSION}/${PACKIT_PROJECT_NAME_VERSION}.tar.xz"
         - sh -exc "ls ${PACKIT_PROJECT_NAME_VERSION}.tar.xz"
+
+  - job: copr_build
+    trigger: commit
+    branch: "^main$"
+    owner: "@cockpit"
+    project: "main-builds"
+    preserve_project: True
 
   - job: propose_downstream
     trigger: release


### PR DESCRIPTION
Build every commit into main into
https://copr.fedorainfracloud.org/coprs/g/cockpit/main-builds/

We will use that for cross-project testing (e.g. running cockpit-podman's tests in podman upstream PRs). Users can also install that to test bug fixes and new features after they landed, but before they got released.

---

See https://github.com/cockpit-project/cockpit/pull/19117#issuecomment-1657895111 for the plan.