### PR TITLE
eslint: enable no-useless-fragment rule by default

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,6 +39,7 @@
         "react/jsx-curly-newline": "off",
         "react/jsx-handler-names": "off",
         "react/prop-types": "off",
+        "react/jsx-no-useless-fragment": "error",
         "space-before-function-paren": "off",
         "standard/no-callback-literal": "off",
 

--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -54,11 +54,9 @@ class Images extends React.Component {
                 .catch(ex => {
                     const error = cockpit.format(_("Failed to download image $0:$1"), imageName, imageTag || "latest");
                     const errorDetail = (
-                        <>
-                            <p> {_("Error message")}:
-                                <samp>{cockpit.format("$0 $1", ex.message, ex.reason)}</samp>
-                            </p>
-                        </>
+                        <p> {_("Error message")}:
+                            <samp>{cockpit.format("$0 $1", ex.message, ex.reason)}</samp>
+                        </p>
                     );
                     this.setState({ imageDownloadInProgress: undefined });
                     this.props.onAddNotification({ type: 'danger', error, errorDetail });


### PR DESCRIPTION
This rule is not part of the standard ESLint recommends set but is useful and can be auto-fixed.