### PR TITLE
Pass all local images for container integration details

### DIFF
--- a/src/ContainerIntegration.jsx
+++ b/src/ContainerIntegration.jsx
@@ -98,7 +98,10 @@ const ContainerIntegration = ({ container, localImages }) => {
     const volumes = renderContainerVolumes(container.Mounts);
 
     const image = localImages.filter(img => img.Id === container.Image)[0];
-    const env = <ContainerEnv containerEnv={container.Config.Env} imageEnv={image.Env} />;
+    let env = null;
+    // Podman allows one to remove an image while it has a container attached
+    if (image)
+        env = <ContainerEnv containerEnv={container.Config.Env} imageEnv={image.Env} />;
 
     return (
         <DescriptionList isAutoColumnWidths columnModifier={{ md: '3Col' }} className='container-integration'>

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -677,28 +677,27 @@ class Containers extends React.Component {
 
         // Convert to the search result output
         let localImages = null;
+        let nonIntermediateImages = null;
         if (this.props.images) {
-            localImages = Object.keys(this.props.images).reduce((images, id) => {
+            localImages = Object.keys(this.props.images).map(id => {
                 const img = this.props.images[id];
-                if (img.RepoTags) {
-                    img.Index = img.RepoTags[0].split('/')[0];
-                    img.Name = img.RepoTags[0];
-                    img.toString = function imgToString() { return this.Name };
-                    images.push(img);
-                }
-                return images;
+                img.Index = img.RepoTags?.[0] ? img.RepoTags[0].split('/')[0] : "";
+                img.Name = utils.image_name(img);
+                img.toString = function imgToString() { return this.Name };
+                return img;
             }, []);
+            nonIntermediateImages = localImages.filter(img => img.Index !== "");
         }
 
         const createContainer = (inPod) => {
-            if (localImages)
+            if (nonIntermediateImages)
                 Dialogs.show(
                     <utils.PodmanInfoContext.Consumer>
                         {(podmanInfo) => (
                             <DialogsContext.Consumer>
                                 {(Dialogs) => (
                                     <ImageRunModal user={this.props.user}
-                                                              localImages={localImages}
+                                                              localImages={nonIntermediateImages}
                                                               pod={inPod}
                                                               systemServiceAvailable={this.props.systemServiceAvailable}
                                                               userServiceAvailable={this.props.userServiceAvailable}
@@ -742,7 +741,7 @@ class Containers extends React.Component {
                     <ToolbarItem>
                         <Button variant="primary" key="get-new-image-action"
                                 id="containers-containers-create-container-btn"
-                                isDisabled={localImages === null}
+                                isDisabled={nonIntermediateImages === null}
                                 onClick={() => createContainer(null)}>
                             {_("Create container")}
                         </Button>
@@ -825,7 +824,7 @@ class Containers extends React.Component {
                                                 <Badge isRead className={"ct-badge-pod-" + podStatus.toLowerCase()}>{_(podStatus)}</Badge>
                                                 <Button variant="secondary"
                                                         className="create-container-in-pod"
-                                                        isDisabled={localImages === null}
+                                                        isDisabled={nonIntermediateImages === null}
                                                         onClick={() => createContainer(this.props.pods[section])}>
                                                     {_("Create container in pod")}
                                                 </Button>

--- a/test/check-application
+++ b/test/check-application
@@ -861,6 +861,10 @@ class TestApplication(testlib.MachineCase):
         b.wait_not_present("div.pf-v5-c-modal-box")
         self.waitContainerRow(IMG_INTERMEDIATE)
 
+        # Integration tab should not crash with an intermediate image
+        self.toggleExpandedContainer(IMG_INTERMEDIATE)
+        b.click(".pf-m-expanded button:contains('Integration')")
+
         # Delete intermediate image which is in use
         self.execute(auth, f"podman untag {IMG_INTERMEDIATE}")
         clickDeleteImage(intermediate_image_sel)


### PR DESCRIPTION
On some systems a toolbox container has an intermediate image as image which since 17d258855fac34556d66337f9015d47741dd482c is no longer passed to the renderRow.

Closes #1649

---

I am unsure how I got into this situation or how to reproduce it. But it is :100: valid for a container to depend on an intermediate image and it should not crash the page.