### PR TITLE
Fix magic env var value auto-splitting

### DIFF
--- a/src/Env.jsx
+++ b/src/Env.jsx
@@ -81,7 +81,7 @@ export const EnvVar = ({ id, item, onChange, idx, removeitem, additem, itemCount
                        onChange={(_event, value) => {
                            utils.validationClear(validationFailed, "envValue", onValidationChange);
                            utils.validationDebounce(() => onValidationChange({ ...validationFailed, envValue: validateEnvVar(value, "envValue") }));
-                           handleEnvValue('envValue', value, idx, onChange, additem, itemCount, item.envValue);
+                           handleEnvValue('envValue', value, idx, onChange, additem, itemCount, item.envKey);
                        }} />
                 <FormHelper helperTextInvalid={validationFailed?.envValue} />
             </FormGroup>

--- a/test/check-application
+++ b/test/check-application
@@ -1928,11 +1928,22 @@ class TestApplication(testlib.MachineCase):
         b.set_input_text('#run-image-dialog-env-2-value', 'GRAPE')
         b.click('#run-image-dialog-env-2-btn-close')
         b.click('.env-form .btn-add')
-        # Test inputting an key=var entry
-        b.set_val('#run-image-dialog-env-3-value',
-                  "RHUBARB=STRAWBERRY DURIAN=LEMON TEST_URL=wss://cockpit/?start=1&stop=0")
+        # Test inputting an key=var entry; that should auto-split on '='
+        b.set_input_text('#run-image-dialog-env-3-value', "RHUBARB=STRAWBERRY", value_check=False)
+        b.wait_val("#run-image-dialog-env-3-key", "RHUBARB")
+        b.wait_val("#run-image-dialog-env-3-value", "STRAWBERRY")
+
+        # with copy&paste you can also set multiple variables
+        b.click('.env-form .btn-add')
+        b.set_val('#run-image-dialog-env-4-value',
+                  "DURIAN=LEMON TEST_URL=wss://cockpit/?start=1&stop=0")
         # set_val does not trigger onChange so append a space.
-        b.set_input_text('#run-image-dialog-env-3-value', ' ', append=True, value_check=False)
+        b.set_input_text('#run-image-dialog-env-4-value', ' ', append=True, value_check=False)
+
+        b.wait_val("#run-image-dialog-env-4-key", "DURIAN")
+        b.wait_val("#run-image-dialog-env-4-value", "LEMON")
+        b.wait_val("#run-image-dialog-env-5-key", "TEST_URL")
+        b.wait_val("#run-image-dialog-env-5-value", "wss://cockpit/?start=1&stop=0")
 
         b.click('.env-form .btn-add')
         b.set_input_text('#run-image-dialog-env-6-key', 'HOSTNAME')


### PR DESCRIPTION
The `companionField` in handleEnvValue() is meant to be the *other* (key/value) field. It doesn't make sense to specify its own value, that just looked like a copy&paste error from the *-key input handler.

With that you can type "FOO=bar" and get the automatic split. The test "cheated" with `set_val()` which sets all letters atomically. Test "RHUBARB=STRAWBERRY" separately with proper keyboard input.

Splitting muliple variables can only work with an atomic value setting, i.e. the user doing copy&paste. Keep the `set_val()` bit and explain it, and also validate that the fields get created and split as expected.

---

Spotted as part of #1832. It may help with the [testRunImageUser failure](https://artifacts.dev.testing-farm.io/3a44f391-ea98-46b4-b63f-9bb8d565c2ea/), but it's confusing/obvious enough to be a good bug fix even if it doesn't fix that particular race.

I triggered an extra /firefox run.