### PR TITLE
workflows: Force nightly trigger

### DIFF
--- a/.github/workflows/updates-testing-nightly.yml
+++ b/.github/workflows/updates-testing-nightly.yml
@@ -19,4 +19,4 @@ jobs:
           mkdir -p ~/.config/cockpit-dev
           echo "${{ github.token }}" >> ~/.config/cockpit-dev/github-token
           TEST_OS=$(PYTHONPATH=bots python3 -c 'from lib.constants import TEST_OS_DEFAULT; print(TEST_OS_DEFAULT)')
-          ./bots/tests-trigger "-" "${TEST_OS}/updates-testing"
+          bots/tests-trigger --force "-" "${TEST_OS}/updates-testing"


### PR DESCRIPTION
It may well happen that nothing has landed on main since the last time the nightly run happened. Disable the "isn't in triggerable state (is: success)" check.

---

This [failed last night](https://github.com/cockpit-project/cockpit-podman/actions/runs/6079229511/job/16491455998) as I already manually triggered it yesterday evening.

I [triggered a run from this branch](https://github.com/cockpit-project/cockpit-podman/actions/runs/6080223985), it succeeded and created a status. It's also visible in this PR, as it's the same SHA that I triggered the workflow on.