### PR TITLE
[feat] render podman container/pod ports as ranges

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -1915,6 +1915,19 @@ class TestApplication(testlib.MachineCase):
         b.click('.publish-port-form .btn-add')
         b.set_input_text('#run-image-dialog-publish-4-ip-address', '127.0.0.2')
         b.set_input_text('#run-image-dialog-publish-4-container-port', '9001')
+        # publish range of ports
+        b.click('.publish-port-form .btn-add')
+        b.set_input_text('#run-image-dialog-publish-5-container-port', '4000')
+        b.set_input_text('#run-image-dialog-publish-5-host-port', '4000')
+        b.click('.publish-port-form .btn-add')
+        b.set_input_text('#run-image-dialog-publish-6-container-port', '4001')
+        b.set_input_text('#run-image-dialog-publish-6-host-port', '4001')
+        b.click('.publish-port-form .btn-add')
+        b.set_input_text('#run-image-dialog-publish-7-container-port', '4002')
+        b.set_input_text('#run-image-dialog-publish-7-host-port', '4002')
+        b.click('.publish-port-form .btn-add')
+        b.set_input_text('#run-image-dialog-publish-8-container-port', '4003')
+        b.set_input_text('#run-image-dialog-publish-8-host-port', '4003')
 
         # Configure env
         b.click('.env-form .btn-add')
@@ -2033,11 +2046,14 @@ class TestApplication(testlib.MachineCase):
                        '127.0.0.2:')
         b.wait_in_text(f'#containers-containers tr:contains("{IMG_BUSYBOX}") dt:contains("Ports") + dd',
                        ' \u2192 8001/tcp')
+        b.wait_in_text(f'#containers-containers tr:contains("{IMG_BUSYBOX}") dt:contains("Ports") + dd',
+                       '0.0.0.0:4000-4003 \u2192 4000-4003/tcp')
         b.wait_not_in_text(f'#containers-containers tr:contains("{IMG_BUSYBOX}") dt:contains("Ports") + dd',
                            '7001/tcp')
 
         ports = self.execute(auth, "podman inspect --format '{{.NetworkSettings.Ports}}' busybox-with-tty")
         self.assertRegex(ports, r'5000/tcp:\[{(0.0.0.0)? 6000}\]')
+        self.assertRegex(ports, r'400[0-3]?/tcp:\[{(0.0.0.0)? 400[0-3]?}\]')
         self.assertIn('5001/udp:[{127.0.0.1 6001}]', ports)
         self.assertIn('8001/tcp:[{', ports)
         self.assertIn('9001/tcp:[{127.0.0.2 ', ports)


### PR DESCRIPTION
This PR allows rendering podman container ports  as  ranges.

It makes sure to only render a range if the range of ports has the same protocol and IP and the host ports are an equivalent range.

This is my first PR in javascript, so please let me know if anything needs fixed!

Closes #1378 

Examples:
![Screenshot_20240829_135103](https://github.com/user-attachments/assets/ae68ce10-e559-4c46-806c-df9502891f5e)
