### PR TITLE
Makefile: workaround pasta user containers being broken

### DIFF
--- a/test/run
+++ b/test/run
@@ -12,6 +12,11 @@ if [ "$TEST_SCENARIO" == "devel" ]; then
     export TEST_COVERAGE=yes
 fi
 
+# Workaround broken podman pasta on Fedora-CoreOS https://bugzilla.redhat.com/show_bug.cgi?id=2277954
+if [ "$TEST_OS" == "fedora-coreos" ]; then
+    export RUN_TESTS_OPTIONS="${RUN_TESTS_OPTIONS} --enable-network"
+fi
+
 make codecheck
 make check
 make po/podman.pot


### PR DESCRIPTION
When a system container runs a user container cannot be created as it exits with a pasta error.

Reported as https://bugzilla.redhat.com/show_bug.cgi?id=2277954