### PR TITLE
Fix dropdown's overflow in contains list

### DIFF
--- a/src/Containers.scss
+++ b/src/Containers.scss
@@ -1,8 +1,6 @@
 @import "global-variables";
 
 .container-pod {
-    overflow-x: auto;
-
     .pf-v5-c-card__header {
         border-color: #ddd;
         padding-top: var(--pf-v5-global--spacer--md);


### PR DESCRIPTION
Fixes #1386

The issue: 

[Screencast from 2023-08-24 10-24-52.webm](https://github.com/cockpit-project/cockpit-podman/assets/108616679/33461de7-c13d-4845-bb59-21f97f2d937d)

This was introduced in https://github.com/cockpit-project/cockpit-podman/pull/1357 as fix as fix for [screen width bug](https://github.com/cockpit-project/cockpit-podman/issues/1319). However it seems that the screen width bug is fixed with `word-break: break-all;`, so using `overflow-x: auto;` seems redundant. Futhermore, the issue it introduced seems bigger than the issue it was originally fixing.