### PR TITLE
test: Check podman socket going away while cockpit session is running

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -487,7 +487,8 @@ class Application extends React.Component {
                     this.cleanupAfterService(system);
                 });
 
-        // Listen for podman socket/service going away
+        // HACK: Listen for podman socket/service going away; this is only necessary with the C bridge
+        // (Debian 12, RHEL 8). With the Python bridge, the above streamEvents() resolves when the service goes away.
         const ch = cockpit.channel({ superuser: system ? "require" : null, payload: "stream", unix: client.getAddress(system) });
         ch.addEventListener("close", () => {
             console.log("init", system ? "system" : "user", "podman service closed");

--- a/test/check-application
+++ b/test/check-application
@@ -1640,19 +1640,33 @@ WantedBy=multi-user.target default.target
     def testFailingPodmanService(self):
         b = self.browser
 
-        self.execute(True, "systemctl mask podman.service")
-        self.addCleanup(self.execute, True, "systemctl unmask podman.service")
-        self.execute(False, "systemctl --user mask podman.service")
-        self.addCleanup(self.execute, False, "systemctl --user unmask podman.service")
-        self.login_and_go("/podman")
+        try:
+            self.execute(True, "systemctl mask podman.service")
+            self.execute(False, "systemctl --user mask podman.service")
+            self.login_and_go("/podman")
 
-        # Troubleshoot action
+            # Troubleshoot action
+            b.wait_text("#app .pf-v5-c-empty-state__title", "Podman service failed")
+            b.click("#app .pf-v5-c-empty-state button")
+            b.enter_page("/system/services")
+            # services page is too slow
+            with b.wait_timeout(60):
+                b.wait_in_text("#service-details", "podman.socket")
+            b.logout()
+        finally:
+            self.execute(True, "systemctl unmask podman.service")
+            self.execute(False, "systemctl --user unmask podman.service")
+
+        # now let it fail while c-podman is running
+        b.login_and_go("/podman")
+        b.wait_visible("#app")
+        b.wait_in_text("#containers-images", "system")
+        b.wait_in_text("#containers-images", "user")
+        self.execute(True, "systemctl stop podman.service")
+        b.wait_not_in_text("#containers-images", "system")
+        b.wait_in_text("#containers-images", "user")
+        self.execute(False, "systemctl --user stop podman.service")
         b.wait_text("#app .pf-v5-c-empty-state__title", "Podman service failed")
-        b.click("#app .pf-v5-c-empty-state button")
-        b.enter_page("/system/services")
-        # services page is too slow
-        with b.wait_timeout(60):
-            b.wait_in_text("#service-details", "podman.socket")
 
     def testCreateContainerSystem(self):
         self._testCreateContainer(True)


### PR DESCRIPTION
This covers the `streamEvents` plus explicit channel watching in
app.jsx. We can use this to guard when to remove the extra
`cockpit.channel()` `close` watching, which is not necessary with the
Python bridge, but still relevant on the C bridge (Debian 12 and RHEL 8).