### PR TITLE
test: Drop dummy interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,6 @@ TAR_ARGS = --sort=name --mtime "@$(shell git show --no-patch --format='%at')" --
 
 VM_CUSTOMIZE_FLAGS =
 
-# HACK: https://github.com/containers/podman/issues/21896 and https://bugzilla.redhat.com/show_bug.cgi?id=2277954
-VM_CUSTOMIZE_FLAGS += --run-command 'nmcli con add type dummy con-name fake ifname fake0 ip4 1.2.3.4/24 gw4 1.2.3.1 >&2'
-
 # the following scenarios need network access
 ifeq ("$(TEST_SCENARIO)","updates-testing")
 VM_CUSTOMIZE_FLAGS += --run-command 'dnf -y update --setopt=install_weak_deps=False --enablerepo=updates-testing >&2'


### PR DESCRIPTION
passt got fixed in [1] to get along with multiple network interfaces and no default routes.

[1] https://bodhi.fedoraproject.org/updates/FEDORA-2024-4632bfa865
[2] https://bugzilla.redhat.com/show_bug.cgi?id=2277954

----

This should only work in updates-testing scenario today. This will take some time to propagate to Fedora, CentOS 10 etc., and there's no hurry to land this -- I mostly just want to validate the bodhi update. [Last night's run](https://cockpit-logs.us-east-1.linodeobjects.com/pull-0-c775d715-20240626-015919-fedora-40-updates-testing/log.html) was against that version and passed, now let's try this without the hack.