### PR TITLE
Add podman-next scenario

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,4 +19,4 @@ jobs:
           mkdir -p ~/.config/cockpit-dev
           echo "${{ github.token }}" >> ~/.config/cockpit-dev/github-token
           TEST_OS=$(PYTHONPATH=bots python3 -c 'from lib.constants import TEST_OS_DEFAULT; print(TEST_OS_DEFAULT)')
-          bots/tests-trigger --force "-" "${TEST_OS}/updates-testing"
+          bots/tests-trigger --force "-" "${TEST_OS}/updates-testing" "${TEST_OS}/podman-next"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,11 +1,11 @@
-name: fedora-updates-testing
+name: nightly
 on:
   schedule:
     - cron: '0 1 * * *'
   # can be run manually on https://github.com/cockpit-project/cockpit-podman/actions
   workflow_dispatch:
 jobs:
-  fedora-updates-testing:
+  trigger:
     permissions:
       statuses: write
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,10 @@ ifeq ("$(TEST_SCENARIO)","updates-testing")
 VM_CUSTOMIZE_FLAGS = --run-command 'dnf -y update --enablerepo=updates-testing,updates-testing-modular >&2'
 endif
 
+ifeq ("$(TEST_SCENARIO)","podman-next")
+VM_CUSTOMIZE_FLAGS = --run-command 'dnf -y copr enable rhcontainerbot/podman-next >&2; dnf -y update >&2'
+endif
+
 # build a VM with locally built distro pkgs installed
 $(VM_IMAGE): $(TARFILE) packaging/debian/rules packaging/debian/control packaging/arch/PKGBUILD bots
 	# HACK for ostree images: skip the rpm build/install


### PR DESCRIPTION
Enable https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next and regularly test against that. While we do have reverse dependency testing against podman itself, we don't yet have it against all the related projects yet, like container-selinux, netavark, or crun.
