### PR TITLE
.github: update how to check out bots

### DIFF
--- a/.github/workflows/npm-update-pf.yml
+++ b/.github/workflows/npm-update-pf.yml
@@ -17,8 +17,8 @@ jobs:
 
       - name: Run npm-update bot
         run: |
-          make tools/make-bots tools/node-modules
-          tools/make-bots
+          make tools/node-modules
+          ./test/common/make-bots
           git config --global user.name "GitHub Workflow"
           git config --global user.email "cockpituous@cockpit-project.org"
           mkdir -p ~/.config/cockpit-dev

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -17,8 +17,8 @@ jobs:
 
       - name: Run npm-update bot
         run: |
-          make tools/make-bots tools/node-modules
-          tools/make-bots
+          make tools/node-modules
+          ./test/common/make-bots
           git config --global user.name "GitHub Workflow"
           git config --global user.email "cockpituous@cockpit-project.org"
           mkdir -p ~/.config/cockpit-dev


### PR DESCRIPTION
We moved away from `tools/bots` in 89db1c68a9ff2b2b6f9a55e.

Still fails in my fork, not sure why? https://github.com/jelly/cockpit-podman/actions/runs/6074983559/job/16480217353