### PR TITLE
fmf: Hack around Testing Farm's tag-repository priority

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -26,6 +26,14 @@ fi
 # HACK: ensure that critical components are up to date: https://github.com/psss/tmt/issues/682
 dnf update -y podman crun conmon criu
 
+# HACK: TF prioritizes Fedora tag repo over all others, in particular our daily COPR for revdep tests
+# This is bad -- let the highest version win instead!
+# https://gitlab.com/testing-farm/infrastructure/-/blob/testing-farm/ranch/public/citool-config/guest-setup/pre-artifact-installation/templates/tag.repo.j2?ref_type=heads
+for f in $(grep -l -r 'testing-farm-tag-repository' /etc/yum.repos.d); do
+    sed -i '/priority/d' "$f"
+done
+dnf update -y cockpit-podman
+
 # Show critical package versions
 rpm -q runc crun podman criu kernel-core selinux-policy cockpit-podman cockpit-bridge || true
 


### PR DESCRIPTION
TF runs add the Fedora tag repository with `priority=9`. This breaks upstream reverse dependency tests, as that repository will then win over our "main builds" COPR and thus run tests against a mismatching cockpit-podman rpm.

Counter the hack by dropping the tag repo priority and reinstalling cockpit-podman.

---

See e.g. https://github.com/containers/podman/pull/19953 and all other recent upstream podman PRs, where tests fail like [this](https://artifacts.dev.testing-farm.io/e3b3a2cd-e327-40db-896a-ea6775ef2296/) , because
```
podman-4.7.0~dev-1.20230913192200752553.pr19953.1753.38e069f70.fc38.x86_64
cockpit-podman-75-1.fc38.noarch
```
i.e. this is an outdated Fedora build (not even 76, which is in stable!), instead of the main build.