### PR TITLE
test: Adjust expected HealthCheck API format

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -2411,8 +2411,9 @@ class TestApplication(testlib.MachineCase):
         if podman_version(self) >= (4, 3, 0):
             b.wait_in_text('#container-details-healthcheck dt:contains("When unhealthy") + dd', 'No action')
 
-        self.assertEqual(self.execute(auth, "podman inspect --format '{{.Config.Healthcheck}}' healthy").strip(),
-                         "{[true] 5s 5m25s 35s 2}")
+        # format changed in podman 5.1, adds StartInterval (https://github.com/containers/podman/pull/22334)
+        self.assertIn(self.execute(auth, "podman inspect --format '{{.Config.Healthcheck}}' healthy").strip(),
+                      ["{[true] 5s 5m25s 35s 2}", "{[true] 5s 0s 5m25s 35s 2}"])
 
         # single successful health check
         b.wait_in_text(".ct-listing-panel-body tbody tr", "Passed health run")


### PR DESCRIPTION
podman 5.1 [1], by way of [2], adds a "StartInterval" element to the `.Config.Healthcheck` API field. This is an API breakage, but accept either form until 5.1 is available on all OSes.

[1] https://github.com/containers/podman/pull/22334
[2] https://github.com/containers/image/commit/b6afa8ca7b324aca8fd5a7b5b206fc05c0c04874