### PR TITLE
fmf: Plumb through $TEST_* variables for unexpected messages

### DIFF
--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -3,6 +3,10 @@ discover:
 execute:
     how: tmt
 
+# Let's handle them upstream only, don't break Fedora/RHEL reverse dependency gating
+environment:
+    TEST_AUDIT_NO_SELINUX: 1
+
 /system:
     summary: Run tests on system podman
     discover+:

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -5,12 +5,7 @@ set -eux
 PLAN="$1"
 
 TESTS="$(realpath $(dirname "$0"))"
-if [ -d source ]; then
-    # path for standard-test-source
-    SOURCE="$(pwd)/source"
-else
-    SOURCE="$(realpath $TESTS/../..)"
-fi
+SOURCE="$(realpath $TESTS/../..)"
 
 # https://tmt.readthedocs.io/en/stable/overview.html#variables
 LOGS="${TMT_TEST_DATA:-$(pwd)/logs}"

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -19,7 +19,6 @@ fi
 
 . /etc/os-release
 export TEST_OS="${ID}-${VERSION_ID/./-}"
-export TEST_AUDIT_NO_SELINUX=1
 
 if [ "${TEST_OS#centos-}" != "$TEST_OS" ]; then
     TEST_OS="${TEST_OS}-stream"
@@ -35,6 +34,10 @@ case "$PLAN" in
 esac
 
 EXCLUDES=""
+
+# make it easy to check in logs
+echo "TEST_ALLOW_JOURNAL_MESSAGES: ${TEST_ALLOW_JOURNAL_MESSAGES:-}"
+echo "TEST_AUDIT_NO_SELINUX: ${TEST_AUDIT_NO_SELINUX:-}"
 
 RC=0
 test/common/run-tests --nondestructive --machine 127.0.0.1:22 --browser 127.0.0.1:9090 $TESTS $EXCLUDES || RC=$?


### PR DESCRIPTION
This will allow us to control the value from test plans, in particular for disabling at least some unexpected message checks for reverse dependency testing. We don't want to disable unexpected messages in general for fmf, as we are looking for exactly these in e.g. selinux-policy reverse dependency tests.
    
Move from `su` to `runtest`, as with the former it's impossible to plumb through variables with non-trivial characters, as they cannot be quoted.

---

We got [this failure](https://artifacts.dev.testing-farm.io/faf29d9a-0219-47fb-bef4-6d2a151de209/) in https://github.com/containers/podman/pull/19741 which isn't relevant at all. 

With [this extra test commit](https://github.com/cockpit-project/cockpit-podman/commit/f5dce1dbcc8e14e355ec56b9de879bcc35a300ef) we get [this result](https://artifacts.dev.testing-farm.io/9b38110f-233b-4214-b4d8-a4516fb7bc46/), which proves that this works as intended:
```
TEST_ALLOW_JOURNAL_MESSAGES: .*non-UTF8 @data.*
TEST_AUDIT_NO_SELINUX: 1
```
