### PR TITLE
First steps of quadlet integration

### DIFF
--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -45,7 +45,7 @@ import '@patternfly/patternfly/utilities/Accessibility/accessibility.css';
 
 const _ = cockpit.gettext;
 
-const ContainerActions = ({ container, healthcheck, onAddNotification, localImages, updateContainer }) => {
+const ContainerActions = ({ container, healthcheck, onAddNotification, localImages, updateContainer, isSystemdService }) => {
     const Dialogs = useDialogs();
     const isRunning = container.State.Status == "running";
     const isPaused = container.State.Status === "paused";
@@ -216,9 +216,9 @@ const ContainerActions = ({ container, healthcheck, onAddNotification, localImag
                 {_("Start")}
             </DropdownItem>
         );
-
-        addRenameAction();
-
+        if (!isSystemdService) {
+            addRenameAction();
+        }
         if (container.isSystem && container.State?.CheckpointPath) {
             actions.push(
                 <Divider key="separator-0" />,
@@ -229,7 +229,9 @@ const ContainerActions = ({ container, healthcheck, onAddNotification, localImag
             );
         }
     } else { // running or paused
-        addRenameAction();
+        if (!isSystemdService) {
+            addRenameAction();
+        }
     }
 
     actions.push(<Divider key="separator-1" />);
@@ -427,7 +429,8 @@ class Containers extends React.Component {
                                          healthcheck={healthcheck}
                                          onAddNotification={this.props.onAddNotification}
                                          localImages={localImages}
-                                         updateContainer={this.props.updateContainer} />,
+                                         updateContainer={this.props.updateContainer}
+                                         isSystemdService={isSystemdService} />,
                 props: { className: "pf-v5-c-table__action" }
             });
         }

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -45,7 +45,7 @@ import '@patternfly/patternfly/utilities/Accessibility/accessibility.css';
 
 const _ = cockpit.gettext;
 
-const ContainerActions = ({ container, healthcheck, onAddNotification, localImages, updateContainer, isSystemdService }) => {
+const ContainerActions = ({ container, onAddNotification, localImages, updateContainer, isSystemdService }) => {
     const Dialogs = useDialogs();
     const isRunning = container.State.Status == "running";
     const isPaused = container.State.Status === "paused";
@@ -113,14 +113,6 @@ const ContainerActions = ({ container, healthcheck, onAddNotification, localImag
     const commitContainer = () => {
         Dialogs.show(<ContainerCommitModal container={container}
                                            localImages={localImages} />);
-    };
-
-    const runHealthcheck = () => {
-        client.runHealthcheck(container.isSystem, container.Id)
-                .catch(ex => {
-                    const error = cockpit.format(_("Failed to run health check on container $0"), container.Name); // not-covered: OS error
-                    onAddNotification({ type: 'danger', error, errorDetail: ex.message });
-                });
     };
 
     const restartContainer = (force) => {
@@ -241,16 +233,6 @@ const ContainerActions = ({ container, healthcheck, onAddNotification, localImag
             {_("Commit")}
         </DropdownItem>
     );
-
-    if (isRunning && healthcheck !== "") {
-        actions.push(<Divider key="separator-1-1" />);
-        actions.push(
-            <DropdownItem key="healthcheck"
-                          onClick={() => runHealthcheck()}>
-                {_("Run health check")}
-            </DropdownItem>
-        );
-    }
 
     actions.push(<Divider key="separator-2" />);
     actions.push(
@@ -426,7 +408,6 @@ class Containers extends React.Component {
         if (!container.isDownloading) {
             columns.push({
                 title: <ContainerActions container={container}
-                                         healthcheck={healthcheck}
                                          onAddNotification={this.props.onAddNotification}
                                          localImages={localImages}
                                          updateContainer={this.props.updateContainer}

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -47,7 +47,6 @@ const _ = cockpit.gettext;
 
 const ContainerActions = ({ container, healthcheck, onAddNotification, localImages, updateContainer }) => {
     const Dialogs = useDialogs();
-    const { version } = utils.usePodmanInfo();
     const isRunning = container.State.Status == "running";
     const isPaused = container.State.Status === "paused";
 
@@ -137,8 +136,7 @@ const ContainerActions = ({ container, healthcheck, onAddNotification, localImag
     };
 
     const renameContainer = () => {
-        if (container.State.Status !== "running" ||
-            version.localeCompare("3.0.1", undefined, { numeric: true, sensitivity: 'base' }) >= 0) {
+        if (container.State.Status !== "running") {
             Dialogs.show(<ContainerRenameModal container={container}
                                                updateContainer={updateContainer} />);
         }
@@ -218,9 +216,9 @@ const ContainerActions = ({ container, healthcheck, onAddNotification, localImag
                 {_("Start")}
             </DropdownItem>
         );
-        if (version.localeCompare("3", undefined, { numeric: true, sensitivity: 'base' }) >= 0) {
-            addRenameAction();
-        }
+
+        addRenameAction();
+
         if (container.isSystem && container.State?.CheckpointPath) {
             actions.push(
                 <Divider key="separator-0" />,
@@ -231,9 +229,7 @@ const ContainerActions = ({ container, healthcheck, onAddNotification, localImag
             );
         }
     } else { // running or paused
-        if (version.localeCompare("3.0.1", undefined, { numeric: true, sensitivity: 'base' }) >= 0) {
-            addRenameAction();
-        }
+        addRenameAction();
     }
 
     actions.push(<Divider key="separator-1" />);

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -344,6 +344,7 @@ class Containers extends React.Component {
         const image = container.ImageName;
         const isToolboxContainer = container.Config?.Labels?.["com.github.containers.toolbox"] === "true";
         const isDistroboxContainer = container.Config?.Labels?.manager === "distrobox";
+        const isSystemdService = Boolean(container.Config?.Labels?.PODMAN_SYSTEMD_UNIT);
         let localized_health = null;
 
         // this needs to get along with stub containers from image run dialog, where most properties don't exist yet
@@ -392,6 +393,7 @@ class Containers extends React.Component {
                     <span className="container-name">{container.Name}</span>
                     {isToolboxContainer && <Badge className='ct-badge-toolbox'>toolbox</Badge>}
                     {isDistroboxContainer && <Badge className='ct-badge-distrobox'>distrobox</Badge>}
+                    {isSystemdService && <Badge className='ct-badge-service'>service</Badge>}
                 </Flex>
                 <small>{image}</small>
                 <small>{utils.quote_cmdline(container.Config?.Cmd)}</small>

--- a/src/podman.scss
+++ b/src/podman.scss
@@ -98,6 +98,16 @@
     }
 }
 
+.ct-badge-service {
+    background-color: var(--pf-v5-global--palette--light-blue-100);
+    color: var(--pf-v5-global--palette--light-blue-600);
+
+    .pf-v5-theme-dark & {
+        background-color: var(--pf-v5-global--palette--light-blue-500);
+        color: white;
+    }
+}
+
 .green {
     color: var(--pf-v5-global--success-color--100);
 }

--- a/test/check-application
+++ b/test/check-application
@@ -2987,6 +2987,16 @@ WantedBy=multi-user.target default.target
         self.execute(auth, f"podman inspect --format '{{{{.Id}}}}' {container_name_new}").strip()
         self.waitContainerRow(container_name_new)
 
+        # service containers cannot be renamed
+        if self.supports_quadlet:
+            # HACK https://issues.redhat.com/browse/RHEL-5870
+            if self.machine.image == "rhel-8-10" and not auth:
+                return
+            service_name = "quadlet"
+            self.createQuadlet(service_name, auth=auth)
+            self.waitContainerRow(service_name)
+            b.wait_not_present(self.getContainerAction(service_name, 'Rename'))
+
     def testMultipleContainers(self):
         self.login()
 

--- a/test/check-application
+++ b/test/check-application
@@ -155,6 +155,7 @@ class TestApplication(testlib.MachineCase):
         self.has_criu = "debian" not in m.image and "ubuntu" not in m.image
         self.has_selinux = not any(img in m.image for img in ["arch", "debian", "ubuntu", "suse"])
         self.has_cgroupsV2 = not m.image.startswith('rhel-8')
+        self.supports_quadlet = m.image not in ["debian-stable", "ubuntu-2204"]
 
         self.system_images_count = int(self.execute(True, "podman images -n | wc -l").strip())
         self.user_images_count = int(self.execute(False, "podman images -n | wc -l").strip())
@@ -297,6 +298,32 @@ class TestApplication(testlib.MachineCase):
         # Add local insecure registry into registries conf
         m.write("/etc/containers/registries.conf", REGISTRIES_CONF)
         self.execute(True, "systemctl stop podman.service")
+
+    def createQuadlet(self, name: str, *, auth: bool = False) -> None:
+        quadlet = f"""
+[Unit]
+Description=Podman - {name}
+After=local-fs.target
+
+[Container]
+Image={IMG_BUSYBOX}
+Exec=sleep infinity
+ContainerName={name}
+
+[Install]
+WantedBy=multi-user.target default.target
+"""
+
+        service_file = f"/etc/containers/systemd/{name}.container"
+        if not auth:  # user session
+            service_file = f"/home/admin/.config/containers/systemd/{name}.container"
+
+        systemctl_cmd = "systemctl" if auth else "systemctl --user"
+        self.addCleanup(self.execute, auth, f"{systemctl_cmd} daemon-reload")
+        self.write_file(service_file, quadlet)
+        self.addCleanup(self.execute, auth, f"{systemctl_cmd} stop {name}.service")
+        self.execute(auth, f"{systemctl_cmd} daemon-reload; {systemctl_cmd} start {name}.service")
+        self.execute(auth, f"until {systemctl_cmd} is-active {name}.service; do sleep 1; done")
 
     def testPods(self):
         b = self.browser
@@ -2993,6 +3020,13 @@ class TestApplication(testlib.MachineCase):
 
         b.wait_visible(container_1_sel + " .ct-badge-toolbox:contains('toolbox')")
         b.wait_visible(container_2_sel + " .ct-badge-distrobox:contains('distrobox')")
+
+        if self.supports_quadlet:
+            self.createQuadlet("container_3", auth=True)
+            container_3_id = m.execute("podman container inspect --format '{{.Id}}' container_3").strip()
+            self.waitContainerRow('container_3')
+            container_3_sel = f"#containers-containers tbody tr[data-row-id=\"{container_3_id}{'true'}\"]"
+            b.wait_visible(container_3_sel + " .ct-badge-service:contains('service')")
 
     def testCreatePodSystem(self):
         self._createPod(True)

--- a/test/check-application
+++ b/test/check-application
@@ -1401,9 +1401,6 @@ WantedBy=multi-user.target default.target
             # Check that the restore option is not present
             b.wait_not_present(self.getContainerAction('swamped-crate', 'Restore'))
 
-        # Health check is not set up
-        b.wait_not_present(self.getContainerAction('swamped-crate', 'Run health check'))
-
         b.click("#containers-containers tbody tr:contains('swamped-crate') .pf-v5-c-menu-toggle")
 
         # Start the container
@@ -2720,7 +2717,7 @@ WantedBy=multi-user.target default.target
         # Trigger run manually, adds one more healthy run
         if self.machine.image == "ubuntu-2204":
             time.sleep(5)  # wait a bit, otherwise the request might be ignored
-        self.performContainerAction("healthy", "Run health check")
+        b.click(".ct-listing-panel-body button:contains('Run health check')")
         b.wait_visible(".ct-listing-panel-body tbody:nth-of-type(2) svg.green")
         b.wait_not_present(".ct-listing-panel-body tbody:nth-of-type(3)")
 


### PR DESCRIPTION
Small steps into better supporting quadlets in cockpit-podman.

The visual changes are a new `service` label to identify quadlet/podman generate systemd managed containers

![image](https://github.com/user-attachments/assets/d0f7646c-b39e-44cd-9a10-39b3457ed572)

Other changes are:

* Removing "run healthcheck from the container kebabmenu". This can be done in the details view of a container and doesn't need to be such a prominent feature
* Hide the rename option for quadet/systemd containers, this likely causes issues as the `.container` file determines the name of the container allow users to change it will cause issues.