### PR TITLE
Ignore localhost registry and untagged images in "Pull all images"

### DIFF
--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -72,9 +72,13 @@ class Images extends React.Component {
         Dialogs.show(<ImageSearchModal downloadImage={this.downloadImage} users={this.props.users} />);
     };
 
-    onPullAllImages = () => {
-        Object.values(this.props.images).forEach((image) => this.downloadImage(utils.image_name(image), null, image.uid));
-    };
+    onPullAllImages = () => Object.values(this.props.images).forEach(image => {
+        // ignore nameless (intermediate) images and the localhost/ pseudo-registry (which cannot be pulled)
+        if (image.RepoTags?.find(tag => !tag.startsWith("localhost/")))
+            this.downloadImage(image.RepoTags[0], null, image.uid);
+        else
+            utils.debug("onPullAllImages: ignoring image", image);
+    });
 
     onOpenPruneUnusedImagesDialog = () => {
         this.setState({ showPruneUnusedImagesModal: true });

--- a/test/check-application
+++ b/test/check-application
@@ -1337,19 +1337,13 @@ WantedBy=multi-user.target default.target
         buildImage(image2, 10, auth=False)
         image2_sha = self.execute(False, f"podman inspect --format '{{{{.Id}}}}' {image2}").strip()
 
-        self.execute(False, """
-            podman rmi localhost/test-busybox:latest
-            podman rmi localhost/test-alpine:latest
-
-            # Remove registry container
-            podman rmi localhost/test-registry:latest
-        """)
-
         # Ubuntu has an old podman which ships with a k8s image
         if m.image == "ubuntu-2204":
             self.execute(False, "podman rmi k8s.gcr.io/pause:3.5")
+            self.user_images_count -= 1
+            b.wait_not_in_text("#containers-images", "pause")
 
-        b.wait_in_text("#containers-images", "2 images")
+        b.wait_in_text("#containers-images", f"{self.user_images_count + 2} images")
         b.click("#image-actions-dropdown")
         b.click("button:contains(Pull all images)")
         b.wait_in_text("div.download-in-progress", "Pulling")
@@ -1361,6 +1355,16 @@ WantedBy=multi-user.target default.target
         # assert the image size changed
         b.wait(lambda: getImageSize(image1) > 20)
         b.wait(lambda: getImageSize(image2) > 40)
+
+        # after pulling the two test-images, we now have two <none>:<none> intermediate images
+        # pulling all images ignores them
+        b.wait_in_text("#containers-images", f"{self.user_images_count + 4} images")
+        b.click("#image-actions-dropdown")
+        b.click("button:contains(Pull all images)")
+        b.wait_in_text("div.download-in-progress", "Pulling")
+        b.wait_not_present("div.download-in-progress")
+        b.wait_not_present('.pf-v5-c-alert__title')
+        b.wait_in_text("#containers-images", f"{self.user_images_count + 4} images")
 
     def testLifecycleOperationsUser(self) -> None:
         self._testLifecycleOperations(False)

--- a/test/check-application
+++ b/test/check-application
@@ -1353,8 +1353,8 @@ WantedBy=multi-user.target default.target
         b.click("#image-actions-dropdown")
         b.click("button:contains(Pull all images)")
         b.wait_in_text("div.download-in-progress", "Pulling")
-        b.wait_not_present('h4.pf-v5-c-alert__title:contains("Failed to download image")')
         b.wait_not_present("div.download-in-progress")
+        b.wait_not_present('.pf-v5-c-alert__title')
         b.wait_not_present(f"#containers-images tbody tr[data-row-id=\"user-{image1_sha}\"]".lower())
         b.wait_not_present(f"#containers-images tbody tr[data-row-id=\"user-{image2_sha}\"]".lower())
 


### PR DESCRIPTION
The test was cheating: It carefully removed all localhost/* images before "pull
all images". But that is a realistic situation -- anyone using any pod will at
least have a `localhost/pause` image.

It also does not make sense to use `utils.image_name()` for an API call -- this
is a human UI formatter, `<none>:<none>` is nonsensical for an image pull
request.

Fix onPullAllImages() to weed out tag-less and localhost/* only images, and
cover both cases in the tests.

Fixes #2025
