### PR TITLE
Rework display of current container memory usage

### DIFF
--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -361,7 +361,7 @@ class Containers extends React.Component {
         if (containerStats && status === "running") {
             // container.HostConfig.Memory (0 by default), containerStats.MemUsage
             if (containerStats.CPU != undefined)
-                proc = containerStats.CPU.toFixed(2) + "%";
+                proc = <div className="ct-numeric-column">{containerStats.CPU.toFixed(2) + "%"}</div>;
             if (Number.isInteger(containerStats.MemUsage) && this.state.memTotal) {
                 // the primary view is how much of the host's memory a container uses, for comparability
                 const mem_pct = Math.round(containerStats.MemUsage / this.state.memTotal * 100);
@@ -383,7 +383,7 @@ class Containers extends React.Component {
                     );
                 }
 
-                mem = <div className="container-block">{mem_items}</div>;
+                mem = <div className="container-block ct-numeric-column">{mem_items}</div>;
             }
         }
         const info_block = (
@@ -591,8 +591,8 @@ class Containers extends React.Component {
         const columnTitles = [
             { title: _("Container"), transforms: [cellWidth(20)], sortable: true },
             { title: _("Owner"), sortable: true },
-            { title: _("CPU"), sortable: true },
-            { title: _("Memory"), sortable: true },
+            { title: _("CPU"), sortable: true, props: { className: 'ct-numeric-column' } },
+            { title: _("Memory"), sortable: true, props: { className: 'ct-numeric-column' } },
             { title: _("State"), sortable: true },
             ''
         ];

--- a/src/podman.scss
+++ b/src/podman.scss
@@ -19,6 +19,11 @@
     .pf-v5-c-table.pf-m-compact .pf-v5-c-table__toggle {
         padding-inline-start: 0;
     }
+
+    // don't make the columns too narrow
+    th .pf-v5-c-table__text {
+        min-inline-size: fit-content;
+    }
 }
 
 @media screen and (max-width: 768px) {

--- a/src/podman.scss
+++ b/src/podman.scss
@@ -115,6 +115,17 @@
    color: var(--pf-v5-global--Color--200);
 }
 
+// HACK: PF should offer that: https://github.com/patternfly/patternfly/issues/6572
+.ct-numeric-column {
+    text-align: end;
+
+    .pf-v5-c-table__button {
+        // right-justify the button inside of the th
+        flex-direction: row-reverse;
+        margin-inline-start: 0;
+    }
+}
+
 .content-action {
     text-align: end;
     white-space: nowrap !important;

--- a/src/util.js
+++ b/src/util.js
@@ -44,30 +44,6 @@ export function localize_time(unix_timestamp) {
     return formatRelative(unix_timestamp * 1000, Date.now(), { locale });
 }
 
-export function format_memory_and_limit(usage, limit) {
-    if (usage === undefined || isNaN(usage))
-        return "";
-
-    let mtext = "";
-    let unit;
-    let parts;
-    if (limit) {
-        parts = cockpit.format_bytes(limit, undefined, { separate: true });
-        mtext = " / " + parts.join(" ");
-        unit = parts[1];
-    }
-
-    if (usage) {
-        parts = cockpit.format_bytes(usage, unit, { separate: true });
-        if (mtext)
-            return _(parts[0] + mtext);
-        else
-            return _(parts.join(" "));
-    } else {
-        return "";
-    }
-}
-
 /*
  * The functions quote_cmdline and unquote_cmdline implement
  * a simple shell-like quoting syntax.  They are used when letting the

--- a/test/check-application
+++ b/test/check-application
@@ -4,6 +4,7 @@
 # "class Browser" and "class MachineCase" for the available API.
 
 import os
+import re
 import sys
 import time
 
@@ -1225,6 +1226,14 @@ class TestApplication(testlib.MachineCase):
         self.waitContainer(container_sha, auth, name='swamped-crate', image=IMG_BUSYBOX,
                            state='Running', owner="system" if auth else "admin")
 
+        # run another container with explicit memory 400 MiB limit, with a process that uses 300 MB memory
+        self.execute(
+            auth,
+            f"podman run -d --name picket-fence --memory 400m --stop-timeout 0 {IMG_ALPINE} "
+            """awk 'BEGIN { y = sprintf("%300000000s",""); system("sleep infinity") }'""")
+        picket_fence_sha = self.execute(auth, "podman inspect --format '{{.Id}}' picket-fence").strip()
+        self.waitContainer(picket_fence_sha, auth, name="picket-fence", state="Running")
+
         def get_cpu_usage(sel):
             cpu = self.getContainerAttr(sel, "CPU")
             self.assertIn('%', cpu)
@@ -1238,17 +1247,40 @@ class TestApplication(testlib.MachineCase):
         if auth or self.has_cgroupsV2:
             cpu = get_cpu_usage(IMG_BUSYBOX)
 
-            self.assertIn('/', memory)
-            numbers = memory.split('/')
-            self.assertTrue(numbers[0].strip().replace('.', '', 1).isdigit())
-            full = numbers[1].strip().split()
-            self.assertTrue(full[0].replace('.', '', 1).isdigit())
-            self.assertIn(full[1], ["GB", "MB"])
+            # swamped-crate has no explicit --memory limit
+            # FIXME: current format_bytes() does "KB"; fixed in https://github.com/cockpit-project/cockpit/pull/20356
+            m = re.match(r'([0-9]+)%([0-9.]+) [kK]B$', memory)
+            self.assertTrue(m, memory)
+            mem_pct = int(m.group(1))
+            mem_abs = float(m.group(2))
+            self.assertGreaterEqual(mem_pct, 0)
+            self.assertGreaterEqual(mem_abs, 1.0)
+            # this container doesn't do anything, should have small memory usage
+            self.assertLessEqual(mem_pct, 5)
+            self.assertLessEqual(mem_abs, 300.0)
 
-            # Test that the value is updated dynamically
+            # Test that the CPU value is updated dynamically
             self.execute(auth, "podman exec -i swamped-crate sh -c 'dd bs=1024 < /dev/urandom > /dev/null &'")
             b.wait(lambda: get_cpu_usage(IMG_BUSYBOX) > cpu)
             self.execute(auth, "podman exec swamped-crate sh -c 'pkill dd'")
+
+            # picket-fence has a memory limit
+            memory = self.getContainerAttr(IMG_ALPINE, "Memory")
+            m = re.match(r'([0-9]+)%([0-9.]+) MB([0-9]+)% of ([0-9.]+) MB limit$', memory)
+            self.assertTrue(m, memory)
+            # wide range here, to work on custom testbeds
+            host_mem_pct = int(m.group(1))
+            self.assertGreater(host_mem_pct, 2)
+            self.assertLess(host_mem_pct, 90)
+            # this is fairly well predictable
+            mem_abs = float(m.group(2))
+            self.assertGreaterEqual(mem_abs, 300.0)
+            self.assertLess(mem_abs, 305.0)
+            limit_mem_pct = int(m.group(3))
+            self.assertGreaterEqual(limit_mem_pct, 70)
+            self.assertLessEqual(limit_mem_pct, 75)
+            # 400 MiB limit
+            self.assertEqual(m.group(4), "419")
         else:
             # No support for CGroupsV2
             self.assertEqual(self.getContainerAttr(IMG_BUSYBOX, "CPU"), "n/a")
@@ -2104,9 +2136,9 @@ class TestApplication(testlib.MachineCase):
         if name:
             b.wait_text(sel + " .container-name", name)
         if image:
-            b.wait_in_text(sel + " .container-block small:nth-child(2)", image)
+            b.wait_in_text(sel + " td[data-label=Container] small:nth-child(2)", image)
         if cmd:
-            b.wait_text(sel + " .container-block small:last-child", cmd)
+            b.wait_text(sel + " td[data-label=Container] small:last-child", cmd)
         if owner:
             if owner == "system":
                 b.wait_text(sel + " td[data-label=Owner]", owner)


### PR DESCRIPTION
The previous view like "0.001/16 GB" was not very helpful. For containers
without an explicit memory limit, the denominator `containerStats.MemLimit` is
the *host* memory, not something specific to the container. This makes it hard
to see which containers actually have a configured limit. For containers which
*do* have a memory limit, the numerator applied to that, but that makes it
difficult to compare to other containers and its relative size on the host
(from the "see the forest, not the tree" perspective).

Rework this to show Memory in three parts:

- The first line shows the container's memory usage as a percentage of
the host's memory. That makes them comparable and gives a good
feeling about host resource utilization, similar to the CPU usage
view.

- The second line shows the container's absolute memory usage. This
uses proper SI prefixes and thus uses normalized numbers, not like "0.001".

- *If* the container has an explicit memory limit, show its value and used
percentage, in lower/gray font (similar to the image name and process).
Don't show it for the common case of no limit.

This also gets rid of calling `cockpit.format_bytes()` with the `separate` API,
which we'd like to get rid of (as it encourages these questionable string
trickeries).


----

See [this discussion](https://github.com/cockpit-project/cockpit/pull/20322/files#r1570020217).

On main it looks like this:
![podman-mem-main](https://github.com/cockpit-project/cockpit-podman/assets/200109/a4f7a0b9-3703-4c92-9cce-b9606802a64b)

![image](https://github.com/cockpit-project/cockpit-podman/assets/200109/d9c99344-1d0e-4c8f-96ce-55d46811ce26)

 - [x] Builds on top of PR #1672 

[pixel diff](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1673-bee7fa0f-20240425-151140-fedora-39/log.html)

## Podman: Improve display of memory usage

The Podman Containers page now shows the memory used by a container as percentage of host memory and also the absolute usage with an appropriate unit. It also does not show a limit any more for containers which don't actually have a configured limit. For those which do, it shows both the absolute limit and which percentage of this is currently used.

This makes it easier to get an overview of the host's RAM utilization and relative sizes of the containers, similar to how it already presents the CPU usage. It also makes it clear which containers have a memory limit.

![Screen Shot 2024-04-25 at 16 55 07](https://github.com/cockpit-project/cockpit-podman/assets/200109/7f581f8e-726b-4176-be6a-2fbba4ad23e5)

