### PR TITLE
Implement pull option for existing images

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -1751,7 +1751,7 @@ class TestApplication(testlib.MachineCase):
 
         # Now that we have downloaded an image, verify that selecting download latest image
         # downloads the latest image we now push to the registry. Note this image has a /latest file
-        # to differnatiate it from the other local image.
+        # to differentiate it from the other local image.
         self.execute(True, f"podman push {new_image_sha} localhost:5000/my-busybox")
         self.execute(True, f"podman push {new_image_sha} localhost:6000/my-busybox")
         self.execute(True, f"podman rmi {new_image_sha}")

--- a/test/check-application
+++ b/test/check-application
@@ -537,6 +537,7 @@ class TestApplication(testlib.MachineCase):
         b.click("#containers-containers-create-container-btn")
         b.set_input_text("#create-image-image-select-typeahead", "registry")
         b.wait_visible('button.pf-v5-c-select__menu-item:contains("registry")')
+        self.confirm_modal("Cancel")
 
     def testBasicUser(self):
         self._testBasic(False)

--- a/test/check-application
+++ b/test/check-application
@@ -268,6 +268,18 @@ class TestApplication(testlib.MachineCase):
             self.fail("Timed out waiting for StartedAt change")
             return ''  # quiesce mypy, not reached
 
+    def setupRegistry(self):
+        m = self.machine
+
+        self.execute(True, f"""
+            podman run -d -p 5000:5000 --name registry --stop-timeout 0 {IMG_REGISTRY}
+            podman run -d -p 6000:5000 --name registry_alt --stop-timeout 0 {IMG_REGISTRY}
+        """)
+
+        # Add local insecure registry into registries conf
+        m.write("/etc/containers/registries.conf", REGISTRIES_CONF)
+        self.execute(True, "systemctl stop podman.service")
+
     def testPods(self):
         b = self.browser
 
@@ -1184,6 +1196,105 @@ class TestApplication(testlib.MachineCase):
               .selectImageAndDownload() \
               .expectDownloadErrorForNonExistingTag()
 
+    def testPullImage(self):
+        b = self.browser
+        m = self.machine
+
+        self.setupRegistry()
+
+        def buildImage(auth, size, image_name):
+            temp_dir = self.machine.execute(f"""
+                set -eu
+                D=$(mktemp -d -p {self.vm_tmpdir})
+                # Allow admin to read the created directory, mktemp by default creates it unreadable for other users
+                chmod 755 $D
+                truncate -s {size}M $D/test.img
+                printf 'FROM scratch\\nCOPY test.img /\\n' > $D/Containerfile
+                echo $D
+            """).strip()
+            self.execute(auth, f"podman build -t {image_name} {temp_dir}")
+
+        def getImageSize(image_name):
+            return float(b.text(f"tr:contains('{image_name}') td[data-label='Disk space']").replace(' MB', ''))
+
+        image1 = "localhost:5000/test-image:1"
+
+        # build update and push it
+        buildImage(True, 50, image1)
+        self.execute(True, f"podman push {image1}; podman rmi {image1}")
+
+        # build image which we try to pull
+        buildImage(True, 1, image1)
+        image1_sha = self.execute(True, f"podman inspect --format '{{{{.Id}}}}' {image1}").strip()
+
+        self.login()
+
+        image1_sel = f"#containers-images tbody tr[data-row-id=\"{image1_sha}true\"]".lower()
+
+        b.click("#containers-images button.pf-v5-c-expandable-section__toggle")
+        b.click(f'{image1_sel} .pf-v5-c-menu-toggle')
+        b.click(image1_sel + " button.pf-v5-c-menu__item:contains('Pull')")
+        b.wait_in_text("div.download-in-progress", "Pulling")
+        b.wait_not_present(image1_sel)
+
+        # assert that the new image is bigger, the initial image as 1MB, the
+        # new one 50MB.
+        b.wait(lambda: getImageSize(image1) > 40)
+
+        image1_update_sha = self.execute(True, f"podman inspect --format '{{{{.Id}}}}' {image1}").strip()
+        self.assertNotEqual(image1_sha, image1_update_sha)
+        b.wait_visible(f"#containers-images tbody tr[data-row-id=\"{image1_update_sha}true\"]".lower())
+
+        # Try to pull multiple images, drop to superuser as its easier to
+        # remove all images and pulling all images will show an error if the
+        # registry is not available.
+        b.drop_superuser()
+
+        image1 = "localhost:5000/test-image:1"
+
+        # build update and push it
+        buildImage(False, 25, image1)
+        self.execute(False, f"podman push {image1}; podman rmi {image1}")
+
+        # build image which we try to pull
+        buildImage(False, 1, image1)
+        image1_sha = self.execute(False, f"podman inspect --format '{{{{.Id}}}}' {image1}").strip()
+
+        image2 = "localhost:5000/test-image:2"
+
+        # build update and push it
+        buildImage(False, 50, image2)
+        self.execute(False, f"podman push {image2}; podman rmi {image2}")
+
+        # build image which we try to pull
+        buildImage(False, 10, image2)
+        image2_sha = self.execute(False, f"podman inspect --format '{{{{.Id}}}}' {image2}").strip()
+
+        self.execute(False, """
+            podman rmi localhost/test-busybox:latest
+            podman rmi localhost/test-alpine:latest
+
+            # Remove registry container
+            podman rmi localhost/test-registry:latest
+        """)
+
+        # Ubuntu has an old podman which ships with a k8s image
+        if m.image == "ubuntu-2204":
+            self.execute(False, "podman rmi k8s.gcr.io/pause:3.5")
+
+        b.wait_in_text("#containers-images", "2 images")
+        b.click("#image-actions-dropdown")
+        b.click("button:contains(Pull all images)")
+        b.wait_in_text("div.download-in-progress", "Pulling")
+        b.wait_not_present('h4.pf-v5-c-alert__title:contains("Failed to download image")')
+        b.wait_not_present("div.download-in-progress")
+        b.wait_not_present(f"#containers-images tbody tr[data-row-id=\"{image1_sha}false\"]".lower())
+        b.wait_not_present(f"#containers-images tbody tr[data-row-id=\"{image2_sha}false\"]".lower())
+
+        # assert the image size changed
+        b.wait(lambda: getImageSize(image1) > 20)
+        b.wait(lambda: getImageSize(image2) > 40)
+
     def testLifecycleOperationsUser(self):
         self._testLifecycleOperations(False)
 
@@ -1585,11 +1696,8 @@ class TestApplication(testlib.MachineCase):
         self.execute(True, f"podman commit {new_container} newimage")
         new_image_sha = self.execute(True, "podman inspect --format '{{.Id}}' newimage").strip()
 
-        self.execute(True, f"podman run -d -p 5000:5000 --name registry --stop-timeout 0 {IMG_REGISTRY}")
-        self.execute(True, f"podman run -d -p 6000:5000 --name registry_alt --stop-timeout 0 {IMG_REGISTRY}")
-        # Add local insecure registry into registries conf
-        self.machine.write("/etc/containers/registries.conf", REGISTRIES_CONF)
-        self.execute(True, "systemctl stop podman.service")
+        self.setupRegistry()
+
         # Push busybox image to the local registries
         self.execute(True,
                      f"podman tag {IMG_BUSYBOX} localhost:5000/my-busybox; podman push localhost:5000/my-busybox")


### PR DESCRIPTION
This PR implements a 'Pull' option for existing images. This action is added in the dropdown menu for an image. In addition to this, it includes a 'Pull all images' option at the top level to pull all images in storage. The goal is to easily allow updating containers when using tags like 'latest' or a just major version number.

The implementation makes use of the existing downloadImage function that is used when downloading a new image. It was slightly modified to support multiple images being downloaded simultaneously.

I'm not familiar with the localization mechanism used in Cockpit, but in line with other strings I wrapped the labels in `_("Label")`. Upon changing the display language this (somewhat obviously) didn't automatically work, so translations will need to be added.

---
# Podman: Add image pull action

The new `Pull` option in the image context menu updates the existing image to the latest version on its registry.

![image](https://github.com/cockpit-project/cockpit-podman/assets/67428/adea36d3-de36-4d8e-ab52-8845b0d11f2e)
