### PR TITLE
appstream: Fix validation problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TARFILE=$(RPM_NAME)-$(VERSION).tar.xz
 NODE_CACHE=$(RPM_NAME)-node-$(VERSION).tar.xz
 SPEC=$(RPM_NAME).spec
 PREFIX ?= /usr/local
-APPSTREAMFILE=org.cockpit-project.$(PACKAGE_NAME).metainfo.xml
+APPSTREAMFILE=org.cockpit_project.$(PACKAGE_NAME).metainfo.xml
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check for node_modules/
 NODE_MODULES_TEST=package-lock.json

--- a/org.cockpit_project.podman.metainfo.xml
+++ b/org.cockpit_project.podman.metainfo.xml
@@ -9,8 +9,16 @@
   <description>
     <p>
       The Cockpit user interface for Podman containers.
+
+      podman (Pod Manager) is a fully featured daemon-less engine for OCI
+      containers, pods (groups of containers), and container images. It
+      is CLI, API, and functionally compatible with Docker.
     </p>
   </description>
   <extends>org.cockpit_project.cockpit</extends>
   <launchable type="cockpit-manifest">podman</launchable>
+  <url type="homepage">https://cockpit-project.org/</url>
+  <developer id="org.cockpit-project">
+    <name>Cockpit Project</name>
+  </developer>
 </component>

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Martin Pitt <mpitt@debian.org>
 Uploaders: Reinhard Tartler <siretart@tauware.de>
 Build-Depends: debhelper-compat (= 13),
-Standards-Version: 4.6.2
+Standards-Version: 4.7.0
 Rules-Requires-Root: no
 Homepage: https://github.com/cockpit-project/cockpit-podman
 Vcs-Git: https://salsa.debian.org/debian/cockpit-podman.git


### PR DESCRIPTION
Rename the file to match its ID, add developer/home page, and extend the
description. This fixes all issues with `appstreamcli validate`:

> W: org.cockpit_project.podman: url-homepage-missing
> W: org.cockpit_project.podman: metainfo-filename-cid-mismatch
> I: org.cockpit_project.podman:38: description-first-para-too-short
> I: org.cockpit_project.podman: developer-info-missing

---

See https://appstream.debian.org/sid/main/issues/cockpit-podman.html . `metainfo-filename-cid-mismatch` is new with the recent update of AppStream to 1.0.3 in Debian. See also https://github.com/cockpit-project/cockpit/pull/21103