### PR TITLE
packaging: drop Fedora 36/37 workarounds

### DIFF
--- a/packaging/cockpit-podman.spec.in
+++ b/packaging/cockpit-podman.spec.in
@@ -34,7 +34,7 @@ BuildRequires: libappstream-glib-devel
 Requires:       cockpit-bridge
 Requires:       podman >= 2.0.4
 # HACK https://github.com/containers/crun/issues/1091
-%if 0%{?fedora} == 36 || 0%{?fedora} == 37 || 0%{?centos} == 9
+%if 0%{?centos} == 9
 Requires:       criu-libs
 %endif
 


### PR DESCRIPTION
According to the GitHub issue this was also fixed in the packaging in F37. But as F37 is now EOL it is also fine to drop.