### PR TITLE
Fix navigation bugs

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -116,13 +116,12 @@ class Application extends React.Component {
             textFilter: value
         });
 
-        const options = this.state.location;
-        if (value === "") {
+        const options = { ...this.state.location };
+        if (value === "")
             delete options.name;
-            this.updateUrl(Object.assign(options));
-        } else {
-            this.updateUrl(Object.assign(this.state.location, { name: value }));
-        }
+        else
+            options.name = value;
+        this.updateUrl(options);
     }
 
     onOwnerChanged(value) {
@@ -130,13 +129,12 @@ class Application extends React.Component {
             ownerFilter: value
         });
 
-        const options = this.state.location;
-        if (value == "all") {
+        const options = { ...this.state.location };
+        if (value == "all")
             delete options.owner;
-            this.updateUrl(Object.assign(options));
-        } else {
-            this.updateUrl(Object.assign(options, { owner: value.toString() }));
-        }
+        else
+            options.owner = value.toString();
+        this.updateUrl(options);
     }
 
     onContainerFilterChanged(value) {

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -570,8 +570,11 @@ class Application extends React.Component {
                     const uid = parseInt(options.owner);
                     if (!isNaN(uid))
                         this.setState({ ownerFilter: uid });
-                    else
+                    else {
                         console.log("Ignoring invalid URL owner value:", options.owner);
+                        // go back to previous valid filter
+                        this.onOwnerChanged(this.state.ownerFilter);
+                    }
                 }
             }
         });

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -563,13 +563,13 @@ class Application extends React.Component {
                     this.onContainerFilterChanged(options.container);
                 }
                 if (["user", "all"].includes(options.owner)) {
-                    this.onOwnerChanged(options.owner);
+                    this.setState({ ownerFilter: options.owner });
                 } else if (options.owner === undefined) {
-                    this.onOwnerChanged("all");
+                    this.setState({ ownerFilter: "all" });
                 } else {
                     const uid = parseInt(options.owner);
                     if (!isNaN(uid))
-                        this.onOwnerChanged(uid);
+                        this.setState({ ownerFilter: uid });
                     else
                         console.log("Ignoring invalid URL owner value:", options.owner);
                 }

--- a/test/check-application
+++ b/test/check-application
@@ -699,6 +699,11 @@ WantedBy=multi-user.target default.target
             b.go("#/?owner=user")
             verify_user()
 
+            # changing to an invalid user keeps the current filter
+            b.go("#/?owner=huh")
+            b.wait_js_cond('window.location.hash === "#/?owner=user"')
+            verify_user()
+
             b.set_val("#containers-containers-owner", "all")
             self.waitNumImages(self.user_images_count + self.system_images_count)
             self.waitNumContainers(2, auth=True)


### PR DESCRIPTION
I noticed these while working on #2020.  On initial load or change URL, these functions were called:

> onNavigate Object { path: [], href: "/?owner=0", url_root: "", options: {…} }
> onOwnerChanged 0
> updateUrl Object { owner: "0" }

When changing the owner selector it was even more pronounced and shows the loop:

> onOwnerChanged user
> updateUrl Object { owner: "user" }
> onNavigate Object { path: [], href: "/?owner=user", url_root: "", options: {…} }
> onOwnerChanged user
> updateUrl Object { owner: "user" }

With this PR, the initial load or URL change just triggers

> onNavigate Object { path: [], href: "/", url_root: "", options: {} }

and changing the owner selector:

> onOwnerChanged 0
> updateUrl Object { owner: "0" }
> onNavigate Object { path: [], href: "/?owner=0", url_root: "", options: {…} }
