### PR TITLE
test: Move from `restore_dir()` to `podman system reset` for user

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -74,12 +74,8 @@ for retry in $(seq 5); do
     sleep $((5 * retry * retry))
 done
 
-# copy images for user podman tests; podman insists on user session
-loginctl enable-linger $(id -u admin)
-for img in localhost/test-alpine localhost/test-busybox localhost/test-registry; do
-    podman save  $img | sudo -i -u admin podman load
-done
-loginctl disable-linger $(id -u admin)
+# image setup, shared with upstream tests
+$TESTS/../vm.install
 
 systemctl enable --now cockpit.socket podman.socket
 

--- a/test/check-application
+++ b/test/check-application
@@ -140,11 +140,19 @@ class TestApplication(testlib.MachineCase):
                                                     ssh_port=m.ssh_port,
                                                     identity_file=m.identity_file)
 
-        # Enable user service as well
-        self.admin_s.execute("systemctl --user stop podman.service; systemctl --now --user enable podman.socket")
-        self.restore_dir("/home/admin/.local/share/containers")
-        self.addCleanup(self.admin_s.execute, "systemctl --user stop podman.service podman.socket || true")
-        # Ubuntu 22.04 has old podman that does not know about --time
+        # Enable user service as well; copy our images (except cockpit/ws) from system
+        self.admin_s.execute("""
+            systemctl --user stop podman.service
+            for img in $(ls /var/lib/test-images/*.tar | grep -v cockpitws); do podman load < "$img"; done
+            systemctl --now --user enable podman.socket
+            """)
+        self.addCleanup(self.admin_s.execute, """
+            systemctl --user stop podman.service podman.socket
+            podman system reset --force
+            """)
+        # HACK: system reset has 10s timeout, make that faster with an extra `stop`
+        # https://github.com/containers/podman/issues/21874
+        # Ubuntu 22.04 has old podman that does not know about rm --time
         if m.image == 'ubuntu-2204':
             self.addCleanup(self.admin_s.execute, "podman rm --force --all", timeout=300)
             self.addCleanup(self.admin_s.execute, "podman pod rm --force --all", timeout=300)

--- a/test/vm.install
+++ b/test/vm.install
@@ -26,13 +26,12 @@ fi
 # Since 4.0 podman now ships the pause image
 podman images --format '{{.Repository}}:{{.Tag}}' | grep -Ev 'localhost/test-|pause|cockpit/ws' | xargs -r podman rmi -f
 
-# copy images for user podman tests; podman insists on user session
-loginctl enable-linger $(id -u admin)
-images=$(podman images --format '{{.Repository}}:{{.Tag}}')
-for img in $images; do
-	podman save  $img | sudo -i -u admin podman load
+# tests reset podman, save the images
+mkdir -p /var/lib/test-images
+for img in $(podman images --format '{{.Repository}}:{{.Tag}}'); do
+    fname="$(echo "$img" | tr -dc '[a-zA-Z-]')"
+    podman save -o "/var/lib/test-images/${fname}.tar" "$img"
 done
-	loginctl disable-linger $(id -u admin)
 
 # 15minutes after boot tmp files are removed and podman stores some tmp lock files
 systemctl disable --now systemd-tmpfiles-clean.timer


### PR DESCRIPTION
The `restore_dir()` for podman's data directory is highly problematic:
This interferes with btrfs subvolumes and overlayfs mounts, and often
causes `cp` failures like

```
cp: cannot stat '/home/admin/.local/share/containers/storage/overlay/compat3876082856': No such file or directory
```

So move to `podman system reset`, and restore the test images
with `podman load` for each test.

Unfortunately `podman system reset` defaults to the 10 s wait timeout
(https://github.com/containers/podman/issues/21874), so we still need
the separate `rm --time 0` hack. But conceptually that can go away once
that bug is fixed.

This approach would also be nice on the system podman side, but it is super
hard to get right there especially on CoreOS: There we simultaneously want a
thorough cleanup, but also rely on the running cockpit/ws container. It also
collides with the "force unmount everything below /var/lib/containers" hack
that we unfortunately still need for some OSes. But doing it for the user at
least solves half of the problem. The observed failures in the field
all occurred on the user directory, anyway.
    
Fixes #1591

---

I tried the "full" approach in #1592, with pieces of it in #1596 and #1597, but this is a mine field :cry: 
