### PR TITLE
Revert "test: Disable firewalld StrictForwardPorts on RHEL 10"

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -23,13 +23,6 @@ Delegate=cpu cpuset io memory pids
 EOF
 fi
 
-if grep -q platform:el10 /usr/lib/os-release && [ -e /etc/firewalld/firewalld.conf ]; then
-    # HACK: unbreak container port forwarding to localhost
-    # https://firewalld.org/2024/11/strict-forward-ports and https://github.com/firewalld/firewalld/issues/1380
-    # TF runs have no firewalld
-    sed -i 's/StrictForwardPorts=yes/StrictForwardPorts=no/' /etc/firewalld/firewalld.conf
-fi
-
 # don't force https:// (self-signed cert)
 mkdir -p /etc/cockpit
 printf "[WebService]\\nAllowUnencrypted=true\\n" > /etc/cockpit/cockpit.conf


### PR DESCRIPTION
The default policy change in RHEL 10 got reverted, see https://issues.redhat.com/browse/RHEL-72937

This reverts commit f1469ec566fdfdbcd7afc0f639c1b164d8ff7ecb.