### PR TITLE
Revert "cockpit-ci: Update container to 2025-02-08"

### DIFF
--- a/.cockpit-ci/container
+++ b/.cockpit-ci/container
@@ -1,1 +1,1 @@
-ghcr.io/cockpit-project/tasks:2025-02-08
+ghcr.io/cockpit-project/tasks:2025-02-01


### PR DESCRIPTION
This causes weird failures in testFailingPodmanService with Firefox 135, see #1999. This breaks too many podman upstream PRs (which run cockpit-podman reverse dependency tests).

This reverts commit 8f78a848de6c49612t 947559fbd46893c1d72141d.

---

Let's land that and then investigate #1999 with less time pressure.