### PR TITLE
fmf: Restrict "-stream" TEST_OS suffix to CentOS 8/9

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -20,7 +20,7 @@ fi
 . /run/host/usr/lib/os-release
 export TEST_OS="${ID}-${VERSION_ID/./-}"
 
-if [ "${TEST_OS#centos-}" != "$TEST_OS" ]; then
+if [ "$TEST_OS" = "centos-8" ] || [ "$TEST_OS" = "centos-9" ]; then
     TEST_OS="${TEST_OS}-stream"
 fi
 


### PR DESCRIPTION
Our c10s CI image is called "centos-10" without the -stream suffix. This fits better with `os-release` and makes the names shorter. Adjust the building of `$TEST_OS` accordingly.

[1] https://github.com/cockpit-project/bots/pull/6218

----

Note that I can't enable c10s testing on c-podman just yet, the initial blocker is https://issues.redhat.com/browse/RHEL-32905 (which is impossible to work around). So let's just cherry-pick https://github.com/cockpit-project/starter-kit/pull/839 for the time being, so that I won't forget.