### PR TITLE
test: Move from CDP to BiDi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = b5a98be3e0601b45cd8a557cde1c80b896a903fb # 322 + 19 commits
+COCKPIT_REPO_COMMIT = 8ede522e5066e680850dd2ae049e2e24f99c4230 # 322 + 30 commits
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'
@@ -136,12 +136,9 @@ devel-uninstall:
 print-version:
 	@echo "$(VERSION)"
 
-# required for running integration tests; commander and ws are deps of chrome-remote-interface
+# required for running integration tests
 TEST_NPMS = \
-       node_modules/chrome-remote-interface \
-       node_modules/commander \
        node_modules/sizzle \
-       node_modules/ws \
        $(NULL)
 
 dist: $(TARFILE)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "devDependencies": {
     "argparse": "2.0.1",
-    "chrome-remote-interface": "^0.33.0",
     "esbuild": "0.23.0",
     "esbuild-plugin-copy": "2.1.1",
     "esbuild-plugin-replace": "1.4.0",
@@ -32,6 +31,7 @@
     "eslint-plugin-react": "7.35.0",
     "eslint-plugin-react-hooks": "4.6.2",
     "gettext-parser": "8.0.0",
+    "glob": "11.0.0",
     "htmlparser": "1.7.7",
     "jed": "1.1.1",
     "sass": "1.77.8",
@@ -49,13 +49,13 @@
     "@patternfly/react-styles": "5.3.1",
     "@patternfly/react-table": "5.3.4",
     "@patternfly/react-tokens": "5.3.1",
+    "@xterm/addon-canvas": "0.7.0",
+    "@xterm/xterm": "5.5.0",
     "docker-names": "1.2.1",
     "ipaddr.js": "2.2.0",
     "prop-types": "15.8.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "throttle-debounce": "5.0.2",
-    "@xterm/xterm": "5.5.0",
-    "@xterm/addon-canvas": "0.7.0"
+    "throttle-debounce": "5.0.2"
   }
 }

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -14,7 +14,7 @@ if [ -e .git ]; then
     mv .git dot-git
 else
     # upstream tarballs ship test dependencies; print version for debugging
-    grep '"version"' node_modules/chrome-remote-interface/package.json
+    grep '"version"' node_modules/sizzle/package.json
 fi
 
 . /run/host/usr/lib/os-release


### PR DESCRIPTION
See https://github.com/cockpit-project/cockpit/pull/20832

Drop chrome-remote-interface NPM dependency.

Explicitly add a "glob" devDependency to follow suit with
https://github.com/cockpit-project/cockpit/commit/680decc155a
It was previously used implicitly through a transient dependency of
something else, but our esbuild po-plugin uses it explicitly.
    
Also sort package.json properly (done by `npm install --save-dev`).

