### PR TITLE
fmf: Add slirp4netns dependency

### DIFF
--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -9,6 +9,8 @@ require:
   - make
   - nodejs
   - python3
+  # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=2269485
+  - slirp4netns
 duration: 30m
 
 /system:


### PR DESCRIPTION
Rawhide's most recent containers-common dropped it, but podman still needs it: https://bugzilla.redhat.com/show_bug.cgi?id=2269485

Until that gets sorted out, add a test dependency.

----

All rawhide tests [started to fail like this](https://artifacts.dev.testing-farm.io/71f500ce-c7a0-4b7e-b9ef-47ded095378e/) last night.