### PR TITLE
Move to connection object based API

### DIFF
--- a/src/ContainerCheckpointModal.jsx
+++ b/src/ContainerCheckpointModal.jsx
@@ -12,7 +12,7 @@ import * as client from './client.js';
 
 const _ = cockpit.gettext;
 
-const ContainerCheckpointModal = ({ containerWillCheckpoint, onAddNotification }) => {
+const ContainerCheckpointModal = ({ con, containerWillCheckpoint, onAddNotification }) => {
     const Dialogs = useDialogs();
     const [inProgress, setProgress] = useState(false);
     const [keep, setKeep] = useState(false);
@@ -21,7 +21,7 @@ const ContainerCheckpointModal = ({ containerWillCheckpoint, onAddNotification }
 
     const handleCheckpointContainer = () => {
         setProgress(true);
-        client.postContainer(containerWillCheckpoint.uid, "checkpoint", containerWillCheckpoint.Id, {
+        client.postContainer(con, "checkpoint", containerWillCheckpoint.Id, {
             keep,
             leaveRunning,
             tcpEstablished,

--- a/src/ContainerCommitModal.jsx
+++ b/src/ContainerCommitModal.jsx
@@ -17,7 +17,7 @@ import * as utils from './util.js';
 
 const _ = cockpit.gettext;
 
-const ContainerCommitModal = ({ container, localImages }) => {
+const ContainerCommitModal = ({ con, container, localImages }) => {
     const Dialogs = useDialogs();
 
     const [imageName, setImageName] = useState("");
@@ -77,7 +77,7 @@ const ContainerCommitModal = ({ container, localImages }) => {
         setNameError("");
         setDialogError("");
         setDialogErrorDetail("");
-        client.commitContainer(container.uid, commitData)
+        client.commitContainer(con, commitData)
                 .then(() => Dialogs.close())
                 .catch(ex => {
                     setDialogError(cockpit.format(_("Failed to commit container $0"), container.Name));

--- a/src/ContainerDeleteModal.jsx
+++ b/src/ContainerDeleteModal.jsx
@@ -10,7 +10,7 @@ import * as client from './client.js';
 
 const _ = cockpit.gettext;
 
-const ContainerDeleteModal = ({ containerWillDelete, onAddNotification }) => {
+const ContainerDeleteModal = ({ con, containerWillDelete, onAddNotification }) => {
     const Dialogs = useDialogs();
 
     const handleRemoveContainer = () => {
@@ -18,7 +18,7 @@ const ContainerDeleteModal = ({ containerWillDelete, onAddNotification }) => {
         const id = container ? container.Id : "";
 
         Dialogs.close();
-        client.delContainer(container.uid, id, false)
+        client.delContainer(con, id, false)
                 .catch(ex => {
                     const error = cockpit.format(_("Failed to remove container $0"), container.Name); // not-covered: OS error
                     onAddNotification({ type: 'danger', error, errorDetail: ex.message });

--- a/src/ContainerHealthLogs.jsx
+++ b/src/ContainerHealthLogs.jsx
@@ -44,7 +44,7 @@ const HealthcheckOnFailureActionText = {
     kill: _("Force stop"),
 };
 
-const ContainerHealthLogs = ({ container, onAddNotification, state }) => {
+const ContainerHealthLogs = ({ con, container, onAddNotification, state }) => {
     const healthCheck = container.Config?.Healthcheck ?? container.Config?.Health ?? {}; // not-covered: only on old version
     const healthState = container.State?.Healthcheck ?? container.State?.Health ?? {}; // not-covered: only on old version
     const logs = [...(healthState.Log || [])].reverse(); // not-covered: Log should always exist, belt-and-suspenders
@@ -91,7 +91,7 @@ const ContainerHealthLogs = ({ container, onAddNotification, state }) => {
                 { container.State.Status === "running" &&
                     <FlexItem>
                         <Button variant="secondary" onClick={() => {
-                            client.runHealthcheck(container.uid, container.Id)
+                            client.runHealthcheck(con, container.Id)
                                     .catch(ex => {
                                         const error = cockpit.format(_("Failed to run health check on container $0"), container.Name); // not-covered: OS error
                                         onAddNotification({ type: 'danger', error, errorDetail: ex.message });

--- a/src/ContainerRenameModal.jsx
+++ b/src/ContainerRenameModal.jsx
@@ -15,7 +15,7 @@ import * as utils from './util.js';
 
 const _ = cockpit.gettext;
 
-const ContainerRenameModal = ({ container, updateContainer }) => {
+const ContainerRenameModal = ({ con, container, updateContainer }) => {
     const Dialogs = useDialogs();
     const [name, setName] = useState(container.Name);
     const { version } = utils.usePodmanInfo();
@@ -44,12 +44,12 @@ const ContainerRenameModal = ({ container, updateContainer }) => {
 
         setNameError(null);
         setDialogError(null);
-        client.renameContainer(container.uid, container.Id, { name })
+        client.renameContainer(con, container.Id, { name })
                 .then(() => {
                     Dialogs.close();
                     // HACK: This is a workaround for missing API rename event in Podman versions less than 4.1.
                     if (version.localeCompare("4.1", undefined, { numeric: true, sensitivity: 'base' }) < 0) {
-                        updateContainer(container.Id, container.uid); // not-covered: only on old version
+                        updateContainer(con, container.Id); // not-covered: only on old version
                     }
                 })
                 .catch(ex => {

--- a/src/ContainerRestoreModal.jsx
+++ b/src/ContainerRestoreModal.jsx
@@ -12,7 +12,7 @@ import * as client from './client.js';
 
 const _ = cockpit.gettext;
 
-const ContainerRestoreModal = ({ containerWillRestore, onAddNotification }) => {
+const ContainerRestoreModal = ({ con, containerWillRestore, onAddNotification }) => {
     const Dialogs = useDialogs();
 
     const [inProgress, setInProgress] = useState(false);
@@ -23,7 +23,7 @@ const ContainerRestoreModal = ({ containerWillRestore, onAddNotification }) => {
 
     const handleRestoreContainer = () => {
         setInProgress(true);
-        client.postContainer(containerWillRestore.uid, "restore", containerWillRestore.Id, {
+        client.postContainer(con, "restore", containerWillRestore.Id, {
             keep,
             tcpEstablished,
             ignoreStaticIP,

--- a/src/ContainerTerminal.jsx
+++ b/src/ContainerTerminal.jsx
@@ -115,7 +115,7 @@ class ContainerTerminal extends React.Component {
         const realWidth = this.term._core._renderService.dimensions.css.cell.width;
         const cols = Math.floor((width - padding) / realWidth);
         this.term.resize(cols, 24);
-        client.resizeContainersTTY(this.props.uid, this.state.sessionId, this.props.tty, cols, 24)
+        client.resizeContainersTTY(this.props.con, this.state.sessionId, this.props.tty, cols, 24)
                 .catch(e => this.setState({ errorMessage: e.message }));
     }
 
@@ -190,7 +190,7 @@ class ContainerTerminal extends React.Component {
     }
 
     execAndConnect() {
-        client.execContainer(this.props.uid, this.state.container)
+        client.execContainer(this.props.con, this.state.container)
                 .then(r => {
                     const address = rest.getAddress(this.props.uid);
                     const channel = cockpit.channel({
@@ -273,6 +273,7 @@ class ContainerTerminal extends React.Component {
 }
 
 ContainerTerminal.propTypes = {
+    con: PropTypes.object.isRequired,
     containerId: PropTypes.string.isRequired,
     containerStatus: PropTypes.string.isRequired,
     width: PropTypes.number.isRequired,

--- a/src/ImageDeleteModal.jsx
+++ b/src/ImageDeleteModal.jsx
@@ -22,7 +22,7 @@ function sortTags(a, b) {
     return a.localeCompare(b);
 }
 
-export const ImageDeleteModal = ({ imageWillDelete, onAddNotification }) => {
+export const ImageDeleteModal = ({ con, imageWillDelete, onAddNotification }) => {
     const Dialogs = useDialogs();
     const repoTags = imageWillDelete.RepoTags ? imageWillDelete.RepoTags : [];
     const isIntermediateImage = repoTags.length === 0;
@@ -45,7 +45,7 @@ export const ImageDeleteModal = ({ imageWillDelete, onAddNotification }) => {
     const handleRemoveImage = (tags, all, close_dialog = true) => {
         const handleForceRemoveImage = () => {
             Dialogs.close();
-            return client.delImage(imageWillDelete.uid, imageWillDelete.Id, true)
+            return client.delImage(con, imageWillDelete.Id, true)
                     .catch(ex => {
                         const error = cockpit.format(_("Failed to force remove image $0"), imageWillDelete.RepoTags[0]);
                         onAddNotification({ type: 'danger', error, errorDetail: ex.message });
@@ -57,7 +57,7 @@ export const ImageDeleteModal = ({ imageWillDelete, onAddNotification }) => {
         }
 
         if (all) {
-            client.delImage(imageWillDelete.uid, imageWillDelete.Id, false)
+            client.delImage(con, imageWillDelete.Id, false)
                     .catch(ex => {
                         Dialogs.show(<ForceRemoveModal name={isIntermediateImage ? _("intermediate image") : repoTags[0]}
                                                        handleForceRemove={handleForceRemoveImage}
@@ -67,7 +67,7 @@ export const ImageDeleteModal = ({ imageWillDelete, onAddNotification }) => {
             // Call another untag once previous one resolved. Calling all at once can result in undefined behavior
             const tag = tags.shift();
             const i = tag.lastIndexOf(":");
-            client.untagImage(imageWillDelete.uid, imageWillDelete.Id, tag.substring(0, i), tag.substring(i + 1, tag.length))
+            client.untagImage(con, imageWillDelete.Id, tag.substring(0, i), tag.substring(i + 1, tag.length))
                     .then(() => {
                         if (tags.length > 0)
                             handleRemoveImage(tags, all, false);

--- a/src/ImageHistory.jsx
+++ b/src/ImageHistory.jsx
@@ -17,19 +17,18 @@ const IdColumn = Id => {
     return Id;
 };
 
-const ImageDetails = ({ image }) => {
+const ImageDetails = ({ con, image }) => {
     const [history, setHistory] = useState([]);
     const [error, setError] = useState(null);
-    const uid = image.uid;
     const id = image.Id;
 
     useEffect(() => {
-        client.imageHistory(uid, id).then(setHistory)
+        client.imageHistory(con, id).then(setHistory)
                 .catch(ex => {
                     console.error("Cannot get image history", ex);
                     setError(true);
                 });
-    }, [uid, id]);
+    }, [con, id]);
 
     const columns = ["ID", _("Created"), _("Created by"), _("Size"), _("Comments")];
     let showComments = false;

--- a/src/ImageSearchModal.jsx
+++ b/src/ImageSearchModal.jsx
@@ -122,7 +122,7 @@ export const ImageSearchModal = ({ downloadImage, users }) => {
         if (activeConnection)
             activeConnection.close();
         Dialogs.close();
-        downloadImage(selectedImageName, imageTag, user.uid);
+        downloadImage(selectedImageName, imageTag, user.con);
     };
 
     const handleClose = () => {

--- a/src/PodActions.jsx
+++ b/src/PodActions.jsx
@@ -16,7 +16,7 @@ import * as client from './client.js';
 
 const _ = cockpit.gettext;
 
-const PodDeleteModal = ({ pod }) => {
+const PodDeleteModal = ({ con, pod }) => {
     const Dialogs = useDialogs();
     const [deleteError, setDeleteError] = useState(null);
     const [force, setForce] = useState(false);
@@ -24,7 +24,7 @@ const PodDeleteModal = ({ pod }) => {
     const containers = (pod.Containers || []).filter(ct => ct.Id !== pod.InfraId);
 
     function handlePodDelete() {
-        client.delPod(pod.uid, pod.Id, force)
+        client.delPod(con, pod.Id, force)
                 .then(() => {
                     Dialogs.close();
                 })
@@ -69,7 +69,7 @@ const PodDeleteModal = ({ pod }) => {
     );
 };
 
-export const PodActions = ({ onAddNotification, pod }) => {
+export const PodActions = ({ con, onAddNotification, pod }) => {
     const Dialogs = useDialogs();
 
     const dropdownItems = [];
@@ -79,7 +79,7 @@ export const PodActions = ({ onAddNotification, pod }) => {
             <DropdownItem key="action-stop"
                               className="pod-action-stop"
                               onClick={() =>
-                                  client.postPod(pod.uid, "stop", pod.Id, {})
+                                  client.postPod(con, "stop", pod.Id, {})
                                           .catch(ex => {
                                               const error = cockpit.format(_("Failed to stop pod $0"), pod.Name);
                                               onAddNotification({ type: 'danger', error, errorDetail: ex.message });
@@ -90,7 +90,7 @@ export const PodActions = ({ onAddNotification, pod }) => {
             <DropdownItem key="action-force-stop"
                               className="pod-action-force-stop"
                               onClick={() =>
-                                  client.postPod(pod.uid, "stop", pod.Id, { t: 0 })
+                                  client.postPod(con, "stop", pod.Id, { t: 0 })
                                           .catch(ex => {
                                               const error = cockpit.format(_("Failed to force stop pod $0"), pod.Name);
                                               onAddNotification({ type: 'danger', error, errorDetail: ex.message });
@@ -101,7 +101,7 @@ export const PodActions = ({ onAddNotification, pod }) => {
             <DropdownItem key="action-restart"
                               className="pod-action-restart"
                               onClick={() =>
-                                  client.postPod(pod.uid, "restart", pod.Id, {})
+                                  client.postPod(con, "restart", pod.Id, {})
                                           .catch(ex => {
                                               const error = cockpit.format(_("Failed to restart pod $0"), pod.Name);
                                               onAddNotification({ type: 'danger', error, errorDetail: ex.message });
@@ -112,7 +112,7 @@ export const PodActions = ({ onAddNotification, pod }) => {
             <DropdownItem key="action-force-restart"
                               className="pod-action-force-restart"
                               onClick={() =>
-                                  client.postPod(pod.uid, "restart", pod.Id, { t: 0 })
+                                  client.postPod(con, "restart", pod.Id, { t: 0 })
                                           .catch(ex => {
                                               const error = cockpit.format(_("Failed to force restart pod $0"), pod.Name);
                                               onAddNotification({ type: 'danger', error, errorDetail: ex.message });
@@ -127,7 +127,7 @@ export const PodActions = ({ onAddNotification, pod }) => {
             <DropdownItem key="action-start"
                               className="pod-action-start"
                               onClick={() =>
-                                  client.postPod(pod.uid, "start", pod.Id, {})
+                                  client.postPod(con, "start", pod.Id, {})
                                           .catch(ex => {
                                               const error = cockpit.format(_("Failed to start pod $0"), pod.Name);
                                               onAddNotification({ type: 'danger', error, errorDetail: ex.message });
@@ -142,7 +142,7 @@ export const PodActions = ({ onAddNotification, pod }) => {
             <DropdownItem key="action-unpause"
                               className="pod-action-unpause"
                               onClick={() =>
-                                  client.postPod(pod.uid, "unpause", pod.Id, {})
+                                  client.postPod(con, "unpause", pod.Id, {})
                                           .catch(ex => {
                                               const error = cockpit.format(_("Failed to resume pod $0"), pod.Name);
                                               onAddNotification({ type: 'danger', error, errorDetail: ex.message });
@@ -157,7 +157,7 @@ export const PodActions = ({ onAddNotification, pod }) => {
             <DropdownItem key="action-pause"
                               className="pod-action-pause"
                               onClick={() =>
-                                  client.postPod(pod.uid, "pause", pod.Id, {})
+                                  client.postPod(con, "pause", pod.Id, {})
                                           .catch(ex => {
                                               const error = cockpit.format(_("Failed to pause pod $0"), pod.Name);
                                               onAddNotification({ type: 'danger', error, errorDetail: ex.message });
@@ -175,7 +175,7 @@ export const PodActions = ({ onAddNotification, pod }) => {
         <DropdownItem key="action-delete"
                           className="pod-action-delete pf-m-danger"
                           onClick={() => {
-                              Dialogs.show(<PodDeleteModal pod={pod} />);
+                              Dialogs.show(<PodDeleteModal con={con} pod={pod} />);
                           }}
                           component="button">
             {_("Delete")}

--- a/src/PodCreateModal.jsx
+++ b/src/PodCreateModal.jsx
@@ -87,7 +87,7 @@ export const PodCreateModal = ({ users }) => {
         if (!validateForm())
             return;
         setInProgress(true);
-        client.createPod(owner.uid, getCreateConfig())
+        client.createPod(owner.con, getCreateConfig())
                 .then(Dialogs.close)
                 .catch(ex => {
                     setInProgress(false);

--- a/src/PruneUnusedContainersModal.jsx
+++ b/src/PruneUnusedContainersModal.jsx
@@ -47,9 +47,11 @@ const PruneUnusedContainersModal = ({ close, unusedContainers, onAddNotification
     const handlePruneUnusedContainers = () => {
         setPruning(true);
 
+        const con_for = uid => users.find(u => u.uid === uid).con;
+
         const actions = unusedContainers
                 .filter(u => selectedContainerKeys.includes(u.key))
-                .map(u => client.delContainer(u.uid, u.id, true));
+                .map(u => client.delContainer(con_for(u.uid), u.id, true));
 
         Promise.all(actions).then(close)
                 .catch(ex => {

--- a/src/PruneUnusedImagesModal.jsx
+++ b/src/PruneUnusedImagesModal.jsx
@@ -65,7 +65,7 @@ const PruneUnusedImagesModal = ({ close, unusedImages, onAddNotification, users 
     const handlePruneUnusedImages = () => {
         setPruning(true);
 
-        const actions = deleteOwners.map(owner => client.pruneUnusedImages(owner.uid));
+        const actions = deleteOwners.map(owner => client.pruneUnusedImages(owner.con));
         Promise.all(actions).then(close)
                 .catch(ex => {
                     const error = _("Failed to prune unused images");

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -616,6 +616,9 @@ class Application extends React.Component {
             );
         }
 
+        if (this.state.users.find(u => u.con === null && (u.uid === 0 || u.uid === null))) // not initialized yet
+            return null;
+
         let imageContainerList = {};
         if (this.state.containers !== null) {
             Object.keys(this.state.containers).forEach(c => {

--- a/src/rest.js
+++ b/src/rest.js
@@ -40,13 +40,15 @@ function getAddress(uid) {
     throw new Error(`getAddress: uid ${uid} not supported`);
 }
 
-/* uid: null for logged in session user; 0 for root; in the future we'll support other users */
+/* uid: null for logged in session user; 0 for root; in the future we'll support other users
+ * Returns a connection object with methods monitor(), call(), and close(), and an `uid` property.
+ */
 function connect(uid) {
     const addr = getAddress(uid);
     /* This doesn't create a channel until a request */
     /* HACK: use binary channel to work around https://github.com/cockpit-project/cockpit/issues/19235 */
     const http = cockpit.http(addr.path, { superuser: addr.superuser, binary: true });
-    const connection = {};
+    const connection = { uid };
     const decoder = new TextDecoder();
     const user_str = (uid === null) ? "user" : (uid === 0) ? "root" : `uid ${uid}`;
 
@@ -109,19 +111,7 @@ function connect(uid) {
     return connection;
 }
 
-/*
- * Connects to the podman service, performs a single call, and closes the
- * connection.
- */
-async function call (uid, parameters) {
-    const connection = connect(uid);
-    const result = await connection.call(parameters);
-    connection.close();
-    return result;
-}
-
 export default {
     connect,
-    call,
     getAddress,
 };

--- a/test/check-application
+++ b/test/check-application
@@ -3087,7 +3087,7 @@ WantedBy=multi-user.target default.target
 
         # Nginx config simulates behavior of ghcr.io in terms of `podman search` and `podman manifest inspect`
         self.write_file("/etc/nginx/conf.d/default.conf", NGINX_DEFAULT_CONF,
-            post_restore_action="systemctl stop nginx.service; setsebool -P httpd_can_network_connect 0")
+                        post_restore_action="systemctl stop nginx.service; setsebool -P httpd_can_network_connect 0")
         self.execute(True, """
             setsebool -P httpd_can_network_connect 1
             systemctl start nginx.service


### PR DESCRIPTION
Keep the `connection` and underlying `cockpit.http()` object for each user, and change the client.js API to take a connection object instead of an uid.

With that we don't have to create a new HTTP connection for each request (thus more efficient), and gain the possibility to close a running monitor of a particular user (which will become important for multi-user support).

---

Part of https://issues.redhat.com/browse/COCKPIT-1086