### PR TITLE
test: Adjust expected default RestartPolicy value

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -2538,7 +2538,8 @@ class TestApplication(testlib.MachineCase):
 
         container_name = 'none'
         create_container(container_name)
-        self.assertEqual(self.getRestartPolicy(auth, container_name), '{ 0}')
+        # format changed in podman 5.1 (https://github.com/containers/podman/pull/22322)
+        self.assertIn(self.getRestartPolicy(auth, container_name), ['{ 0}', '{no 0}'])
 
         container_name = 'restart'
         create_container(container_name, 'always')


### PR DESCRIPTION
https://github.com/containers/podman/pull/22322 changes the reported default restart policy from "" to "no". Accept both forms for the time being, until all supported OSes have podman ≥ 5.1.

----

See https://github.com/containers/podman/pull/22322

@mheon FYI