### PR TITLE
test: Relax expected browser message for port conflict, too

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -2322,9 +2322,10 @@ class TestApplication(testlib.MachineCase):
             b.wait_not_present(f"{groupSelector} .pf-v5-c-helper-text__item-text")
             b.wait_visible(".pf-v5-c-modal-box__footer #create-image-create-run-btn:not(:disabled)")
 
-        """ Test the validation errors"""
-        self.allow_browser_errors(
-            "error: Container failed to be started: Internal Server Error: rootlessport listen tcp 0.0.0.0:5000.*")
+        # Test the validation errors
+
+        # complaint about port conflict
+        self.allow_browser_errors("error: Container failed to be started:.*5000.*")
         b = self.browser
         self.login(False)
         container_name = 'portused'


### PR DESCRIPTION
With current pasta, it now looks like this:
```
Container failed to be started: Internal Server Error: pasta failed with exit code 1:
No routable interface for IPv6: IPv6 is disabled
Failed to bind port 5000 (Address already in use) for option '-t 5000-5000:5000-5000', exiting
```

We are not overly concerned with the exact message, as long as it says something about the confliting port 5000.

Follow-up to commit 1a6ccd8d4a

---

See https://github.com/containers/podman/pull/21563#issuecomment-1966591889