### PR TITLE
Remove actual user name from owner help

### DIFF
--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -852,7 +852,7 @@ export class ImageRunModal extends React.Component {
                                                       </TextList>
                                                   </TextContent>
                                                   <TextContent>
-                                                      <Text component={TextVariants.h4}>{cockpit.format("$0 $1", _("User:"), this.props.users[1].name)}</Text>
+                                                      <Text component={TextVariants.h4}>{_("User")}</Text>
                                                       <TextList>
                                                           <TextListItem>
                                                               {_("Ideal for development")}


### PR DESCRIPTION
The explanation when a container should run as system or user isn't specific to the particular user name, so drop it.

This avoids confusion with the upcoming support for multiple users.

Note that we already have "User" as translatable string, so this does not actually add a new string.