### PR TITLE
eslint: configure import sorting rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,16 @@
                 "MemberExpression": 2,
                 "ignoredNodes": [ "JSXAttribute" ]
             }],
+        "import/order": ["error",
+            {
+                "alphabetize": { "order": "asc" },
+                "groups": ["builtin", "external", "internal", "parent", "sibling"],
+                "newlines-between": "always",
+                "pathGroupsExcludedImportTypes": ["react"],
+                "pathGroups": [
+                    { "pattern": "react", "group": "builtin", "position": "before" }
+                ]
+            }],
         "newline-per-chained-call": ["error", { "ignoreChainWithDepth": 2 }],
         "no-var": "error",
         "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
@@ -51,5 +61,10 @@
     "globals": {
         "require": "readonly",
         "module": "readonly"
+    },
+    "settings": {
+        "import/resolver": {
+            "node": { "moduleDirectory": [ "pkg/lib" ], "extensions": [ ".js", ".jsx", ".ts", ".tsx" ] }
+        }
     }
 }

--- a/build.js
+++ b/build.js
@@ -5,11 +5,11 @@ import os from 'node:os';
 
 import copy from 'esbuild-plugin-copy';
 
-import { cockpitCompressPlugin } from './pkg/lib/esbuild-compress-plugin.js';
 import { cockpitPoEsbuildPlugin } from './pkg/lib/cockpit-po-plugin.js';
 import { cockpitRsyncEsbuildPlugin } from './pkg/lib/cockpit-rsync-plugin.js';
 import { cleanPlugin } from './pkg/lib/esbuild-cleanup-plugin.js';
 import { esbuildStylesPlugins } from './pkg/lib/esbuild-common.js';
+import { cockpitCompressPlugin } from './pkg/lib/esbuild-compress-plugin.js';
 
 const useWasm = os.arch() !== 'x64';
 const esbuild = (await import(useWasm ? 'esbuild-wasm' : 'esbuild'));

--- a/src/ContainerCheckpointModal.jsx
+++ b/src/ContainerCheckpointModal.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
+
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
 import { Form } from "@patternfly/react-core/dist/esm/components/Form";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { useDialogs } from "dialogs.jsx";
+
 import cockpit from 'cockpit';
 
 import * as client from './client.js';

--- a/src/ContainerCommitModal.jsx
+++ b/src/ContainerCommitModal.jsx
@@ -1,17 +1,19 @@
 import React, { useState } from 'react';
+
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
+import { FormHelper } from 'cockpit-components-form-helper.jsx';
+import { useDialogs } from "dialogs.jsx";
+import { fmt_to_fragments } from 'utils.jsx';
+
 import cockpit from 'cockpit';
 
-import { FormHelper } from 'cockpit-components-form-helper.jsx';
-import * as utils from './util.js';
-import * as client from './client.js';
 import { ErrorNotification } from './Notification.jsx';
-import { fmt_to_fragments } from 'utils.jsx';
-import { useDialogs } from "dialogs.jsx";
+import * as client from './client.js';
+import * as utils from './util.js';
 
 const _ = cockpit.gettext;
 

--- a/src/ContainerDeleteModal.jsx
+++ b/src/ContainerDeleteModal.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
+
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { useDialogs } from "dialogs.jsx";
+
 import cockpit from 'cockpit';
 
 import * as client from './client.js';

--- a/src/ContainerDetails.jsx
+++ b/src/ContainerDetails.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import cockpit from 'cockpit';
-import * as utils from './util.js';
 
 import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from "@patternfly/react-core/dist/esm/components/DescriptionList";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
+
+import cockpit from 'cockpit';
+
+import * as utils from './util.js';
 
 const _ = cockpit.gettext;
 

--- a/src/ContainerHeader.jsx
+++ b/src/ContainerHeader.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import cockpit from 'cockpit';
+
 import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core/dist/esm/components/Toolbar";
+
+import cockpit from 'cockpit';
 const _ = cockpit.gettext;
 
 const ContainerHeader = ({ user, twoOwners, ownerFilter, handleOwnerChanged, textFilter, handleFilterChanged }) => {

--- a/src/ContainerHealthLogs.jsx
+++ b/src/ContainerHealthLogs.jsx
@@ -18,15 +18,17 @@
  */
 
 import React from 'react';
-import cockpit from 'cockpit';
-import * as utils from './util.js';
-import * as client from './client.js';
 
-import { ListingTable } from "cockpit-components-table.jsx";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from "@patternfly/react-core/dist/esm/components/DescriptionList";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
 import { CheckCircleIcon, ErrorCircleOIcon } from "@patternfly/react-icons";
+
+import cockpit from 'cockpit';
+import { ListingTable } from "cockpit-components-table.jsx";
+
+import * as client from './client.js';
+import * as utils from './util.js';
 
 const _ = cockpit.gettext;
 

--- a/src/ContainerIntegration.jsx
+++ b/src/ContainerIntegration.jsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
-import cockpit from 'cockpit';
 
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from "@patternfly/react-core/dist/esm/components/DescriptionList";
 import { List, ListItem } from "@patternfly/react-core/dist/esm/components/List";
 import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip";
 
+import cockpit from 'cockpit';
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
 const _ = cockpit.gettext;

--- a/src/ContainerLogs.jsx
+++ b/src/ContainerLogs.jsx
@@ -18,15 +18,17 @@
  */
 
 import React from 'react';
+
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
 import { Terminal } from "xterm";
 import { CanvasAddon } from 'xterm-addon-canvas';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import cockpit from 'cockpit';
-import rest from './rest.js';
-import * as client from './client.js';
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
+
+import * as client from './client.js';
+import rest from './rest.js';
 
 import "./ContainerTerminal.css";
 

--- a/src/ContainerRenameModal.jsx
+++ b/src/ContainerRenameModal.jsx
@@ -1,15 +1,17 @@
 import React, { useState } from 'react';
+
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
+import { FormHelper } from 'cockpit-components-form-helper.jsx';
+import { useDialogs } from "dialogs.jsx";
+
 import cockpit from 'cockpit';
 
+import { ErrorNotification } from './Notification.jsx';
 import * as client from './client.js';
 import * as utils from './util.js';
-import { ErrorNotification } from './Notification.jsx';
-import { useDialogs } from "dialogs.jsx";
-import { FormHelper } from 'cockpit-components-form-helper.jsx';
 
 const _ = cockpit.gettext;
 

--- a/src/ContainerRestoreModal.jsx
+++ b/src/ContainerRestoreModal.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
+
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
 import { Form } from "@patternfly/react-core/dist/esm/components/Form";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { useDialogs } from "dialogs.jsx";
+
 import cockpit from 'cockpit';
 
 import * as client from './client.js';

--- a/src/ContainerTerminal.jsx
+++ b/src/ContainerTerminal.jsx
@@ -18,14 +18,16 @@
  */
 
 import React from 'react';
+
 import PropTypes from 'prop-types';
-import cockpit from 'cockpit';
 import { Terminal } from "xterm";
 import { CanvasAddon } from 'xterm-addon-canvas';
-import { ErrorNotification } from './Notification.jsx';
 
-import * as client from './client.js';
+import cockpit from 'cockpit';
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
+
+import { ErrorNotification } from './Notification.jsx';
+import * as client from './client.js';
 
 import "./ContainerTerminal.css";
 

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -1,46 +1,47 @@
 import React from 'react';
+
 import { Badge } from "@patternfly/react-core/dist/esm/components/Badge";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Card, CardBody, CardHeader, CardTitle } from "@patternfly/react-core/dist/esm/components/Card";
 import { Divider } from "@patternfly/react-core/dist/esm/components/Divider";
 import { DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown/index.js';
-import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex";
-import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
-import { LabelGroup } from "@patternfly/react-core/dist/esm/components/Label";
-import { Text, TextVariants } from "@patternfly/react-core/dist/esm/components/Text";
 import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
-import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip";
+import { LabelGroup } from "@patternfly/react-core/dist/esm/components/Label";
+import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
+import { Text, TextVariants } from "@patternfly/react-core/dist/esm/components/Text";
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core/dist/esm/components/Toolbar";
-import { cellWidth, SortByDirection } from '@patternfly/react-table';
+import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip";
+import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex";
 import { MicrochipIcon, MemoryIcon, PortIcon, VolumeIcon, } from '@patternfly/react-icons';
+import { cellWidth, SortByDirection } from '@patternfly/react-table';
+import { KebabDropdown } from "cockpit-components-dropdown.jsx";
+import { useDialogs, DialogsContext } from "dialogs.jsx";
 
 import cockpit from 'cockpit';
-import { ListingTable } from "cockpit-components-table.jsx";
 import { ListingPanel } from 'cockpit-components-listing-panel.jsx';
-import ContainerDetails from './ContainerDetails.jsx';
-import ContainerIntegration, { renderContainerPublishedPorts, renderContainerVolumes } from './ContainerIntegration.jsx';
-import ContainerTerminal from './ContainerTerminal.jsx';
-import ContainerLogs from './ContainerLogs.jsx';
-import ContainerHealthLogs from './ContainerHealthLogs.jsx';
-import ContainerDeleteModal from './ContainerDeleteModal.jsx';
-import ContainerCheckpointModal from './ContainerCheckpointModal.jsx';
-import ContainerRestoreModal from './ContainerRestoreModal.jsx';
-import ForceRemoveModal from './ForceRemoveModal.jsx';
-import * as utils from './util.js';
-import * as client from './client.js';
-import ContainerCommitModal from './ContainerCommitModal.jsx';
-import ContainerRenameModal from './ContainerRenameModal.jsx';
-import { useDialogs, DialogsContext } from "dialogs.jsx";
+import { ListingTable } from "cockpit-components-table.jsx";
 import * as machine_info from 'machine-info.js';
 
-import './Containers.scss';
-import '@patternfly/patternfly/utilities/Accessibility/accessibility.css';
+import ContainerCheckpointModal from './ContainerCheckpointModal.jsx';
+import ContainerCommitModal from './ContainerCommitModal.jsx';
+import ContainerDeleteModal from './ContainerDeleteModal.jsx';
+import ContainerDetails from './ContainerDetails.jsx';
+import ContainerHealthLogs from './ContainerHealthLogs.jsx';
+import ContainerIntegration, { renderContainerPublishedPorts, renderContainerVolumes } from './ContainerIntegration.jsx';
+import ContainerLogs from './ContainerLogs.jsx';
+import ContainerRenameModal from './ContainerRenameModal.jsx';
+import ContainerRestoreModal from './ContainerRestoreModal.jsx';
+import ContainerTerminal from './ContainerTerminal.jsx';
+import ForceRemoveModal from './ForceRemoveModal.jsx';
 import { ImageRunModal } from './ImageRunModal.jsx';
 import { PodActions } from './PodActions.jsx';
 import { PodCreateModal } from './PodCreateModal.jsx';
 import PruneUnusedContainersModal from './PruneUnusedContainersModal.jsx';
+import * as client from './client.js';
+import * as utils from './util.js';
 
-import { KebabDropdown } from "cockpit-components-dropdown.jsx";
+import './Containers.scss';
+import '@patternfly/patternfly/utilities/Accessibility/accessibility.css';
 
 const _ = cockpit.gettext;
 

--- a/src/Env.jsx
+++ b/src/Env.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
+
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
-import { FormHelper } from "cockpit-components-form-helper.jsx";
-import { Grid } from "@patternfly/react-core/dist/esm/layouts/Grid";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
+import { Grid } from "@patternfly/react-core/dist/esm/layouts/Grid";
 import { TrashIcon } from '@patternfly/react-icons';
+import { FormHelper } from "cockpit-components-form-helper.jsx";
+
 import cockpit from 'cockpit';
 
 import * as utils from './util.js';

--- a/src/ForceRemoveModal.jsx
+++ b/src/ForceRemoveModal.jsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
+
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { useDialogs } from "dialogs.jsx";
+
 import cockpit from 'cockpit';
 
 const _ = cockpit.gettext;

--- a/src/ImageDeleteModal.jsx
+++ b/src/ImageDeleteModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
 import { List, ListItem } from '@patternfly/react-core/dist/esm/components/List';

--- a/src/ImageDetails.jsx
+++ b/src/ImageDetails.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import cockpit from 'cockpit';
-import * as utils from './util.js';
 
 import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from "@patternfly/react-core/dist/esm/components/DescriptionList";
 
+import cockpit from 'cockpit';
+
 import ImageUsedBy from './ImageUsedBy.jsx';
+import * as utils from './util.js';
+
 const _ = cockpit.gettext;
 
 const ImageDetails = ({ containers, image, showAll }) => {

--- a/src/ImageHistory.jsx
+++ b/src/ImageHistory.jsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import cockpit from 'cockpit';
-import * as utils from './util.js';
-import * as client from './client.js';
 
+import cockpit from 'cockpit';
 import { ListingTable } from "cockpit-components-table.jsx";
+
+import * as client from './client.js';
+import * as utils from './util.js';
 
 const _ = cockpit.gettext;
 

--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -1,36 +1,37 @@
 import React from 'react';
+
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
-import { FormHelper } from "cockpit-components-form-helper.jsx";
 import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
-import { Grid, GridItem } from "@patternfly/react-core/dist/esm/layouts/Grid";
-import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
-import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
-import { Select, SelectGroup, SelectOption, SelectVariant } from "@patternfly/react-core/dist/esm/deprecated/components/Select";
-import { NumberInput } from "@patternfly/react-core/dist/esm/components/NumberInput";
 import { InputGroup, InputGroupText } from "@patternfly/react-core/dist/esm/components/InputGroup";
-import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
+import { NumberInput } from "@patternfly/react-core/dist/esm/components/NumberInput";
+import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
+import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
 import { Tab, TabTitleText, Tabs } from "@patternfly/react-core/dist/esm/components/Tabs";
 import { Text, TextContent, TextList, TextListItem, TextVariants } from "@patternfly/react-core/dist/esm/components/Text";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import { ToggleGroup, ToggleGroupItem } from "@patternfly/react-core/dist/esm/components/ToggleGroup";
+import { Select, SelectGroup, SelectOption, SelectVariant } from "@patternfly/react-core/dist/esm/deprecated/components/Select";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
-import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
+import { Grid, GridItem } from "@patternfly/react-core/dist/esm/layouts/Grid";
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { FormHelper } from "cockpit-components-form-helper.jsx";
 import * as dockerNames from 'docker-names';
+import { debounce } from 'throttle-debounce';
 
+import cockpit from 'cockpit';
+import { DynamicListForm } from 'cockpit-components-dynamic-list.jsx';
+
+import { onDownloadContainer, onDownloadContainerFinished } from './Containers.jsx';
+import { EnvVar, validateEnvVar } from './Env.jsx';
 import { ErrorNotification } from './Notification.jsx';
-import * as utils from './util.js';
+import { PublishPort, validatePublishPort } from './PublishPort.jsx';
+import { validateVolume, Volume } from './Volume.jsx';
 import * as client from './client.js';
 import rest from './rest.js';
-import cockpit from 'cockpit';
-import { onDownloadContainer, onDownloadContainerFinished } from './Containers.jsx';
-import { PublishPort, validatePublishPort } from './PublishPort.jsx';
-import { DynamicListForm } from 'cockpit-components-dynamic-list.jsx';
-import { validateVolume, Volume } from './Volume.jsx';
-import { EnvVar, validateEnvVar } from './Env.jsx';
-
-import { debounce } from 'throttle-debounce';
+import * as utils from './util.js';
 
 import "./ImageRunModal.scss";
 

--- a/src/ImageSearchModal.jsx
+++ b/src/ImageSearchModal.jsx
@@ -1,21 +1,23 @@
 import React, { useState } from 'react';
+
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { DataList, DataListCell, DataListItem, DataListItemCells, DataListItemRow } from "@patternfly/react-core/dist/esm/components/DataList";
-import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex";
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
 import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
+import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex";
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-
-import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
-import { ErrorNotification } from './Notification.jsx';
-import cockpit from 'cockpit';
-import rest from './rest.js';
-import * as client from './client.js';
-import { fallbackRegistries, usePodmanInfo } from './util.js';
 import { useDialogs } from "dialogs.jsx";
+
+import cockpit from 'cockpit';
+import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
+
+import { ErrorNotification } from './Notification.jsx';
+import * as client from './client.js';
+import rest from './rest.js';
+import { fallbackRegistries, usePodmanInfo } from './util.js';
 
 import './ImageSearchModal.css';
 

--- a/src/ImageUsedBy.jsx
+++ b/src/ImageUsedBy.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import cockpit from 'cockpit';
-import { Button } from "@patternfly/react-core/dist/esm/components/Button";
+
 import { Badge } from "@patternfly/react-core/dist/esm/components/Badge";
-import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex";
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { List, ListItem } from "@patternfly/react-core/dist/esm/components/List";
+import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex";
+
+import cockpit from 'cockpit';
 
 const _ = cockpit.gettext;
 

--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -1,29 +1,30 @@
 import React from 'react';
+
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Card, CardBody, CardFooter, CardHeader, CardTitle } from "@patternfly/react-core/dist/esm/components/Card";
 import { DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown/index.js';
-import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
 import { ExpandableSection } from "@patternfly/react-core/dist/esm/components/ExpandableSection";
 import { Text, TextVariants } from "@patternfly/react-core/dist/esm/components/Text";
+import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
 import { cellWidth } from '@patternfly/react-table';
+import { KebabDropdown } from "cockpit-components-dropdown.jsx";
+import { useDialogs, DialogsContext } from "dialogs.jsx";
 
 import cockpit from 'cockpit';
-import { ListingTable } from "cockpit-components-table.jsx";
 import { ListingPanel } from 'cockpit-components-listing-panel.jsx';
+import { ListingTable } from "cockpit-components-table.jsx";
+
+import { ImageDeleteModal } from './ImageDeleteModal.jsx';
 import ImageDetails from './ImageDetails.jsx';
 import ImageHistory from './ImageHistory.jsx';
 import { ImageRunModal } from './ImageRunModal.jsx';
 import { ImageSearchModal } from './ImageSearchModal.jsx';
-import { ImageDeleteModal } from './ImageDeleteModal.jsx';
 import PruneUnusedImagesModal from './PruneUnusedImagesModal.jsx';
 import * as client from './client.js';
 import * as utils from './util.js';
-import { useDialogs, DialogsContext } from "dialogs.jsx";
 
 import './Images.css';
 import '@patternfly/react-styles/css/utilities/Sizing/sizing.css';
-
-import { KebabDropdown } from "cockpit-components-dropdown.jsx";
 
 const _ = cockpit.gettext;
 

--- a/src/Notification.jsx
+++ b/src/Notification.jsx
@@ -17,6 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 import React from 'react';
+
 import { Alert, AlertActionCloseButton } from "@patternfly/react-core/dist/esm/components/Alert";
 
 import cockpit from 'cockpit';

--- a/src/PodActions.jsx
+++ b/src/PodActions.jsx
@@ -1,16 +1,16 @@
 import React, { useState } from 'react';
 
-import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Alert } from "@patternfly/react-core/dist/esm/components/Alert";
-import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Divider } from '@patternfly/react-core/dist/esm/components/Divider/index.js';
 import { DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown/index.js';
 import { List, ListItem } from "@patternfly/react-core/dist/esm/components/List";
+import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { Stack } from "@patternfly/react-core/dist/esm/layouts/Stack";
+import { KebabDropdown } from "cockpit-components-dropdown.jsx";
+import { useDialogs } from "dialogs.jsx";
 
 import cockpit from 'cockpit';
-import { useDialogs } from "dialogs.jsx";
-import { KebabDropdown } from "cockpit-components-dropdown.jsx";
 
 import * as client from './client.js';
 

--- a/src/PodCreateModal.jsx
+++ b/src/PodCreateModal.jsx
@@ -1,20 +1,22 @@
 import React, { useState } from 'react';
+
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { Radio } from "@patternfly/react-core/dist/esm/components/Radio";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
+import { FormHelper } from 'cockpit-components-form-helper.jsx';
+import { useDialogs } from "dialogs.jsx";
 import * as dockerNames from 'docker-names';
 
-import { FormHelper } from 'cockpit-components-form-helper.jsx';
+import cockpit from 'cockpit';
 import { DynamicListForm } from 'cockpit-components-dynamic-list.jsx';
+
 import { ErrorNotification } from './Notification.jsx';
 import { PublishPort, validatePublishPort } from './PublishPort.jsx';
 import { Volume } from './Volume.jsx';
 import * as client from './client.js';
 import * as utils from './util.js';
-import cockpit from 'cockpit';
-import { useDialogs } from "dialogs.jsx";
 
 const _ = cockpit.gettext;
 

--- a/src/PruneUnusedContainersModal.jsx
+++ b/src/PruneUnusedContainersModal.jsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
+
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
 import { SortByDirection } from "@patternfly/react-table";
+
 import cockpit from 'cockpit';
 import { ListingTable } from 'cockpit-components-table.jsx';
 

--- a/src/PruneUnusedImagesModal.jsx
+++ b/src/PruneUnusedImagesModal.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
+
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
-import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex";
 import { List, ListItem } from "@patternfly/react-core/dist/esm/components/List";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal";
+import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex";
+
 import cockpit from 'cockpit';
 
 import * as client from './client.js';

--- a/src/PublishPort.jsx
+++ b/src/PublishPort.jsx
@@ -3,14 +3,15 @@ import React from 'react';
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
 import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
-import { Grid } from "@patternfly/react-core/dist/esm/layouts/Grid";
-import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
+import { Grid } from "@patternfly/react-core/dist/esm/layouts/Grid";
 import { OutlinedQuestionCircleIcon, TrashIcon } from '@patternfly/react-icons';
-import cockpit from 'cockpit';
+import { FormHelper } from "cockpit-components-form-helper.jsx";
 import ipaddr from "ipaddr.js";
 
-import { FormHelper } from "cockpit-components-form-helper.jsx";
+import cockpit from 'cockpit';
+
 import * as utils from './util.js';
 
 const _ = cockpit.gettext;

--- a/src/Volume.jsx
+++ b/src/Volume.jsx
@@ -1,14 +1,16 @@
 import React from 'react';
+
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
 import { FormGroup } from "@patternfly/react-core/dist/esm/components/Form";
-import { FormHelper } from "cockpit-components-form-helper.jsx";
 import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
-import { Grid } from "@patternfly/react-core/dist/esm/layouts/Grid";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput";
+import { Grid } from "@patternfly/react-core/dist/esm/layouts/Grid";
 import { TrashIcon } from '@patternfly/react-icons';
-import { FileAutoComplete } from 'cockpit-components-file-autocomplete.jsx';
+import { FormHelper } from "cockpit-components-form-helper.jsx";
+
 import cockpit from 'cockpit';
+import { FileAutoComplete } from 'cockpit-components-file-autocomplete.jsx';
 
 import * as utils from './util.js';
 

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -18,17 +18,19 @@
  */
 
 import React from 'react';
-import { Page, PageSection, PageSectionVariants } from "@patternfly/react-core/dist/esm/components/Page";
+
 import { Alert, AlertActionCloseButton, AlertActionLink, AlertGroup } from "@patternfly/react-core/dist/esm/components/Alert";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox";
 import { EmptyState, EmptyStateHeader, EmptyStateFooter, EmptyStateIcon, EmptyStateActions, EmptyStateVariant } from "@patternfly/react-core/dist/esm/components/EmptyState";
+import { Page, PageSection, PageSectionVariants } from "@patternfly/react-core/dist/esm/components/Page";
 import { Stack } from "@patternfly/react-core/dist/esm/layouts/Stack";
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { WithDialogs } from "dialogs.jsx";
 
 import cockpit from 'cockpit';
 import { superuser } from "superuser";
+
 import ContainerHeader from './ContainerHeader.jsx';
 import Containers from './Containers.jsx';
 import Images from './Images.jsx';

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,9 @@
 
 import "cockpit-dark-theme";
 import React from 'react';
+
 import { createRoot } from 'react-dom/client';
+
 import 'patternfly/patternfly-5-cockpit.scss';
 import Application from './app.jsx';
 import './podman.scss';

--- a/src/rest.js
+++ b/src/rest.js
@@ -1,4 +1,5 @@
 import cockpit from "cockpit";
+
 import { debug } from "./util.js";
 
 function manage_error(reject, error, content) {

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 
-import { debounce } from 'throttle-debounce';
 import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip";
+import { debounce } from 'throttle-debounce';
 
 import cockpit from 'cockpit';
 import * as timeformat from 'timeformat';


### PR DESCRIPTION
This more or less enforces existing practice, but cleans up many places where we've deviated from that.  We sort into these groups:

- 'react', if present, always first
- external (`node_modules/`) imports
- cockpitlib (`pkg/lib/`) imports
- parent (`../`) imports
- sibling (`./`) imports

---

This is taken from cockpit-files except the restriction on extensions, as we don't have Typescript here, this likely will flake a bunch but lets hope it won't :crossed_fingers: 