### PR TITLE
test/browser: run tests inside the tasks container

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -1,27 +1,7 @@
 #!/bin/sh
+
 set -eux
-
-# test plan name, passed on to run-test.sh
-PLAN="$1"
-
-export TEST_BROWSER=${TEST_BROWSER:-firefox}
-
-TESTS="$(realpath $(dirname "$0"))"
-export SOURCE="$(realpath $TESTS/../..)"
-
-# https://tmt.readthedocs.io/en/stable/overview.html#variables
-export LOGS="${TMT_TEST_DATA:-$(pwd)/logs}"
-mkdir -p "$LOGS"
-chmod a+w "$LOGS"
-
-# install firefox (available everywhere in Fedora and RHEL)
-# we don't need the H.264 codec, and it is sometimes not available (rhbz#2005760)
-dnf install --disablerepo=fedora-cisco-openh264 -y --setopt=install_weak_deps=False firefox
-
-# nodejs 10 is too old for current Cockpit test API
-if grep -q platform:el8 /etc/os-release; then
-    dnf module switch-to -y nodejs:16
-fi
+cd "${0%/*}/../.."
 
 # HACK: ensure that critical components are up to date: https://github.com/psss/tmt/issues/682
 dnf update -y podman crun conmon criu
@@ -37,6 +17,11 @@ fi
 # Show critical package versions
 rpm -q runc crun podman criu kernel-core selinux-policy cockpit-podman cockpit-bridge || true
 
+# allow test to set up things on the machine
+mkdir -p /root/.ssh
+curl https://raw.githubusercontent.com/cockpit-project/bots/main/machine/identity.pub >> /root/.ssh/authorized_keys
+chmod 600 /root/.ssh/authorized_keys
+
 # create user account for logging in
 if ! id admin 2>/dev/null; then
     useradd -c Administrator -G wheel admin
@@ -48,16 +33,6 @@ echo root:foobar | chpasswd
 
 # avoid sudo lecture during tests
 su -c 'echo foobar | sudo --stdin whoami' - admin
-
-# create user account for running the test
-if ! id runtest 2>/dev/null; then
-    useradd -c 'Test runner' runtest
-    # allow test to set up things on the machine
-    mkdir -p /root/.ssh
-    curl https://raw.githubusercontent.com/cockpit-project/bots/main/machine/identity.pub  >> /root/.ssh/authorized_keys
-    chmod 600 /root/.ssh/authorized_keys
-fi
-chown -R runtest "$SOURCE"
 
 # disable core dumps, we rather investigate them upstream where test VMs are accessible
 echo core > /proc/sys/kernel/core_pattern
@@ -74,15 +49,28 @@ for retry in $(seq 5); do
     sleep $((5 * retry * retry))
 done
 
+CONTAINER="$(cat .cockpit-ci/container)"
+
+# import the test CONTAINER image as a directory tree for nspawn
+mkdir /var/tmp/tasks
+podman export "$(podman create --name tasks-import $CONTAINER)" | tar -x -C /var/tmp/tasks
+podman rm tasks-import
+podman rmi $CONTAINER
+
 # image setup, shared with upstream tests
-$TESTS/../vm.install
+sh -x test/vm.install
 
 systemctl enable --now cockpit.socket podman.socket
 
-# Run tests as unprivileged user
-# once we drop support for RHEL 8, use this:
-# runuser -u runtest --whitelist-environment=TEST_BROWSER,TEST_ALLOW_JOURNAL_MESSAGES,TEST_AUDIT_NO_SELINUX,SOURCE,LOGS $TESTS/run-test.sh $PLAN
-runuser -u runtest --preserve-environment env USER=runtest HOME=$(getent passwd runtest | cut -f6 -d:) $TESTS/run-test.sh $PLAN
+# Run tests in the cockpit tasks container, as unprivileged user
+# Use nspawn to avoid the tests killing the tasks container itself
+chown -R 1111:1111 "${TMT_TEST_DATA}" .
 
-RC=$(cat $LOGS/exitcode)
-exit ${RC:-1}
+SYSTEMD_SECCOMP=0 systemd-nspawn \
+    -D /var/tmp/tasks/ \
+    --ephemeral \
+    --user user \
+    --bind="${TMT_TEST_DATA}":/logs --setenv=LOGS=/logs \
+    --bind="$(pwd)":/source --setenv=SOURCE=/source \
+    --bind-ro=/usr/lib/os-release:/run/host/usr/lib/os-release \
+    sh /source/test/browser/run-test.sh "$@"

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -1,14 +1,9 @@
 require:
+  - systemd-container
   - cockpit-podman
   - cockpit-ws
   - cockpit-system
-  - bzip2
   - criu
-  - git-core
-  - libvirt-python3
-  - make
-  - nodejs
-  - python3
   # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=2269485
   - slirp4netns
 duration: 30m

--- a/test/vm.install
+++ b/test/vm.install
@@ -14,9 +14,10 @@ if grep -q ID.*debian /usr/lib/os-release; then
 fi
 
 # don't force https:// (self-signed cert)
+mkdir -p /etc/cockpit
 printf "[WebService]\\nAllowUnencrypted=true\\n" > /etc/cockpit/cockpit.conf
 
-if type firewall-cmd >/dev/null 2>&1; then
+if systemctl is-active -q firewalld.service; then
     firewall-cmd --add-service=cockpit --permanent
 fi
 


### PR DESCRIPTION
This simplifies the "outside" setup quite a bit and gives us the same tasks container that test runs on the Cockpit CI run under.
