### PR TITLE
test: The debian-testing image now can do checkpoint/restore

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -149,7 +149,8 @@ class TestApplication(testlib.MachineCase):
         self.allow_journal_messages(".*/run.*/podman/podman.*Connection reset by peer")
 
         # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1008249
-        self.has_criu = "debian" not in m.image and "ubuntu" not in m.image
+        # Fixed in crun 1.20-1
+        self.has_criu = m.image != "debian-stable" and "ubuntu" not in m.image
         self.has_selinux = not any(img in m.image for img in ["arch", "debian", "ubuntu", "suse"])
         self.has_cgroupsV2 = not m.image.startswith('rhel-8')
         self.supports_quadlet = m.image not in ["debian-stable", "ubuntu-2204"]


### PR DESCRIPTION
Since crun 1.20 via https://github.com/cockpit-project/bots/pull/7498