### PR TITLE
fmf: Disable SELinux for all of RHEL 10

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -74,7 +74,7 @@ sh -x test/vm.install
 systemctl enable --now cockpit.socket podman.socket
 
 # HACK: https://issues.redhat.com/browse/RHEL-49567
-if [ "$(rpm -q selinux-policy)" = "selinux-policy-40.13.5-1.el10.noarch" ]; then
+if rpm -q selinux-policy | grep -q el10; then
     setenforce 0
 fi
 


### PR DESCRIPTION
The current version selinux-policy-40.13.6-1.el10.noarch *still* breaks machined. This was a courtesy, but I'm not playing this game for longer than necessary. Just disable SELinux in general until we get notified that the bug gets fixed.

----

I notified/re-opened https://issues.redhat.com/browse/RHEL-49567 . Fixes this failure: https://artifacts.dev.testing-farm.io/5c511379-43b6-4c6b-86aa-3a6a7a312db6/