### PR TITLE
test: Drop tuned hack

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -11,10 +11,6 @@ if grep -q ID.*debian /usr/lib/os-release; then
     if systemctl is-enabled docker.service; then
         systemctl disable docker.service
     fi
-
-    # tuned is installed for testing cockpit; but it causes funny bugs, and we are not testing this here
-    # https://launchpad.net/bugs/1774000 https://launchpad.net/bugs/1925765
-    systemctl disable tuned
 fi
 
 # don't force https:// (self-signed cert)


### PR DESCRIPTION
These bugs are fixed in current Ubuntu releases.

----

I tested that manually. But also, our Debian/Ubuntu images already have tuned disabled.