### PR TITLE
Adjust to current Cockpit timeformat API, drop date-fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@patternfly/react-styles": "5.3.1",
     "@patternfly/react-table": "5.3.3",
     "@patternfly/react-tokens": "5.3.1",
-    "date-fns": "3.6.0",
     "docker-names": "1.2.1",
     "ipaddr.js": "2.2.0",
     "prop-types": "15.8.1",

--- a/src/util.js
+++ b/src/util.js
@@ -45,7 +45,7 @@ export const RelativeTime = ({ time }) => {
     if (!time)
         return null;
     const timestamp = typeof time === "string" ? Date.parse(time) : time;
-    const dateRel = timeformat.distanceToNow(timestamp, true);
+    const dateRel = timeformat.distanceToNow(timestamp);
     const dateAbs = timeformat.dateTimeSeconds(timestamp);
     return <Tooltip content={dateAbs}><span>{dateRel}</span></Tooltip>;
 };


### PR DESCRIPTION
Latest cockpit lib moved `timeformata.distanceToNow()` away from date-fns. Drop the obsolete `addSuffix` argument, and drop the now unused date-fns npm dependency.


- [x] #1784