### PR TITLE
test: Always add pasta default route hack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ TAR_ARGS = --sort=name --mtime "@$(shell git show --no-patch --format='%at')" --
 # default customize_flags
 VM_CUSTOMIZE_FLAGS = --no-network
 
+# HACK: https://github.com/containers/podman/issues/21896
+VM_CUSTOMIZE_FLAGS += --run-command 'nmcli con add type dummy con-name fake ifname fake0 ip4 1.2.3.4/24 gw4 1.2.3.1 >&2'
+
 ifeq ($(TEST_COVERAGE),yes)
 RUN_TESTS_OPTIONS+=--coverage
 NODE_ENV=development
@@ -160,9 +163,6 @@ endif
 
 ifeq ("$(TEST_SCENARIO)","podman-next")
 VM_CUSTOMIZE_FLAGS = --run-command 'dnf -y copr enable rhcontainerbot/podman-next >&2; dnf -y update --repo "copr*" >&2'
-
-# HACK: https://github.com/containers/podman/issues/21896
-VM_CUSTOMIZE_FLAGS += --run-command 'nmcli con add type dummy con-name fake ifname fake0 ip4 1.2.3.4/24 gw4 1.2.3.1 >&2'
 endif
 
 # build a VM with locally built distro pkgs installed


### PR DESCRIPTION
podman 5 has landed in Fedora >= 40, so our tests start failing due to https://github.com/containers/podman/issues/21896

Extend the hack from commit cecb2cc6e8f24 to apply to all our images, not just the podman-next scenario.

----

Blocks https://github.com/cockpit-project/bots/pull/6050 . I'll trigger an extra test run against that. That does work, but it mis-reports the result as [fedora-40](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1608-5d3f1302-20240311-075730-fedora-40/log.html). See pilot board.