### PR TITLE
test: Relax expected browser error

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -886,7 +886,7 @@ class TestApplication(testlib.MachineCase):
 
     def _testCommit(self, auth):
         b = self.browser
-        self.allow_browser_errors("Failed to commit container .*: CommitFailure: repository name must be lowercase")
+        self.allow_browser_errors("Failed to commit container .* repository name must be lowercase")
 
         self.login(auth)
 


### PR DESCRIPTION
Drop the "CommitFailure:" part from the expected browser error when trying to commit a container with an invalid name. This is unnecessarily strict, and https://github.com/containers/podman/pull/20377 is going to change it.

---

That part is definitively correct, but at the time of posting this it will *not* suffice to make https://github.com/containers/podman/pull/20377 green. That still needs to be discussed, and I think has to change on the podman side.