### PR TITLE
test: Adjust for `podman inspect` change for "all addresses"

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -1903,9 +1903,9 @@ class TestApplication(testlib.MachineCase):
                            '7001/tcp')
 
         ports = self.execute(auth, "podman inspect --format '{{.NetworkSettings.Ports}}' busybox-with-tty")
-        self.assertIn('5000/tcp:[{ 6000}]', ports)
+        self.assertRegex(ports, r'5000/tcp:\[{(0.0.0.0)? 6000}\]')
         self.assertIn('5001/udp:[{127.0.0.1 6001}]', ports)
-        self.assertIn('8001/tcp:[{ ', ports)
+        self.assertIn('8001/tcp:[{', ports)
         self.assertIn('9001/tcp:[{127.0.0.2 ', ports)
         self.assertNotIn('7001/tcp', ports)
 


### PR DESCRIPTION
https://github.com/containers/podman/pull/21601 changes the output for "bind port to all addresses" from "" to "0.0.0.0". Adjust the test to accept either format.

---

I tested this against the COPR of https://github.com/containers/podman/pull/21601 and the test passes now.