### PR TITLE
test: Adjust for new podman pasta version

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -2322,7 +2322,9 @@ class TestApplication(testlib.MachineCase):
         # Test the validation errors
 
         # complaint about port conflict
-        self.allow_browser_errors("error: Container failed to be started:.*5000.*")
+        self.allow_browser_errors("error: Container failed to be started:.*")
+        self.allow_browser_errors("No routable interface.*")
+        self.allow_browser_errors(".*ddress already in use.*5000.*")
         b = self.browser
         self.login(False)
         container_name = 'portused'


### PR DESCRIPTION
The error is sent in multiple lines and looks like this:
```
error: Container failed to be started: Internal Server Error: pasta failed with exit code 1:
No routable interface for IPv6: IPv6 is disabled
Failed to bind port 5000 (Address already in use) for option '-t 5000-5000:5000-5000', exiting
```

---

see https://github.com/containers/podman/pull/21563#issuecomment-1971649911