### PR TITLE
test: adjust to new CRIU unsupported error from podman

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -1542,7 +1542,12 @@ WantedBy=multi-user.target default.target
 
             def criu_alert():
                 text = b.text(".pf-v5-c-alert.pf-m-danger > .pf-v5-c-alert__description").lower()
-                return "checkpoint/restore requires at least criu" in text or "failed to check for criu" in text
+                errors = [
+                    "configured runtime does not support checkpoint/restore",
+                    "checkpoint/restore requires at least criu",
+                    "failed to check for criu",
+                ]
+                return any(error in text for error in errors)
             b.wait(criu_alert)
             return
 


### PR DESCRIPTION
The [new debian-testing](https://github.com/cockpit-project/bots/pull/7379) image now shows a different error, to avoid line limits convert it to a list. In a follow up I intend to cleanup the errors a bit.