### PR TITLE
build: don't rely on implicitly imported process

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,6 +2,7 @@
 
 import fs from 'node:fs';
 import os from 'node:os';
+import process from 'node:process';
 
 import copy from 'esbuild-plugin-copy';
 


### PR DESCRIPTION
This only works on nodejs and not on alternative implementations.