### PR TITLE
debug tasks-container-update failure

### DIFF
--- a/.github/workflows/tasks-container-update.yml
+++ b/.github/workflows/tasks-container-update.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Pacify git's permission check
         run: git config --global --add safe.directory /__w/cockpit-podman/cockpit-podman
 
+      - run: dnf install -y tmate curl
+
+      - uses: mxschmitt/action-tmate@v3
+        with:
+          install-dependencies: false
+
       - name: Run tasks-container-update
         run: |
           make bots

--- a/packit.yaml
+++ b/packit.yaml
@@ -17,28 +17,6 @@ srpm_build_deps:
 
 jobs:
   - job: copr_build
-    trigger: pull_request
-    targets:
-    - fedora-40
-    - fedora-41
-    - fedora-latest-aarch64
-    - fedora-development
-    - centos-stream-9-x86_64
-    - centos-stream-9-aarch64
-    - centos-stream-10
-
-  - job: tests
-    trigger: pull_request
-    targets:
-      - fedora-40
-      - fedora-41
-      - fedora-latest-aarch64
-      - fedora-development
-      - centos-stream-9-x86_64
-      - centos-stream-9-aarch64
-      - centos-stream-10
-
-  - job: copr_build
     trigger: release
     owner: "@cockpit"
     project: "cockpit-preview"


### PR DESCRIPTION
The last runs of this workflow failed in [machines](https://github.com/cockpit-project/cockpit-machines/actions/runs/12228090535/job/34105778704) , [podman](https://github.com/cockpit-project/cockpit-podman/actions/runs/12230669044/job/34112363978), and cockpit. It worked in starter-kit and ostree, and curiously also in files. The latter doesn't use `environment: self`, so supposedly that's the crucial bit.

Not sure what changed since October, when they were still working. Locally this works:

```
PYTHONPATH=bots python3 -c 'import task; print(task.default_branch())'
main
```

But of course I'm also not using a deploy key locally nor the GitHub token. This needs to be debugged in the workflow infra.