### PR TITLE
package.json: bump esbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
   "devDependencies": {
     "argparse": "^2.0.1",
     "chrome-remote-interface": "^0.32.1",
-    "esbuild": "^0.18.14",
+    "esbuild": "^0.19.1",
     "esbuild-plugin-copy": "^2.0.2",
     "esbuild-plugin-replace": "^1.3.0",
     "esbuild-sass-plugin": "^2.10.0",
-    "esbuild-wasm": "^0.18.14",
+    "esbuild-wasm": "^0.19.1",
     "eslint": "^8.45.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-config-standard-jsx": "^11.0.0",


### PR DESCRIPTION
Bump dependency of esbuild to fix a dependency issue during install

npm i --package-lock-only
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree npm ERR!
npm ERR! While resolving: podman@undefined
npm ERR! Found: esbuild@0.18.20
npm ERR! node_modules/esbuild
npm ERR! dev esbuild@"^0.18.14" from the root project npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer esbuild@"^0.19.1" from esbuild-sass-plugin@2.12.0 npm ERR! node_modules/esbuild-sass-plugin
npm ERR! dev esbuild-sass-plugin@"^2.10.0" from the root project npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry npm ERR! this command with --force or --legacy-peer-deps npm ERR! to accept an incorrect (and potentially broken) dependency resolution.

Closes: #1380