### PR TITLE
ruff: Enable UP032 f-string rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ select = [
     "RUF",     # ruff rules
     "T10",     # flake8-debugger
     "TCH",     # flake8-type-checking
+    "UP032",   # f-string
     "W",       # warnings (mostly whitespace)
     "YTT",     # flake8-2020
 ]


### PR DESCRIPTION
No code changes necessary, but make sure we don't introduce .format().