### PR TITLE
Fix console junk and cockpit.http() streaming lock-ups

### DIFF
--- a/src/ContainerLogs.jsx
+++ b/src/ContainerLogs.jsx
@@ -113,19 +113,9 @@ class ContainerLogs extends React.Component {
         this.resize(this.props.width);
 
         const connection = rest.connect(this.props.uid);
-        const options = {
-            method: "GET",
-            path: client.VERSION + "libpod/containers/" + this.props.containerId + "/logs",
-            body: "",
-            binary: true,
-            params: {
-                follow: true,
-                stdout: true,
-                stderr: true,
-            },
-        };
-
-        connection.monitor(options, this.onStreamMessage, true)
+        connection.monitor(client.VERSION + "libpod/containers/" + this.props.containerId +
+                           "/logs?follow=true&stdout=true&stderr=true",
+                           this.onStreamMessage, true)
                 .then(this.onStreamClose)
                 .catch(e => {
                     const error = JSON.parse(new TextDecoder().decode(e.message));

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -494,18 +494,11 @@ class Application extends React.Component {
         this.updatePods(con);
 
         client.streamEvents(con, message => this.handleEvent(message, con))
-                .catch(e => console.error("init uid", uid, "streamEvents failed:", e.toString()))
-                .finally(() => this.cleanupAfterService(con));
-
-        // HACK: Listen for podman socket/service going away; this is only necessary with the C bridge
-        // (Debian 12, RHEL 8). With the Python bridge, the above streamEvents() resolves when the service goes away.
-        const address = rest.getAddress(uid);
-        const ch = cockpit.channel({ unix: address.path, superuser: address.superuser, payload: "stream" });
-        ch.addEventListener("close", () => {
-            console.log("init uid", uid, "podman service closed");
-            this.cleanupAfterService(con);
-        });
-        ch.send("GET " + client.VERSION + "libpod/events HTTP/1.0\r\nContent-Length: 0\r\n\r\n");
+                .catch(e => console.error("uid", uid, "streamEvents failed:", e.toString()))
+                .finally(() => {
+                    console.log("uid", uid, "podman service closed");
+                    this.cleanupAfterService(con);
+                });
     }
 
     componentDidMount() {

--- a/src/client.js
+++ b/src/client.js
@@ -10,16 +10,7 @@ const podmanCall = (con, name, method, args, body) => con.call({
 const podmanJson = (con, name, method, args, body) => podmanCall(con, name, method, args, body)
         .then(reply => JSON.parse(reply));
 
-const podmanMonitor = (con, name, method, args, callback) => con.monitor(
-    {
-        method,
-        path: VERSION + name,
-        body: "",
-        params: args
-    },
-    callback);
-
-export const streamEvents = (con, callback) => podmanMonitor(con, "libpod/events", "GET", {}, callback);
+export const streamEvents = (con, callback) => con.monitor(VERSION + "libpod/events", callback);
 
 export function getInfo(con) {
     return new Promise((resolve, reject) => {
@@ -33,7 +24,7 @@ export function getInfo(con) {
 
 export const getContainers = con => podmanJson(con, "libpod/containers/json", "GET", { all: true });
 
-export const streamContainerStats = (con, callback) => podmanMonitor(con, "libpod/containers/stats", "GET", { stream: true }, callback);
+export const streamContainerStats = (con, callback) => con.monitor(VERSION + "libpod/containers/stats", callback);
 
 export function inspectContainer(con, id) {
     const options = {

--- a/src/rest.js
+++ b/src/rest.js
@@ -19,6 +19,7 @@ function manage_error(reject, error, content) {
 let call_id = 0;
 
 const NL = '\n'.charCodeAt(0); // always 10, but avoid magic constant
+const CR = '\r'.charCodeAt(0); // always 13, but avoid magic constant
 
 const PODMAN_SYSTEM_ADDRESS = "/run/podman/podman.sock";
 
@@ -40,6 +41,17 @@ function getAddress(uid) {
     throw new Error(`getAddress: uid ${uid} not supported`);
 }
 
+// split an Uint8Array at \r\n\r\n (separate headers from body)
+function splitAtNLNL(array) {
+    for (let i = 0; i <= array.length - 4; i++) {
+        if (array[i] === CR && array[i + 1] === NL && array[i + 2] === CR && array[i + 3] === NL) {
+            return [array.subarray(0, i), array.subarray(i + 4)];
+        }
+    }
+    console.error("did not find NLNL in array", array); // not-covered: if this happens, it's a podman bug
+    return [array, null]; // not-covered: dito
+}
+
 /* uid: null for logged in session user; 0 for root; in the future we'll support other users
  * Returns a connection object with methods monitor(), call(), and close(), and an `uid` property.
  */
@@ -48,42 +60,10 @@ function connect(uid) {
     /* This doesn't create a channel until a request */
     /* HACK: use binary channel to work around https://github.com/cockpit-project/cockpit/issues/19235 */
     const http = cockpit.http(addr.path, { superuser: addr.superuser, binary: true });
+    const raw_channels = [];
     const connection = { uid };
     const decoder = new TextDecoder();
     const user_str = (uid === null) ? "user" : (uid === 0) ? "root" : `uid ${uid}`;
-
-    connection.monitor = function(options, callback, return_raw) {
-        return new Promise((resolve, reject) => {
-            let buffer = new Uint8Array();
-
-            http.request(options)
-                    .stream(data => {
-                        if (return_raw)
-                            callback(data);
-                        else {
-                            buffer = new Uint8Array([...buffer, ...data]);
-
-                            // split the buffer into lines on NL (this is safe with UTF-8)
-                            for (;;) {
-                                const idx = buffer.indexOf(NL);
-                                if (idx < 0)
-                                    break;
-
-                                const line = buffer.slice(0, idx);
-                                buffer = buffer.slice(idx + 1);
-
-                                const line_str = decoder.decode(line);
-                                debug(user_str, "monitor", line_str);
-                                callback(JSON.parse(line_str));
-                            }
-                        }
-                    })
-                    .catch((error, content) => {
-                        manage_error(reject, error, content);
-                    })
-                    .then(resolve);
-        });
-    };
 
     connection.call = function (options) {
         const id = call_id++;
@@ -104,8 +84,67 @@ function connect(uid) {
         });
     };
 
+    connection.monitor = function(path, callback, return_raw = false) {
+        return new Promise((resolve, reject) => {
+            const ch = cockpit.channel({ unix: addr.path, superuser: addr.superuser, payload: "stream", binary: true });
+            raw_channels.push(ch);
+            let buffer = new Uint8Array();
+
+            ch.addEventListener("close", () => {
+                debug(user_str, "monitor", path, "closed");
+                resolve();
+            });
+
+            const onHTTPMessage = message => {
+                const [headers_bin, body] = splitAtNLNL(message.detail);
+                const headers = decoder.decode(headers_bin);
+                debug(user_str, "monitor", path, "HTTP response:", headers);
+                if (headers.match(/^HTTP\/1.*\s+200\s/)) {
+                    // any further message is actual streaming data
+                    ch.removeEventListener("message", onHTTPMessage);
+                    ch.addEventListener("message", onDataMessage);
+
+                    // process the initial response data
+                    if (body)
+                        onDataMessage({ detail: body });
+                } else {
+                    manage_error(reject, { reason: headers.split('\r\n')[0] }, body);
+                }
+            };
+
+            const onDataMessage = message => {
+                if (return_raw) {
+                    // debug(user_str, "monitor", path, "raw data:", message.detail);
+                    callback(message.detail);
+                } else {
+                    buffer = new Uint8Array([...buffer, ...message.detail]);
+
+                    // split the buffer into lines on NL (this is safe with UTF-8)
+                    for (;;) {
+                        const idx = buffer.indexOf(NL);
+                        if (idx < 0)
+                            break;
+
+                        const line = buffer.slice(0, idx);
+                        buffer = buffer.slice(idx + 1);
+
+                        const line_str = decoder.decode(line);
+                        debug(user_str, "monitor", path, "data:", line_str);
+                        callback(JSON.parse(line_str));
+                    }
+                }
+            };
+
+            // the initial message is the HTTP status response
+            ch.addEventListener("message", onHTTPMessage);
+
+            ch.send("GET " + path + " HTTP/1.0\r\nContent-Length: 0\r\n\r\n");
+        });
+    };
+
     connection.close = function () {
         http.close();
+        raw_channels.forEach(ch => ch.close());
     };
 
     return connection;

--- a/test/check-application
+++ b/test/check-application
@@ -3147,6 +3147,38 @@ WantedBy=multi-user.target default.target
         b.wait_text("button.pf-v5-c-menu__item:not([disabled])", "localhost:5000/my-busybox:search-tag")
         b.wait_js_cond("document.querySelectorAll('.pf-v5-c-menu__item:not([disabled])').length === 1")
 
+    @testlib.skipImage("page does not survive this with the C bridge", "ubuntu-2204", "rhel-8-*")
+    def testReconnectStability(self):
+        # reloading the page reconnects to the podman services; make sure this works reliably
+        b = self.browser
+
+        self.execute(True, f"podman run -d --name sys1 --stop-timeout 0 {IMG_BUSYBOX} sleep infinity")
+        self.execute(False, f"podman run -d --name user1 --stop-timeout 0 {IMG_ALPINE} sleep infinity")
+        self.login()
+
+        for _ in range(10):
+            self.waitNumContainers(2, auth=True)
+            b.wait_text("#containers-containers tbody:nth-of-type(1) .container-name", "sys1")
+            b.wait_text("#containers-containers tbody:nth-of-type(2) .container-name", "user1")
+            b.wait(lambda: self.getContainerAttr("user1", "State") == "Running")
+            b.wait(lambda: self.getContainerAttr("sys1", "State") == "Running")
+
+            b.reload()
+            b.enter_page("/podman")
+            b.wait_visible("#app")
+
+        # system events still work
+        self.performContainerAction(IMG_BUSYBOX, "Force stop")
+        b.wait(lambda: self.getContainerAttr("sys1", "State") in NOT_RUNNING)
+        self.performContainerAction(IMG_BUSYBOX, "Start")
+        b.wait(lambda: self.getContainerAttr("sys1", "State") == "Running")
+
+        # user events still work
+        self.performContainerAction(IMG_ALPINE, "Force stop")
+        b.wait(lambda: self.getContainerAttr("user1", "State") in NOT_RUNNING)
+        self.performContainerAction(IMG_ALPINE, "Start")
+        b.wait(lambda: self.getContainerAttr("sys1", "State") == "Running")
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
See my woes in https://github.com/cockpit-project/cockpit-podman/pull/2024#issuecomment-2705655132 . This is a problem on current main already. I started with reproducing this in a test, the first run should make sure it actually fails on all OSes as expected -- it does on commit 987ef61b, like [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-2038-987ef61b-20250307-075845-fedora-42/log.html). Only debian-stable and rhel-8-10 are passing (with the C bridge).

The current PR version also includes the fix.

I realize this is rather odd. I put it onto my TODO list to reproduce this issue in cockpit's unit tests and fix that bug properly. But I've been chasing this for three days, and it's not going to be easy with the existing https://docs.python.org/3/library/http.client.html based implementation, we'll have to come up with something creative -- such as generalizing the approach here.