### PR TITLE
test: Drop push/pull ID preservation assumption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ VM_CUSTOMIZE_FLAGS = --run-command 'dnf -y update --setopt=install_weak_deps=Fal
 endif
 
 ifeq ("$(TEST_SCENARIO)","podman-next")
-VM_CUSTOMIZE_FLAGS = --run-command 'dnf -y copr enable rhcontainerbot/podman-next >&2; dnf -y update >&2'
+VM_CUSTOMIZE_FLAGS = --run-command 'dnf -y copr enable rhcontainerbot/podman-next >&2; dnf -y update --repo 'copr*' >&2'
 endif
 
 # build a VM with locally built distro pkgs installed

--- a/test/check-application
+++ b/test/check-application
@@ -1016,6 +1016,7 @@ class TestApplication(testlib.MachineCase):
                          f"podman tag {IMG_BUSYBOX} localhost:6000/my-busybox; podman push localhost:6000/my-busybox")
             # Untag busybox image which duplicates the image we are about to download
             self.execute(True, f"podman rmi -f {IMG_BUSYBOX} localhost:5000/my-busybox localhost:6000/my-busybox")
+            self.execute(False, f"podman rmi -f {IMG_BUSYBOX}")
 
         class DownloadImageDialog:
             def __init__(self, imageName, imageTag=None, user="system"):
@@ -1147,7 +1148,13 @@ class TestApplication(testlib.MachineCase):
             .fillDialog() \
             .selectImageAndDownload() \
             .expectDownloadSuccess()
-        dialog1.deleteImage(True, another=IMG_BUSYBOX_LATEST)
+        # test recognition/deletion of multiple image tags
+        second_tag = "localhost/copybox:latest"
+        self.execute(False, f"podman tag localhost:5000/my-busybox {second_tag}")
+        # expand details
+        b.click("#containers-images tr:contains('my-busybox') td.pf-v5-c-table__toggle button")
+        b.wait_in_text("#containers-images tbody.pf-m-expanded tr .image-details", second_tag)
+        dialog1.deleteImage(True, another=second_tag)
 
         dialog = DownloadImageDialog('my-busybox', 'latest', user="system")
         dialog.openDialog() \

--- a/test/check-application
+++ b/test/check-application
@@ -1140,6 +1140,7 @@ class TestApplication(testlib.MachineCase):
             .fillDialog() \
             .selectImageAndDownload() \
             .expectDownloadSuccess()
+        dialog0.deleteImage()
 
         dialog1 = DownloadImageDialog('my-busybox', user="user")
         dialog1.openDialog() \
@@ -1147,8 +1148,6 @@ class TestApplication(testlib.MachineCase):
             .selectImageAndDownload() \
             .expectDownloadSuccess()
         dialog1.deleteImage(True, another=IMG_BUSYBOX_LATEST)
-
-        dialog0.deleteImage()
 
         dialog = DownloadImageDialog('my-busybox', 'latest', user="system")
         dialog.openDialog() \


### PR DESCRIPTION
Until very recently, a cycle of `podman push`/`pull` preserved an
image's ID. Starting with containers-common 1-98 this is not the case
any more, as that changed the on-disk compression format. Quoting podman
devs: "The digests validate a specific image _representation_, not some
abstract "sameness" of an image."

Instead, remove the original busybox image for the user as well (that
already happend for the system user), and more explicitly check deletion
of an image with multiple tags.

Fixes https://github.com/containers/podman/issues/20611

Obsoletes https://github.com/cockpit-project/bots/issues/5515