### PR TITLE
fmf: Install criu test dependency

### DIFF
--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -3,6 +3,7 @@ require:
   - cockpit-ws
   - cockpit-system
   - bzip2
+  - criu
   - git-core
   - libvirt-python3
   - make


### PR DESCRIPTION
It's not a strict requires, but our tests want to cover checkpoint/restore. podman's crun → criu-libs dependency seems to come and go, and is too indirect to rely on.

-----

Spotted in https://github.com/containers/podman/pull/19500