### PR TITLE
Don't crash when image is being downloaded and integration/console tab is clicked

### DIFF
--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -454,21 +454,24 @@ class Containers extends React.Component {
                 renderer: ContainerDetails,
                 data: { container }
             });
-            tabs.push({
-                name: _("Integration"),
-                renderer: ContainerIntegration,
-                data: { container, localImages }
-            });
-            tabs.push({
-                name: _("Logs"),
-                renderer: ContainerLogs,
-                data: { containerId: container.Id, containerStatus: container.State.Status, width: this.state.width, system: container.isSystem }
-            });
-            tabs.push({
-                name: _("Console"),
-                renderer: ContainerTerminal,
-                data: { containerId: container.Id, containerStatus: container.State.Status, width: this.state.width, system: container.isSystem, tty }
-            });
+
+            if (!container.isDownloading) {
+                tabs.push({
+                    name: _("Integration"),
+                    renderer: ContainerIntegration,
+                    data: { container, localImages }
+                });
+                tabs.push({
+                    name: _("Logs"),
+                    renderer: ContainerLogs,
+                    data: { containerId: container.Id, containerStatus: container.State.Status, width: this.state.width, system: container.isSystem }
+                });
+                tabs.push({
+                    name: _("Console"),
+                    renderer: ContainerTerminal,
+                    data: { containerId: container.Id, containerStatus: container.State.Status, width: this.state.width, system: container.isSystem, tty }
+                });
+            }
         }
 
         if (healthcheck) {
@@ -480,8 +483,7 @@ class Containers extends React.Component {
         }
 
         return {
-            expandedContent: <ListingPanel colSpan='4'
-                                           tabRenderers={tabs} />,
+            expandedContent: <ListingPanel colSpan='4' tabRenderers={tabs} />,
             columns,
             initiallyExpanded: document.location.hash.substr(1) === container.Id,
             props: {

--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -330,7 +330,7 @@ export class ImageRunModal extends React.Component {
             tempImage.isSystem = isSystem;
             tempImage.State = { Status: _("downloading") };
             tempImage.Created = new Date();
-            tempImage.Names = [tempImage.name];
+            tempImage.Name = tempImage.name;
             tempImage.Image = createConfig.image;
             tempImage.isDownloading = true;
 


### PR DESCRIPTION
Large images which take some time download already shown the tabs but clicking on it would result in a JavaScript error as the Container object would not yet be available.

Closes:  #1408