### PR TITLE
pf-v5-m-loading does not exists

### DIFF
--- a/src/ImageRunModal.scss
+++ b/src/ImageRunModal.scss
@@ -16,7 +16,7 @@
 }
 
 // Fix the dot next to spinner: https://github.com/patternfly/patternfly-react/issues/6383
-.pf-v5-c-select__list-item.pf-v5-m-loading {
+.pf-v5-c-select__list-item.pf-m-loading {
     list-style-type: none;
 }
 


### PR DESCRIPTION
This class is still called `pf-m-loading` in PatternFly v5 and still suffers from 6383. As the component is deprecated we should consider moving away from it.