### PR TITLE
Validate environment variables

### DIFF
--- a/src/Env.jsx
+++ b/src/Env.jsx
@@ -14,10 +14,15 @@ import * as utils from './util.js';
 const _ = cockpit.gettext;
 
 export function validateEnvVar(env, key) {
+    const re = /^[a-zA-Z_]{1,}[a-zA-Z0-9_]*$/;
     switch (key) {
     case "envKey":
         if (!env)
             return _("Key must not be empty");
+        if (/^\d/.test(env))
+            return _("Key must not begin with a digit");
+        if (!re.test(env))
+            return _("Key contains invalid characters");
         break;
     case "envValue":
         break;
@@ -73,7 +78,6 @@ export const EnvVar = ({ id, item, onChange, idx, removeitem, additem, itemCount
                 id={id + "-value-group"}
                 label={_("Value")}
                 fieldId={id + "-value-address"}
-                isRequired
             >
                 <TextInput id={id + "-value"}
                        value={item.envValue || ''}

--- a/test/check-application
+++ b/test/check-application
@@ -2535,7 +2535,8 @@ class TestApplication(testlib.MachineCase):
 
         # Test validation of environment variables
         b.click('.env-form .btn-add')
-        b.set_input_text("#run-image-dialog-env-0-key-group input", "sometext")
+        validateField("#run-image-dialog-env-0-key-group", "[]]]", "invalid characters")
+        validateField("#run-image-dialog-env-0-key-group", "1a", "not begin with a digit")
         validateField("#run-image-dialog-env-0-key-group", "", "must not be empty", resetValue="sometext")
 
         b.set_input_text("#run-image-dialog-name", container_name)


### PR DESCRIPTION
Validate env var keys with regex. Remove Required asterisk for value. This might sound weird but Podman and shells in general allow setting env vars without values.

Fixes: https://github.com/cockpit-project/cockpit-podman/issues/1622