### PR TITLE
tmt: Disable fedora repo for C10 tests

### DIFF
--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -3,6 +3,14 @@ discover:
 execute:
     how: tmt
 
+# counteract https://issues.redhat.com/browse/TFT-2564
+adjust:
+  prepare+:
+  - how: shell
+    script: |
+      rm --force --verbose /etc/yum.repos.d/fedora.repo
+    when: distro == centos-10
+
 # Let's handle them upstream only, don't break Fedora/RHEL reverse dependency gating
 environment:
     TEST_AUDIT_NO_SELINUX: 1


### PR DESCRIPTION
https://issues.redhat.com/browse/TFT-2564 roars its ugly head again and completely breaks installation due to installing Fedora packages on CentOS 10.

See https://github.com/containers/podman/pull/24255

Same solution as https://github.com/cockpit-project/cockpit-machines/commit/41f337fd85b85