### PR TITLE
Fix searching containers with full URL

### DIFF
--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -516,7 +516,7 @@ export class ImageRunModal extends React.Component {
         }
 
         // Strip out all non-allowed container image characters when filtering.
-        let regexString = searchText.replace(/[^\w_.:-]/g, "");
+        let regexString = searchText.replace(/[^/\w_.:-]/g, "");
         // Strip image registry option if set for comparing results for docker.io searching for docker.io/fedora
         // returns docker.io/$username/fedora for example.
         if (regexString.includes('/')) {

--- a/test/check-application
+++ b/test/check-application
@@ -1767,7 +1767,10 @@ class TestApplication(testlib.MachineCase):
         b.set_input_text("#run-image-dialog-name", container_name)
 
         # Local registry
-        b.set_input_text("#create-image-image-select-typeahead", "my-busybox")
+        b.set_input_text("#create-image-image-select-typeahead", "no-container")
+        b.wait_text("button.pf-v5-c-select__menu-item.pf-m-disabled", "No images found")
+        # Search with full url
+        b.set_input_text("#create-image-image-select-typeahead", "localhost:5000/my-busybox")
         b.click('button.pf-v5-c-toggle-group__button:contains("Local")')
 
         # Select image


### PR DESCRIPTION
Fixes bug that makes it impossible to search containers with full URL such as `docker.io/{user}/{container_name}`.