### PR TITLE
test: Disable firewalld StrictForwardPorts on RHEL 10

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -23,6 +23,13 @@ Delegate=cpu cpuset io memory pids
 EOF
 fi
 
+if grep -q platform:el10 /usr/lib/os-release && [ -e /etc/firewalld/firewalld.conf ]; then
+    # HACK: unbreak container port forwarding to localhost
+    # https://firewalld.org/2024/11/strict-forward-ports and https://github.com/firewalld/firewalld/issues/1380
+    # TF runs have no firewalld
+    sed -i 's/StrictForwardPorts=yes/StrictForwardPorts=no/' /etc/firewalld/firewalld.conf
+fi
+
 # don't force https:// (self-signed cert)
 mkdir -p /etc/cockpit
 printf "[WebService]\\nAllowUnencrypted=true\\n" > /etc/cockpit/cockpit.conf


### PR DESCRIPTION
RHEL 10 started to break `podman -p` port forwarding to localhost by default [1]. This was a deliberate change [2][3]. We really don't care about firewalling localhost ports from containers (does anybody really?), so revert back to the previous behaviour (which is still the default on Fedora) of having StrictForwardPorts=no.

This obsoletes our naughty https://github.com/cockpit-project/bots/issues/7291

[1] https://issues.redhat.com/browse/RHEL-72937
[2] https://firewalld.org/2024/11/strict-forward-ports
[3] https://github.com/firewalld/firewalld/issues/1380

---

This should make the [four skipped tests](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1951-68a71ea4-20250107-150223-rhel-10-0/log.html) green again. After this lands, I'll send a bots PR to drop the naughty.