### PR TITLE
Fix irritating Enter key behaviour in container creation dialog

### DIFF
--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -743,8 +743,10 @@ export class ImageRunModal extends React.Component {
             </ToggleGroup>
         );
 
+        /* ignore Enter key, it otherwise opens the first popover help; this clears
+         * the search input and is still irritating from other elements like check boxes */
         const defaultBody = (
-            <Form>
+            <Form onKeyDown={e => e.key === 'Enter' && e.preventDefault()}>
                 {this.state.dialogError && <ErrorNotification errorMessage={this.state.dialogError} errorDetail={this.state.dialogErrorDetail} />}
                 <FormGroup id="image-name-group" fieldId='run-image-dialog-name' label={_("Name")} className="ct-m-horizontal">
                     <TextInput id='run-image-dialog-name'

--- a/test/check-application
+++ b/test/check-application
@@ -1738,8 +1738,15 @@ class TestApplication(testlib.MachineCase):
 
         # Local registry
         b.click('button.pf-v5-c-toggle-group__button:contains("localhost:5000")')
-        b.set_input_text("#create-image-image-select-typeahead", "my-busybox")
+        b.set_input_text("#create-image-image-select-typeahead", "my-busybox", blur=False)
         b.wait_text("button.pf-v5-c-select__menu-item:not(.pf-m-disabled)", "localhost:5000/my-busybox")
+
+        # pressing Enter does not disturb the dialog or open popup help
+        b.wait_val("#create-image-image-select-typeahead", "my-busybox")
+        b.key("Enter")
+        time.sleep(0.3)
+        self.assertFalse(b.is_present(".pf-v5-c-popover"))
+        b.wait_val("#create-image-image-select-typeahead", "my-busybox")
 
         # Select image
         b.click('button.pf-v5-c-select__menu-item:contains("localhost:5000/my-busybox")')


### PR DESCRIPTION
Pressing "Enter" in the dialog on any active form element (such as the search input or the checkboxes) previously bubbled up to the Form, which then activated the first popover help. This is unexpected and very irritating especially when using the search input.

Just ignore the Enter key to fix that, similar to what the image search modal already does.

See https://github.com/cockpit-project/cockpit-podman/pull/1821#issuecomment-2374302608