### PR TITLE
po: Don't mark JavaScript strings as c-format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,13 +70,14 @@ $(COCKPIT_REPO_STAMP): Makefile
 LINGUAS=$(basename $(notdir $(wildcard po/*.po)))
 
 po/$(PACKAGE_NAME).js.pot:
-	xgettext --default-domain=$(PACKAGE_NAME) --output=$@ --language=C --keyword= \
+	xgettext --default-domain=$(PACKAGE_NAME) --output=- --language=C --keyword= \
 		--keyword=_:1,1t --keyword=_:1c,2,2t --keyword=C_:1c,2 \
 		--keyword=N_ --keyword=NC_:1c,2 \
 		--keyword=gettext:1,1t --keyword=gettext:1c,2,2t \
 		--keyword=ngettext:1,2,3t --keyword=ngettext:1c,2,3,4t \
 		--keyword=gettextCatalog.getString:1,3c --keyword=gettextCatalog.getPlural:2,3,4c \
-		--from-code=UTF-8 $$(find src/ -name '*.[jt]s' -o -name '*.[jt]sx')
+		--from-code=UTF-8 $$(find src/ -name '*.[jt]s' -o -name '*.[jt]sx') | \
+		sed '/^#/ s/, c-format//' > $@
 
 po/$(PACKAGE_NAME).html.pot: $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP)
 	pkg/lib/html2po.js -o $@ $$(find src -name '*.html')


### PR DESCRIPTION
We don't use printf-style C format macros like "%s" in the JavaScript code, at least not for translations. But xgettext interprets the "$0% Free" in pkg/kubernetes/scripts/nodes.js as C format string, which confuses translation tools and blocks the proper translation of this string.

As there doesn't seem to be a way to change the `--keyword=ngettext` argument to do that, just filter out the `c-format` tag with sed.

Taken from https://github.com/cockpit-project/cockpit/commit/449d76c0e6d9

Fixes #1712

----

Tested with `make po/podman.pot`. diff:

```diff
--- /tmp/podman.pot.orig	2024-06-21 14:39:15.548457329 +0200
+++ po/podman.pot	2024-06-21 14:39:35.140548117 +0200
@@ -73,8 +73,8 @@
 msgstr[0] ""
 msgstr[1] ""
 
+#
 #: src/Containers.jsx:379
-#, c-format
 msgid "$0% of $1 limit"
 msgstr ""
```