### PR TITLE
workflows: Switch release to cockpit/tasks container; packit: Release to Fedora 40

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   source:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/cockpit-project/unit-tests
+      image: quay.io/cockpit/tasks:latest
       options: --user root
     permissions:
       # create GitHub release

--- a/packit.yaml
+++ b/packit.yaml
@@ -21,6 +21,7 @@ jobs:
     targets:
     - fedora-38
     - fedora-39
+    - fedora-40
     - fedora-latest-aarch64
     - fedora-development
     - centos-stream-9-x86_64
@@ -32,6 +33,7 @@ jobs:
     targets:
       - fedora-38
       - fedora-39
+      - fedora-40
       - fedora-latest-aarch64
       - fedora-development
       - centos-stream-9-x86_64
@@ -64,6 +66,7 @@ jobs:
       - fedora-development
       - fedora-38
       - fedora-39
+      - fedora-40
 
   - job: koji_build
     trigger: commit
@@ -71,6 +74,7 @@ jobs:
       - fedora-development
       - fedora-38
       - fedora-39
+      - fedora-40
 
   - job: bodhi_update
     trigger: commit
@@ -78,3 +82,4 @@ jobs:
       # rawhide updates are created automatically
       - fedora-38
       - fedora-39
+      - fedora-40


### PR DESCRIPTION
The unit-tests container was dropped in
https://github.com/cockpit-project/cockpit/commit/f16f1fc14b88c

Cherry-picked from https://github.com/cockpit-project/starter-kit/commit/6e1427493a