### PR TITLE
dependabot: Group React and types packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,15 +19,19 @@ updates:
       esbuild:
         patterns:
           - "esbuild*"
-      stylelint:
-        patterns:
-          - "stylelint*"
-      xterm:
-        patterns:
-          - "xterm*"
       patternfly:
         patterns:
           - "@patternfly*"
+      react:
+        patterns:
+          - "react*"
+      stylelint:
+        patterns:
+          - "stylelint*"
+      types:
+        patterns:
+          - "@types*"
+          - "types*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Also sort the list alphabetically.

---

See #1694 and #1695, they shouldn't be updated together.