### PR TITLE
Fix "Run Image" dialog default owner

### DIFF
--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -82,7 +82,9 @@ export class ImageRunModal extends React.Component {
 
         const default_owner = this.props.pod
             ? this.props.users.find(u => u.uid === this.props.pod.uid)
-            : this.props.users[0];
+            : (this.props.image
+                ? this.props.users.find(u => u.uid === this.props.image.uid)
+                : this.props.users[0]);
 
         this.state = {
             command,

--- a/test/check-application
+++ b/test/check-application
@@ -1849,6 +1849,12 @@ WantedBy=multi-user.target default.target
 
         b.wait_visible("#run-image-dialog-command[value='sh']")
 
+        # shows Owner iff authenticated
+        if auth:
+            b.wait_visible("#run-image-dialog-owner-system:checked")
+        else:
+            b.wait_not_in_text(".pf-v5-c-modal-box", "Owner")
+
         # Check memory configuration
         # Only works with CGroupsV2
         if auth or self.has_cgroupsV2:

--- a/test/check-application
+++ b/test/check-application
@@ -1280,7 +1280,7 @@ WantedBy=multi-user.target default.target
 
         image1_sel = f"#containers-images tbody tr[data-row-id=\"0-{image1_sha}\"]".lower()
 
-        b.click("#containers-images button.pf-v5-c-expandable-section__toggle")
+        showImages(b)
         b.click(f'{image1_sel} .pf-v5-c-menu-toggle')
         b.click(image1_sel + " button.pf-v5-c-menu__item:contains('Pull')")
         b.wait_in_text("div.download-in-progress", "Pulling")
@@ -1817,8 +1817,7 @@ WantedBy=multi-user.target default.target
             self.execute(False, "podman rmi --all")
 
         self.login(system=auth)
-
-        b.click("#containers-images button.pf-v5-c-expandable-section__toggle")
+        showImages(b)
 
         b.wait_in_text("#containers-images", IMG_BUSYBOX)
         b.wait_in_text("#containers-images", IMG_ALPINE)
@@ -2478,7 +2477,7 @@ WantedBy=multi-user.target default.target
 
         # Start a podman container which uses a port
         self.execute(False, f"podman run -d -p 5000:5000 --name registry --stop-timeout 0 {IMG_REGISTRY}")
-        b.click("#containers-images button.pf-v5-c-expandable-section__toggle")
+        showImages(b)
 
         b.wait_visible(f'#containers-images td[data-label="Image"]:contains("{IMG_BUSYBOX}")')
         b.click(f'#containers-images tbody tr:contains("{IMG_BUSYBOX}") .ct-container-create')
@@ -2560,8 +2559,7 @@ WantedBy=multi-user.target default.target
             self.execute(False, f"podman rmi {IMG_BUSYBOX}")
 
         self.login(system=auth)
-
-        b.click("#containers-images button.pf-v5-c-expandable-section__toggle")
+        showImages(b)
 
         b.wait_visible(f'#containers-images td[data-label="Image"]:contains("{IMG_BUSYBOX}")')
         b.click(f'#containers-images tbody tr:contains("{IMG_BUSYBOX}") .ct-container-create')
@@ -2646,7 +2644,7 @@ WantedBy=multi-user.target default.target
                             skip_layouts=["rtl"])
 
         self.toggleExpandedContainer("sick")
-        b.click("#containers-images button.pf-v5-c-expandable-section__toggle")
+        showImages(b)
 
         b.wait_visible('#containers-images td[data-label="Image"]:contains("busybox:latest")')
         b.click('#containers-images tbody tr:contains("busybox:latest") .ct-container-create')
@@ -2716,7 +2714,7 @@ WantedBy=multi-user.target default.target
             self.execute(False, f"podman rmi {IMG_BUSYBOX}")
 
         self.login(system=auth)
-        b.click("#containers-images button.pf-v5-c-expandable-section__toggle")
+        showImages(b)
 
         def create_container(name: str, policy: str | None = None) -> None:
             b.wait_visible(f'#containers-images td[data-label="Image"]:contains("{IMG_BUSYBOX}")')

--- a/test/check-application
+++ b/test/check-application
@@ -2262,6 +2262,30 @@ WantedBy=multi-user.target default.target
             b.wait_in_text('#containers-containers .pf-v5-c-empty-state', 'No running containers')
             b.wait_in_text('#containers-images .pf-v5-c-empty-state', 'No images')
 
+    def testRunImageUserWithAuth(self):
+        b = self.browser
+
+        self.login()
+        showImages(b)
+
+        # create container from user image
+        b.wait_in_text("#containers-images", IMG_BUSYBOX)
+        b.click(f"#containers-images tr[data-row-id^='user-']:contains({IMG_BUSYBOX_LATEST}) .ct-container-create")
+        b.wait_visible("#run-image-dialog-owner-admin:checked")
+        b.set_input_text("#run-image-dialog-name", "user1")
+        b.click('.pf-v5-c-modal-box__footer #create-image-create-run-btn')
+        b.wait_not_present(".pf-v5-c-modal-box")
+        user1_sha = self.execute(False, "podman inspect --format '{{.Id}}' user1").strip()
+        self.waitContainer(user1_sha, auth=False, owner="admin", state='Running')
+
+        b.click(f"#containers-images tr[data-row-id^='0-']:contains({IMG_BUSYBOX_LATEST}) .ct-container-create")
+        b.wait_visible("#run-image-dialog-owner-system:checked")
+        b.set_input_text("#run-image-dialog-name", "sys1")
+        b.click('.pf-v5-c-modal-box__footer #create-image-create-run-btn')
+        b.wait_not_present(".pf-v5-c-modal-box")
+        sys1_sha = self.execute(True, "podman inspect --format '{{.Id}}' sys1").strip()
+        self.waitContainer(sys1_sha, auth=True, owner="system", state='Running')
+
     def check_content(self, kind: str, present: list[str], not_present: list[str]) -> None:
         b = self.browser
         for item in present:


### PR DESCRIPTION
The dialog's Owner: radio button should default to the owner of the image that was selected to run, not statically to "system". In most cases you don't want to run a system container from a user image.

This scenario is not covered anywhere yet, and difficult to put into `testRunImage{User,System}`, so create a new `testRunImageUserWithAuth` test case for this.
