### PR TITLE
pods: Fix PodCreateModal validation issues

### DIFF
--- a/src/PodCreateModal.jsx
+++ b/src/PodCreateModal.jsx
@@ -77,10 +77,10 @@ export const PodCreateModal = ({ user, systemServiceAvailable, userServiceAvaila
     */
     const dynamicListOnValidationChange = (key, value) => {
         setValidationFailed(prevState => {
-            prevState[key] = value;
-            if (prevState[key].every(a => a === undefined))
-                delete prevState[key];
-            return prevState;
+            const newState = Object.assign({}, prevState, { [key]: value });
+            if (newState[key].every(a => a === undefined))
+                delete newState[key];
+            return newState;
         });
     };
 

--- a/src/PodCreateModal.jsx
+++ b/src/PodCreateModal.jsx
@@ -129,7 +129,7 @@ export const PodCreateModal = ({ user, systemServiceAvailable, userServiceAvaila
             };
         });
         if (publishValidation.some(entry => entry && Object.keys(entry).length > 0))
-            newValidationFailed.publish = publishValidation.filter(entry => entry !== undefined);
+            newValidationFailed.publish = publishValidation;
 
         const podNameValidation = validatePodName(podName);
 

--- a/src/PodCreateModal.jsx
+++ b/src/PodCreateModal.jsx
@@ -101,12 +101,20 @@ export const PodCreateModal = ({ user, systemServiceAvailable, userServiceAvaila
     };
 
     const isFormInvalid = validationFailed => {
-        const groupHasError = row => row && Object.values(row)
-                .filter(val => val) // Filter out empty/undefined properties
-                .length > 0; // If one field has error, the whole group (dynamicList) is invalid
+        function publishGroupHasError(row, idx) {
+            // We always ignore errors for empty slots in
+            // publish. Errors for these slots might show up when the
+            // debounced validation runs after a row has been removed.
+            if (!row || !publish[idx])
+                return false;
+
+            return Object.values(row)
+                    .filter(val => val) // Filter out empty/undefined properties
+                    .length > 0; // If one field has error, the whole group (dynamicList) is invalid
+        }
 
         // If at least one group is invalid, then the whole form is invalid
-        return validationFailed.publish?.some(groupHasError) ||
+        return validationFailed.publish?.some(publishGroupHasError) ||
             !!validationFailed.podName;
     };
 

--- a/test/check-application
+++ b/test/check-application
@@ -2942,13 +2942,9 @@ class TestApplication(testlib.MachineCase):
         b.wait_visible(container_1_sel + " .ct-badge-toolbox:contains('toolbox')")
         b.wait_visible(container_2_sel + " .ct-badge-distrobox:contains('distrobox')")
 
-    # this isn't *really* a Firefox bug, but the different timing just triggers this a lot
-    # https://github.com/cockpit-project/cockpit-podman/issues/1836
-    @testlib.skipBrowser("pod dialog state management is broken", "firefox")
     def testCreatePodSystem(self):
         self._createPod(True)
 
-    @testlib.skipBrowser("pod dialog state management is broken", "firefox")
     def testCreatePodUser(self):
         self._createPod(False)
 


### PR DESCRIPTION
I have found four issues:

 - Validation results would not always make it into the UI while typing into the fields. This was confusing, but hitting "Create" would always straighten things out.
 - Removing port rows and then hitting "Create" while something was invalid would shift the (genuine) validation errors into the places of the previous removed ports. There they would invisbly keep the "Create" button from ever getting enabled again.
 - `<TextInput type="number" />` does not usefully distinguish between empty strings and strings that are not numbers, and it sends fewer change notifications than expected. For example, starting to type random letters into a previously empty field will produce no change events and we get no opportunity to run our validation code.
 - The Volumes are not validated at the top-level, but do have their own validation rules. (Just "container path can not be empty".) Instead of showing validation errors, invalid volumes are simply omitted when creating the pod.