### PR TITLE
test: Drop /var/lib/containers/ subdirectory unmounting

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -106,14 +106,12 @@ class TestApplication(testlib.MachineCase):
             while pgrep podman; do sleep 0.1; done
             pkill -e -9 conmon || true
             while pgrep conmon; do sleep 0.1; done
-            findmnt --list -otarget | grep /var/lib/containers/. | xargs -r umount
             sync
             """)
 
         # backup/restore pristine podman state, so that tests can run on existing testbeds
         self.restore_dir("/var/lib/containers")
 
-        # HACK: sometimes podman leaks mounts
         self.addCleanup(m.execute, """
             systemctl stop podman.service podman.socket
             systemctl reset-failed podman.service podman.socket
@@ -122,7 +120,6 @@ class TestApplication(testlib.MachineCase):
             while pgrep podman; do sleep 0.1; done
             pkill -e -9 conmon || true
             while pgrep conmon; do sleep 0.1; done
-            findmnt --list -otarget | grep /var/lib/containers/. | xargs -r umount
             sync
             """)
 


### PR DESCRIPTION
podman creates an overlay mount or btrfs volume in a subdirectory there, which is legit. Let's see how far the tests get without this.