### PR TITLE
test: Consistently stop podman in testNotRunning

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -1452,8 +1452,7 @@ class TestApplication(testlib.MachineCase):
         b = self.browser
 
         def disable_system():
-            self.execute(True, "systemctl disable --now podman.socket")
-            self.execute(True, "killall podman || true")
+            self.execute(True, "systemctl disable --now podman.socket; systemctl stop podman.service")
 
         def enable_system():
             self.execute(True, "systemctl enable --now podman.socket")


### PR DESCRIPTION
In all other places we use `systemctl stop podman` to shut it down orderly. Do the same in `testNotRunning`, to avoid provoking a failed service.