### PR TITLE
test: Remove cockpit/ws container on non-OSTree images

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -37,6 +37,9 @@ fi
 # Since 4.0 podman now ships the pause image
 podman images --format '{{.Repository}}:{{.Tag}}' | grep -Ev 'localhost/test-|pause|cockpit/ws' | xargs -r podman rmi -f
 
+# clean up cockpit/ws on Fedora images, as it "breaks" pixel tests; it's only relevant for OSTree images
+[ -n "${OSTREE_VERSION:-}" ] || podman rmi -f quay.io/cockpit/ws || true
+
 # tests reset podman, save the images
 mkdir -p /var/lib/test-images
 for img in $(podman images --format '{{.Repository}}:{{.Tag}}'); do


### PR DESCRIPTION
In https://github.com/cockpit-project/bots/pull/7046 we want to pre-install the cockpit/ws container to the fedora-40 image (and in the future, whichever Fedora version the container is based on). This "breaks" pixel tests due to the additional container image, so remove it for anything except OSTree images.

We don't just want to include it in the pixel tests, as the container's base image and pixel reference OS move independently.