### PR TITLE
Makefile: Treat *-bootc images as OSTree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ rpm: $(TARFILE)
 # build a VM with locally built distro pkgs installed
 $(VM_IMAGE): $(TARFILE) packaging/debian/rules packaging/debian/control packaging/arch/PKGBUILD bots
 	# HACK for ostree images: skip the rpm build/install
-	if [ "$$TEST_OS" = "fedora-coreos" ] || [ "$$TEST_OS" = "rhel4edge" ]; then \
+	if [ "$${TEST_OS%coreos}" != "$$TEST_OS" ] || [ "$${TEST_OS%bootc}" != "$$TEST_OS" ] || [ "$$TEST_OS" = "rhel4edge" ]; then \
 	    bots/image-customize --verbose --fresh --no-network --run-command 'mkdir -p /usr/local/share/cockpit' \
 	                         --upload dist/:/usr/local/share/cockpit/podman \
 	                         --script $(CURDIR)/test/vm.install $(TEST_OS); \


### PR DESCRIPTION
On these we also can't install RPMs, and give them the "direct install" treatment instead.

Also generalize the "fedora-coreos" match.

----

See https://github.com/cockpit-project/bots/pull/6171 for introducing a bootc image.