### PR TITLE
packit: Drop testing on CentOS 8 Stream

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -76,7 +76,7 @@ Run `make vm` to build an RPM and install it into a standard Cockpit test VM.
 This will be `fedora-39` by default. You can set `$TEST_OS` to use a different
 image, for example
 
-    TEST_OS=centos-8-stream make vm
+    TEST_OS=centos-9-stream make vm
 
 Then run
 
@@ -97,7 +97,7 @@ Use this command to list all known tests:
 
 You can also run all of the tests:
 
-    TEST_OS=centos-8-stream make check
+    make check
 
 However, this is rather expensive, and most of the time it's better to let the
 CI machinery do this on a draft pull request.

--- a/packit.yaml
+++ b/packit.yaml
@@ -25,7 +25,6 @@ jobs:
     - fedora-development
     - centos-stream-9-x86_64
     - centos-stream-9-aarch64
-    - centos-stream-8-x86_64
 
   - job: tests
     trigger: pull_request
@@ -36,7 +35,6 @@ jobs:
       - fedora-development
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
-      - centos-stream-8-x86_64
 
   - job: copr_build
     trigger: release

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -20,7 +20,7 @@ fi
 . /run/host/usr/lib/os-release
 export TEST_OS="${ID}-${VERSION_ID/./-}"
 
-if [ "$TEST_OS" = "centos-8" ] || [ "$TEST_OS" = "centos-9" ]; then
+if [ "$TEST_OS" = "centos-9" ]; then
     TEST_OS="${TEST_OS}-stream"
 fi
 

--- a/test/check-application
+++ b/test/check-application
@@ -136,7 +136,7 @@ class TestApplication(testlib.MachineCase):
         # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1008249
         self.has_criu = "debian" not in m.image and "ubuntu" not in m.image
         self.has_selinux = "arch" not in m.image and "debian" not in m.image and "ubuntu" not in m.image
-        self.has_cgroupsV2 = m.image not in ["centos-8-stream"] and not m.image.startswith('rhel-8')
+        self.has_cgroupsV2 = not m.image.startswith('rhel-8')
 
         self.system_images_count = int(self.execute(True, "podman images -n | wc -l").strip())
         self.user_images_count = int(self.execute(False, "podman images -n | wc -l").strip())


### PR DESCRIPTION
C8S is going to be EOL in a month [1], and we are not going to do a RHEL 8 update at this point any more.

Keep testing on rhel-8-10 though, as we do want to keep the code working for the beiboot scenario or backports.

[1] https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/

---

En passant this also sweeps the recent [c8s regression](https://artifacts.dev.testing-farm.io/25066bae-7ddb-4bd3-a254-2693f15dfb68/) under the rug which we've been ignoring for a while. So c-podman tests should go green again now.