### PR TITLE
test: show catatonit version for testing farm runs

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -21,7 +21,7 @@ if [ -n "$main_builds_repo" ]; then
 fi
 
 # Show critical package versions
-rpm -q runc crun podman criu passt kernel-core selinux-policy cockpit-podman cockpit-bridge || true
+rpm -q runc crun podman criu passt catatonit kernel-core selinux-policy cockpit-podman cockpit-bridge || true
 
 # Show network information, for pasta debugging
 ip address show


### PR DESCRIPTION
CentOS 10 is currently broken with:

Error: building local pause image: finding pause binary: exec: "catatonit": executable file not found in $PATH

So check if the package is installed.

---

Can already locally reproduce the issue but this seems useful regardless