### PR TITLE
Handle cases where the image provides no env

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -112,7 +112,7 @@ function parseImageInfo(info) {
         image.Entrypoint = info.Config.Entrypoint;
         image.Command = info.Config.Cmd;
         image.Ports = Object.keys(info.Config.ExposedPorts || {});
-        image.Env = info.Config.Env;
+        image.Env = info.Config.Env || [];
     }
     image.Author = info.Author;
 


### PR DESCRIPTION
Hey! If a container provided no environment variables itself it would crash the frontend of cockpit whenever you clicked into the integrations tab on the running container. Podman's api wasn't providing config.env in these cases which led to it being undefined, this is just a small change to make sure it's always set to an array