### PR TITLE
test: enable ruff preview rules

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 118

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ exclude = [
     "node_modules/",
 ]
 line-length = 118
+preview = true
 src = []
 
 [tool.ruff.lint]

--- a/test/check-application
+++ b/test/check-application
@@ -150,7 +150,7 @@ class TestApplication(testlib.MachineCase):
         if self.getError():
             # dump container logs for debugging
             for auth in [False, True]:
-                print(f"----- {auth and 'system' or 'user'} containers -----", file=sys.stderr)
+                print(f"----- {'system' if auth else 'user'} containers -----", file=sys.stderr)
                 self.execute(auth, "podman ps -a >&2")
                 self.execute(auth, 'for c in $(podman ps -aq); do echo "---- $c ----" >&2; podman logs $c >&2; done')
 


### PR DESCRIPTION
Ruff's preview rules now implements the rules which we used flake8 for.