### PR TITLE
fmf: Explicitly install iptables-nft for Fedora 41 as well

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -6,8 +6,9 @@ cd "${0%/*}/../.."
 # HACK: ensure that critical components are up to date: https://github.com/psss/tmt/issues/682
 dnf update -y podman crun conmon criu
 
-# Missing iptables-nft dependency https://issues.redhat.com/browse/RHEL-58240
-if grep -q 'platform:el10' /etc/os-release; then
+# Missing iptables-nft dependency https://issues.redhat.com/browse/RHEL-58240 and
+# https://bugzilla.redhat.com/show_bug.cgi?id=2319310
+if grep -Eq 'platform:(el10|f41)' /etc/os-release; then
     dnf install -y iptables-nft
 fi
 


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=2319310

---

This should hopefully put an end to the occasional [checkpoint/restore failures](https://artifacts.dev.testing-farm.io/cae003c8-50ff-4261-821e-0e8d7ddfff8b/) in upstream podman F41 PRs such as https://github.com/containers/podman/pull/24300 or https://github.com/containers/podman/pull/24238#issuecomment-2417049948