### PR TITLE
Fix undefined property checks

### DIFF
--- a/src/ContainerDetails.jsx
+++ b/src/ContainerDetails.jsx
@@ -67,7 +67,7 @@ const ContainerDetails = ({ container }) => {
                         <DescriptionListTerm>{_("State")}</DescriptionListTerm>
                         <DescriptionListDescription>{render_container_state(container)}</DescriptionListDescription>
                     </DescriptionListGroup>
-                    {container?.State.Checkpointed && <DescriptionListGroup>
+                    {container.State?.Checkpointed && <DescriptionListGroup>
                         <DescriptionListTerm>{_("Latest checkpoint")}</DescriptionListTerm>
                         <DescriptionListDescription>{utils.localize_time(Date.parse(container.State.CheckpointedAt) / 1000)}</DescriptionListDescription>
                     </DescriptionListGroup>}

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -397,7 +397,7 @@ class Containers extends React.Component {
         }
         const info_block = (
             <div className="container-block">
-                <span className="container-name">{container?.Name}</span>
+                <span className="container-name">{container.Name}</span>
                 <small>{image}</small>
                 <small>{utils.quote_cmdline(container.Config?.Cmd)}</small>
             </div>


### PR DESCRIPTION
In both places we already know that `container` is defined. What we meant in ContainerDetails.jsx was to guard against a missing `.State` object.

Spotted by coverity.