### PR TITLE
.github: set `[no-test]` prefix for dependabot PR's

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "[no-test]"
     labels:
       - "node_modules"
-      - "no-test"
     groups:
       eslint:
         patterns:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,4 +1,4 @@
-name: Update node_modules
+name: update node_modules
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, labeled]
@@ -54,28 +54,27 @@ jobs:
           ssh-add -D
           ssh-agent -k
 
-      - name: Clear no-test label
+      - name: Clear [no-test] prefix from PR title
+        if: ${{ contains(github.event.pull_request.title, '[no-test]') }}
         uses: actions/github-script@v6
+        env:
+          TITLE: '${{ github.event.pull_request.title }}'
         with:
           script: |
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: 'no-test'
-              });
-            } catch (e) {
-              if (e.name == 'HttpError' && e.status == 404) {
-                /* expected: 404 if label is unset */
-              } else {
-                throw e;
-              }
-            }
+            const title = process.env['TITLE'].replace(/\[no-test\]\W+ /, '')
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              title,
+            });
 
       - name: Force push node_modules update
         run: |
-          git commit --amend --no-edit node_modules
+          # Dependabot prefixes the commit with [no-test] which we don't want to keep in the commit
+          title=$(git show --pretty="%s" -s | sed -E "s/\[no-test\]\W+ //")
+          body=$(git show -s --pretty="%b")
+          git commit --amend -m "${title}" -m "${body}" --no-edit node_modules
           eval $(ssh-agent)
           ssh-add - <<< '${{ secrets.SELF_DEPLOY_KEY }}'
           git push --force 'git@github.com:${{ github.repository }}' '${{ github.head_ref }}'


### PR DESCRIPTION
Dependabot sets labels after PR creation so our pull requests tests would run regardless which is a waste of resources.