### PR TITLE
Convert substr() usage to substring()

### DIFF
--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -474,7 +474,7 @@ class Containers extends React.Component {
         return {
             expandedContent: <ListingPanel colSpan='4' tabRenderers={tabs} />,
             columns,
-            initiallyExpanded: document.location.hash.substr(1) === container.Id,
+            initiallyExpanded: document.location.hash.substring(1) === container.Id,
             props: {
                 key: container.Id + container.isSystem.toString(),
                 "data-row-id": container.Id + container.isSystem.toString(),

--- a/src/util.js
+++ b/src/util.js
@@ -37,7 +37,7 @@ export function truncate_id(id) {
     if (!id) {
         return "";
     }
-    return id.substr(0, 12);
+    return id.substring(0, 12);
 }
 
 // this supports formatted strings (via Date.parse) or raw timestamps


### PR DESCRIPTION
String.prototype.substr() is a deprecated API.

---

Couldn't find an eslint rule for this, so we'll have to pay attention.