### PR TITLE
packit: Enable centos-stream-10

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -25,6 +25,7 @@ jobs:
     - fedora-development
     - centos-stream-9-x86_64
     - centos-stream-9-aarch64
+    - centos-stream-10
 
   - job: tests
     trigger: pull_request
@@ -35,6 +36,7 @@ jobs:
       - fedora-development
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
+      - centos-stream-10
 
   - job: copr_build
     trigger: release

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -4,8 +4,6 @@ require:
   - cockpit-ws
   - cockpit-system
   - criu
-  # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=2269485
-  - slirp4netns
 duration: 30m
 
 /system:


### PR DESCRIPTION
https://issues.redhat.com/browse/RHEL-34650 finally got fixed, so podman works in CentOS/RHEL 10 now.