### PR TITLE
.github: add a Fedora updates-testing nightly scenario

### DIFF
--- a/.github/workflows/updates-testing-nightly.yml
+++ b/.github/workflows/updates-testing-nightly.yml
@@ -1,0 +1,22 @@
+name: fedora-updates-testing
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  # can be run manually on https://github.com/cockpit-project/cockpit-podman/actions
+  workflow_dispatch:
+jobs:
+  fedora-updates-testing:
+    permissions:
+      statuses: write
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Trigger updates-testing scenario
+        run: |
+          make bots
+          mkdir -p ~/.config/cockpit-dev
+          echo "${{ github.token }}" >> ~/.config/cockpit-dev/github-token
+          TEST_OS=$(PYTHONPATH=bots python3 -c 'from lib.constants import TEST_OS_DEFAULT; print(TEST_OS_DEFAULT)')
+          ./bots/tests-trigger "-" "${TEST_OS}/updates-testing"


### PR DESCRIPTION
Test Fedora with updates-testing nightly every night. When a test fails an issue will be opened.