### PR TITLE
lint: Ignore test functions in vulture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,8 @@ mark-parentheses = false
 
 [tool.ruff.lint.isort]
 known-first-party = ["cockpit"]
+
+[tool.vulture]
+ignore_names = [
+   "test[A-Z0-9]*",
+]


### PR DESCRIPTION
These aren't unused, but discovered/enumerated by `unittest` or `pytest`.

---

Fixes [this static-code failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6048-20240311-121551-77e2f887-ubuntu-stable-cockpit-project-cockpit-podman/log.html) after we added vulture to the tasks container.