### PR TITLE
packit: Drop copr_build job redundancy, re-disable Fedora 42

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -25,9 +25,10 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-41
-      - fedora-42
-      - fedora-latest-aarch64
-      - fedora-development
+      # https://pagure.io/fedora-infrastructure/issue/12389
+      # - fedora-42
+      - fedora-latest-stable-aarch64
+      - fedora-rawhide
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
       - centos-stream-10

--- a/packit.yaml
+++ b/packit.yaml
@@ -18,14 +18,8 @@ srpm_build_deps:
 jobs:
   - job: copr_build
     trigger: pull_request
-    targets:
-    - fedora-41
-    - fedora-42
-    - fedora-latest-aarch64
-    - fedora-development
-    - centos-stream-9-x86_64
-    - centos-stream-9-aarch64
-    - centos-stream-10
+    # implicitly defined by "tests" job, no extra build-only targets
+    targets: []
 
   - job: tests
     trigger: pull_request


### PR DESCRIPTION
The cloud images are missing [1] and not even COPR works. Also move the aarch64 test from -latest (which is 42 now, which doesn't work) to -latest-stable (which is 41).

"-development" also triggers -42, so avoid the alias and explicitly say "rawhide".
    
[1] https://pagure.io/fedora-infrastructure/issue/12389

----

Similar to https://github.com/cockpit-project/cockpit/pull/21591 , same rant applies.

Once this lands, I'll apply it to machines and files (ostree is fine).
