### PR TITLE
test: Accept different criu test failure error message

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -1306,8 +1306,10 @@ class TestApplication(testlib.MachineCase):
             b.click('.pf-v5-c-modal-box button:contains(Checkpoint)')
             b.wait_not_present('.modal_dialog')
 
-            b.wait(lambda: "checkpoint/restore requires at least criu"
-                   in b.text(".pf-v5-c-alert.pf-m-danger > .pf-v5-c-alert__description").lower())
+            def criu_alert():
+                text = b.text(".pf-v5-c-alert.pf-m-danger > .pf-v5-c-alert__description").lower()
+                return "checkpoint/restore requires at least criu" in text or "failed to check for criu" in text
+            b.wait(criu_alert)
             return
 
         # Run a container


### PR DESCRIPTION
Current Debian testing got a new podman version which changed the error message when `criu` is not available, to "failed to check for criu version: "criu": executable file not found in $PATH".

This is a bit less nice than the previous version requirement, but still clear enough, so accept it.

---

This blocks the [debian-testing refresh](https://github.com/cockpit-project/bots/pull/5358). see the [failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-5358-20231009-162657-bc35b231-debian-testing-cockpit-project-cockpit-podman/log.html). I'll trigger an extra run against that new image here.