### PR TITLE
Quadlet support v2

### DIFF
--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -824,12 +824,14 @@ class Containers extends React.Component {
                                         let caption;
                                         let podStatus;
                                         let pod;
+                                        let isPodService = false;
                                         let con;
                                         if (section !== 'no-pod') {
                                             pod = this.props.pods[section];
                                             con = this.props.users.find(u => u.uid === pod.uid).con;
                                             tableProps['aria-label'] = cockpit.format("Containers of pod $0", pod.Name);
                                             podStatus = pod.Status;
+                                            isPodService = Boolean(pod.Labels?.PODMAN_SYSTEMD_UNIT);
                                             caption = pod.Name;
                                         } else {
                                             tableProps['aria-label'] = _("Containers");
@@ -838,12 +840,13 @@ class Containers extends React.Component {
                                         const actions = caption && (
                                             <>
                                                 <Badge isRead className={"ct-badge-pod-" + podStatus.toLowerCase()}>{_(podStatus)}</Badge>
+                                                {!isPodService &&
                                                 <Button variant="secondary"
                                                         className="create-container-in-pod"
                                                         isDisabled={nonIntermediateImages === null}
                                                         onClick={() => createContainer(this.props.pods[section])}>
                                                     {_("Create container in pod")}
-                                                </Button>
+                                                </Button>}
                                                 <PodActions con={con}
                                                             onAddNotification={this.props.onAddNotification}
                                                             pod={pod} />

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -380,7 +380,7 @@ class Containers extends React.Component {
                     <span className="container-name">{container.Name}</span>
                     {isToolboxContainer && <Badge className='ct-badge-toolbox'>toolbox</Badge>}
                     {isDistroboxContainer && <Badge className='ct-badge-distrobox'>distrobox</Badge>}
-                    {isSystemdService && <Badge className='ct-badge-service'>service</Badge>}
+                    {isSystemdService && <Badge className='ct-badge-service'>{_("service")}</Badge>}
                 </Flex>
                 <small>{image}</small>
                 <small>{utils.quote_cmdline(container.Config?.Cmd)}</small>

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -865,6 +865,7 @@ class Containers extends React.Component {
                                                         <Flex justifyContent={{ default: 'justifyContentFlexStart' }}>
                                                             <h3 className='pod-name'>{caption}</h3>
                                                             <span>{_("pod")}</span>
+                                                            {isPodService && <Badge className='ct-badge-service'>{_("service")}</Badge>}
                                                             {this.renderPodDetails(this.props.pods[section], podStatus)}
                                                         </Flex>
                                                     </CardTitle>

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -239,14 +239,16 @@ const ContainerActions = ({ con, container, onAddNotification, localImages, upda
         </DropdownItem>
     );
 
-    actions.push(<Divider key="separator-2" />);
-    actions.push(
-        <DropdownItem key="delete"
+    if (!isSystemdService) {
+        actions.push(<Divider key="separator-2" />);
+        actions.push(
+            <DropdownItem key="delete"
                       className="pf-m-danger"
                       onClick={deleteContainer}>
-            {_("Delete")}
-        </DropdownItem>
-    );
+                {_("Delete")}
+            </DropdownItem>
+        );
+    }
 
     return <KebabDropdown position="right" dropdownItems={actions} isDisabled={isDownloading} />;
 };

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -160,44 +160,51 @@ const ContainerActions = ({ con, container, onAddNotification, localImages, upda
 
     const actions = [];
     if (isRunning || isPaused) {
-        actions.push(
-            <DropdownItem key="stop"
+        // TODO: cockpit-podman currently isn't aware of podman quadlets as they don't keep containers around when stopped, failed or not yet started by default.
+        // Allowing a user to stop or restart a container can result in the container disappearing from the list without a way to start it again. Until cockpit-podman
+        // can list quadlets these actions are disabled.
+        if (!isSystemdService) {
+            actions.push(
+                <DropdownItem key="stop"
                           onClick={() => stopContainer()}>
-                {_("Stop")}
-            </DropdownItem>,
-            <DropdownItem key="force-stop"
+                    {_("Stop")}
+                </DropdownItem>,
+                <DropdownItem key="force-stop"
                           onClick={() => stopContainer(true)}>
-                {_("Force stop")}
-            </DropdownItem>,
-            <DropdownItem key="restart"
+                    {_("Force stop")}
+                </DropdownItem>,
+                <DropdownItem key="restart"
                           onClick={() => restartContainer()}>
-                {_("Restart")}
-            </DropdownItem>,
-            <DropdownItem key="force-restart"
+                    {_("Restart")}
+                </DropdownItem>,
+                <DropdownItem key="force-restart"
                           onClick={() => restartContainer(true)}>
-                {_("Force restart")}
-            </DropdownItem>
-        );
+                    {_("Force restart")}
+                </DropdownItem>
+            );
 
-        if (!isPaused) {
-            actions.push(
-                <DropdownItem key="pause"
+            if (!isPaused) {
+                actions.push(
+                    <DropdownItem key="pause"
                           onClick={() => pauseContainer()}>
-                    {_("Pause")}
-                </DropdownItem>
-            );
-        } else {
-            actions.push(
-                <DropdownItem key="resume"
+                        {_("Pause")}
+                    </DropdownItem>
+                );
+            } else {
+                actions.push(
+                    <DropdownItem key="resume"
                           onClick={() => resumeContainer()}>
-                    {_("Resume")}
-                </DropdownItem>
-            );
+                        {_("Resume")}
+                    </DropdownItem>
+                );
+            }
         }
 
         if (container.uid == 0 && !isPaused) {
+            if (actions.length > 0)
+                actions.push(<Divider key="separator-0" />);
+
             actions.push(
-                <Divider key="separator-0" />,
                 <DropdownItem key="checkpoint"
                               onClick={() => checkpointContainer()}>
                     {_("Checkpoint")}
@@ -849,7 +856,9 @@ class Containers extends React.Component {
                                                 </Button>}
                                                 <PodActions con={con}
                                                             onAddNotification={this.props.onAddNotification}
-                                                            pod={pod} />
+                                                            pod={pod}
+                                                            isPodService={isPodService}
+                                                />
                                             </>
                                         );
                                         return (

--- a/src/PodActions.jsx
+++ b/src/PodActions.jsx
@@ -69,7 +69,7 @@ const PodDeleteModal = ({ con, pod }) => {
     );
 };
 
-export const PodActions = ({ con, onAddNotification, pod }) => {
+export const PodActions = ({ con, onAddNotification, pod, isPodService }) => {
     const Dialogs = useDialogs();
 
     const dropdownItems = [];
@@ -190,6 +190,7 @@ export const PodActions = ({ con, onAddNotification, pod }) => {
             toggleButtonId={"pod-" + pod.Name + (pod.uid === 0 ? "-system" : "-user") + "-action-toggle"}
             position="right"
             dropdownItems={dropdownItems}
+            isDisabled={isPodService}
         />
     );
 };

--- a/src/podman.scss
+++ b/src/podman.scss
@@ -108,6 +108,13 @@
     }
 }
 
+/* Override the card's font-family RedHatDisplay for the service Badge so it
+ * looks consistent with a normal container service badge.
+ */
+.pf-v5-c-card__title-text .ct-badge-service {
+    font-family: var(--pf-v5-global--FontFamily--text);
+}
+
 .green {
     color: var(--pf-v5-global--success-color--100);
 }

--- a/test/check-application
+++ b/test/check-application
@@ -300,7 +300,6 @@ WantedBy=multi-user.target default.target
         self.write_file(service_file, quadlet)
         self.addCleanup(self.execute, auth, f"{systemctl_cmd} stop {name}.service")
         self.execute(auth, f"{systemctl_cmd} daemon-reload; {systemctl_cmd} start {name}.service")
-        self.execute(auth, f"until {systemctl_cmd} is-active {name}.service; do sleep 1; done")
 
     def testPods(self) -> None:
         b = self.browser

--- a/test/check-application
+++ b/test/check-application
@@ -3206,6 +3206,31 @@ WantedBy=multi-user.target default.target
         self.performContainerAction(IMG_ALPINE, "Start")
         b.wait(lambda: self.getContainerAttr("sys1", "State") == "Running")
 
+    def _testQuadlets(self, *, system: bool = False) -> None:
+        b = self.browser
+        self.login(system=system)
+
+        service_name = "quak"
+        self.createQuadlet(service_name, auth=system)
+        self.waitContainerRow(service_name)
+
+        # Cannot delete a quadlet container, they are managed by .container units
+        b.click(f"#containers-containers tbody tr:contains('{service_name}') .pf-v5-c-menu-toggle")
+        b.wait_visible(self.getContainerAction(service_name, 'Commit'))
+        b.wait_not_present(self.getContainerAction(service_name, 'Delete'))
+        b.click(f"#containers-containers tbody tr:contains('{service_name}') .pf-v5-c-menu-toggle")
+        b.wait_not_present('.pf-v5-c-menu__item')
+
+    # HACK: quadlets broken on RHEL-8 https://issues.redhat.com/browse/RHEL-5870
+    @testlib.skipImage("no quadlet support", "debian-stable", "ubuntu-2204", "rhel-8-10")
+    def testQuadletsSystem(self):
+        self._testQuadlets(system=True)
+
+    # HACK: quadlets broken on RHEL-8 https://issues.redhat.com/browse/RHEL-5870
+    @testlib.skipImage("no quadlet support", "debian-stable", "ubuntu-2204", "rhel-8-10")
+    def testQuadletsUsers(self):
+        self._testQuadlets(system=False)
+
 
 if __name__ == '__main__':
     testlib.test_main()

--- a/test/check-application
+++ b/test/check-application
@@ -3232,16 +3232,24 @@ PodName={name}
         self.createQuadlet(service_name, auth=system)
         self.waitContainerRow(service_name)
 
-        # Cannot delete a quadlet container, they are managed by .container units
         b.click(f"#containers-containers tbody tr:contains('{service_name}') .pf-v5-c-menu-toggle")
         b.wait_visible(self.getContainerAction(service_name, 'Commit'))
+
+        # Cannot delete a quadlet container, they are managed by .container units
         b.wait_not_present(self.getContainerAction(service_name, 'Delete'))
+
+        # Lifecycle operations are not available such as Stop/Restart/Pause
+        b.wait_not_present(self.getContainerAction(service_name, 'Stop'))
+        b.wait_not_present(self.getContainerAction(service_name, 'Restart'))
+        b.wait_not_present(self.getContainerAction(service_name, 'Pause'))
+
         b.click(f"#containers-containers tbody tr:contains('{service_name}') .pf-v5-c-menu-toggle")
         b.wait_not_present('.pf-v5-c-menu__item')
 
         # Quadlet pod support was introduced in podman 5.0.0
         if podman_version(self) >= (5, 0, 0):
             podName = "homeassistant"
+            podOwner = "system" if system else "user"
             self.createQuadletPod(podName, auth=system)
             self.createQuadlet("zigbee", podName=podName, auth=system)
             self.waitPodRow(podName, present=True)
@@ -3255,6 +3263,9 @@ PodName={name}
 
             # Quadlet pods are shown as a service group
             b.wait_visible("#table-homeassistant .pf-v5-c-card__header .ct-badge-service:contains('service')")
+
+            # Lifecycle operations are not available such as Start/Restart
+            b.wait_visible(f"#pod-{podName}-{podOwner}-action-toggle:disabled")
 
     # HACK: quadlets broken on RHEL-8 https://issues.redhat.com/browse/RHEL-5870
     @testlib.skipImage("no quadlet support", "debian-stable", "ubuntu-2204", "rhel-8-10")

--- a/test/check-application
+++ b/test/check-application
@@ -3253,6 +3253,9 @@ PodName={name}
             # Cannot create a container in a pod
             b.wait_not_present(".create-container-in-pod")
 
+            # Quadlet pods are shown as a service group
+            b.wait_visible("#table-homeassistant .pf-v5-c-card__header .ct-badge-service:contains('service')")
+
     # HACK: quadlets broken on RHEL-8 https://issues.redhat.com/browse/RHEL-5870
     @testlib.skipImage("no quadlet support", "debian-stable", "ubuntu-2204", "rhel-8-10")
     def testQuadletsSystem(self):

--- a/test/check-application
+++ b/test/check-application
@@ -276,7 +276,8 @@ class TestApplication(testlib.MachineCase):
         m.write("/etc/containers/registries.conf", REGISTRIES_CONF)
         self.execute(True, "systemctl stop podman.service")
 
-    def createQuadlet(self, name: str, *, auth: bool = False) -> None:
+    def createQuadlet(self, name: str, podName: str | None = None, *, auth: bool = False) -> None:
+        pod_option = f'Pod={podName}.pod' if podName else ''
         quadlet = f"""
 [Unit]
 Description=Podman - {name}
@@ -286,6 +287,7 @@ After=local-fs.target
 Image={IMG_BUSYBOX}
 Exec=sleep infinity
 ContainerName={name}
+{pod_option}
 
 [Install]
 WantedBy=multi-user.target default.target
@@ -300,6 +302,22 @@ WantedBy=multi-user.target default.target
         self.write_file(service_file, quadlet)
         self.addCleanup(self.execute, auth, f"{systemctl_cmd} stop {name}.service")
         self.execute(auth, f"{systemctl_cmd} daemon-reload; {systemctl_cmd} start {name}.service")
+
+    def createQuadletPod(self, name: str, *, auth: bool = False) -> None:
+        quadlet = f"""
+[Pod]
+PodName={name}
+"""
+        service_file = f"/etc/containers/systemd/{name}.pod"
+        if not auth:  # user session
+            service_file = f"/home/admin/.config/containers/systemd/{name}.pod"
+
+        systemctl_cmd = "systemctl" if auth else "systemctl --user"
+        self.addCleanup(self.execute, auth, f"{systemctl_cmd} daemon-reload")
+        self.write_file(service_file, quadlet)
+        self.addCleanup(self.execute, auth, f"{systemctl_cmd} stop {name}-pod.service")
+        self.execute(auth, f"{systemctl_cmd} daemon-reload; {systemctl_cmd} start {name}-pod.service")
+        self.execute(auth, f"until {systemctl_cmd} is-active {name}-pod.service; do sleep 1; done")
 
     def testPods(self) -> None:
         b = self.browser
@@ -3220,6 +3238,20 @@ WantedBy=multi-user.target default.target
         b.wait_not_present(self.getContainerAction(service_name, 'Delete'))
         b.click(f"#containers-containers tbody tr:contains('{service_name}') .pf-v5-c-menu-toggle")
         b.wait_not_present('.pf-v5-c-menu__item')
+
+        # Quadlet pod support was introduced in podman 5.0.0
+        if podman_version(self) >= (5, 0, 0):
+            podName = "homeassistant"
+            self.createQuadletPod(podName, auth=system)
+            self.createQuadlet("zigbee", podName=podName, auth=system)
+            self.waitPodRow(podName, present=True)
+            containerId = self.execute(system, "podman inspect --format '{{.Id}}' zigbee").strip()
+            self.waitPodContainer("homeassistant", [{"name": "zigbee", "image": IMG_BUSYBOX,
+                                  "command": "sleep infinity", "state": "Running", "id": containerId}],
+                                  system=system)
+
+            # Cannot create a container in a pod
+            b.wait_not_present(".create-container-in-pod")
 
     # HACK: quadlets broken on RHEL-8 https://issues.redhat.com/browse/RHEL-5870
     @testlib.skipImage("no quadlet support", "debian-stable", "ubuntu-2204", "rhel-8-10")

--- a/test/vm.install
+++ b/test/vm.install
@@ -50,3 +50,8 @@ done
 # 15minutes after boot tmp files are removed and podman stores some tmp lock files
 systemctl disable --now systemd-tmpfiles-clean.timer
 systemctl --global disable systemd-tmpfiles-clean.timer
+
+# mitigate stupid/broken 90s timeout for user quadlet units
+# https://github.com/containers/podman/issues/22197#issuecomment-2728794702
+mkdir -p /etc/systemd/user/podman-user-wait-network-online.service.d
+printf '[Service]\nExecStart=\nExecStart=/bin/true\n' > /etc/systemd/user/podman-user-wait-network-online.service.d/disable.conf


### PR DESCRIPTION
This PR removes all lifecycle actions as stopping a quadlet container/pod or restarting (and having it fail) leads to the container/pod going away unexpectedly. That is because showing stopped/failed quadlets involves more work.

## UI Changes

Pod group is now shown as `pod service group`. (**outdated**)

![image](https://github.com/user-attachments/assets/f086a296-d486-4a57-baf7-c1e237befb0b)


Open discussion topic is if this should wait on a link to the service page where users can easily stop/restart their container/pods?