### PR TITLE
Replace "only running" Select with Switch

### DIFF
--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -5,9 +5,9 @@ import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { Card, CardBody, CardHeader, CardTitle } from "@patternfly/react-core/dist/esm/components/Card";
 import { Divider } from "@patternfly/react-core/dist/esm/components/Divider";
 import { DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown/index.js';
-import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect";
 import { LabelGroup } from "@patternfly/react-core/dist/esm/components/Label";
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover";
+import { Switch } from "@patternfly/react-core/dist/esm/components/Switch";
 import { Text, TextVariants } from "@patternfly/react-core/dist/esm/components/Text";
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core/dist/esm/components/Toolbar";
 import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip";
@@ -595,11 +595,11 @@ class Containers extends React.Component {
             emptyCaption = _("Loading...");
         else if (this.props.textFilter.length > 0)
             emptyCaption = _("No containers that match the current filter");
-        else if (this.props.filter == "running")
+        else if (this.props.onlyRunning)
             emptyCaption = _("No running containers");
 
         if (this.props.containers !== null && this.props.pods !== null) {
-            filtered = Object.keys(this.props.containers).filter(id => !(this.props.filter == "running") || ["running", "restarting"].includes(this.props.containers[id].State.Status));
+            filtered = Object.keys(this.props.containers).filter(id => !this.props.onlyRunning || ["running", "restarting"].includes(this.props.containers[id].State.Status));
 
             if (this.props.ownerFilter !== "all") {
                 filtered = filtered.filter(id => {
@@ -660,7 +660,7 @@ class Containers extends React.Component {
                 const lcf = this.props.textFilter.toLowerCase();
                 if (section != "no-pod") {
                     const pod = this.props.pods[section];
-                    if ((this.props.filter == "running" && pod.Status != "Running") ||
+                    if ((this.props.onlyRunning && pod.Status != "Running") ||
                         // If nor the pod name nor any container inside the pod fit the filter, hide the whole pod
                         (!partitionedContainers[section].length && pod.Name.toLowerCase().indexOf(lcf) < 0) ||
                         (this.props.ownerFilter !== "all" &&
@@ -732,14 +732,11 @@ class Containers extends React.Component {
         const filterRunning = (
             <Toolbar>
                 <ToolbarContent className="containers-containers-toolbarcontent">
-                    <ToolbarItem variant="label" htmlFor="containers-containers-filter">
-                        {_("Show")}
-                    </ToolbarItem>
-                    <ToolbarItem>
-                        <FormSelect id="containers-containers-filter" value={this.props.filter} onChange={(_, value) => this.props.handleFilterChange(value)}>
-                            <FormSelectOption value='all' label={_("All")} />
-                            <FormSelectOption value='running' label={_("Only running")} />
-                        </FormSelect>
+                    <ToolbarItem alignSelf="center">
+                        <Switch id="containers-containers-only-running"
+                                label={_("Only running")}
+                                isChecked={this.props.onlyRunning}
+                                onChange={(_, value) => this.props.handleOnlyRunningChange(value)} />
                     </ToolbarItem>
                     <Divider orientation={{ default: "vertical" }} />
                     <ToolbarItem>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -61,7 +61,7 @@ class Application extends React.Component {
             users: [{ con: null, uid: 0, name: _("system") }, { con: null, uid: null, name: _("user") }],
             images: null,
             containers: null,
-            containersFilter: "all",
+            onlyRunning: false,
             containersStats: {},
             textFilter: "",
             ownerFilter: "all",
@@ -78,7 +78,7 @@ class Application extends React.Component {
         this.onDismissNotification = this.onDismissNotification.bind(this);
         this.onFilterChanged = this.onFilterChanged.bind(this);
         this.onOwnerChanged = this.onOwnerChanged.bind(this);
-        this.onContainerFilterChanged = this.onContainerFilterChanged.bind(this);
+        this.onContainerOnlyRunningChanged = this.onContainerOnlyRunningChanged.bind(this);
         this.updateContainer = this.updateContainer.bind(this);
         this.goToServicePage = this.goToServicePage.bind(this);
         this.onNavigate = this.onNavigate.bind(this);
@@ -137,18 +137,15 @@ class Application extends React.Component {
         this.updateUrl(options);
     }
 
-    onContainerFilterChanged(value) {
-        this.setState({
-            containersFilter: value
-        });
+    onContainerOnlyRunningChanged(value) {
+        this.setState({ onlyRunning: value });
 
-        const options = this.state.location;
-        if (value == "running") {
-            delete options.container;
-            this.updateUrl(Object.assign(options));
-        } else {
-            this.updateUrl(Object.assign(options, { container: value }));
-        }
+        const options = { ...this.state.location };
+        if (value)
+            options.running = "true";
+        else
+            delete options.running;
+        this.updateUrl(options);
     }
 
     updateState(state, key, newValue) {
@@ -554,9 +551,7 @@ class Application extends React.Component {
                 if (options.name) {
                     this.onFilterChanged(options.name);
                 }
-                if (options.container) {
-                    this.onContainerFilterChanged(options.container);
-                }
+                this.onContainerOnlyRunningChanged(options.running == "true");
                 if (["user", "all"].includes(options.owner)) {
                     this.setState({ ownerFilter: options.owner });
                 } else if (options.owner === undefined) {
@@ -639,7 +634,7 @@ class Application extends React.Component {
                 onAddNotification={this.onAddNotification}
                 textFilter={this.state.textFilter}
                 ownerFilter={this.state.ownerFilter}
-                showAll={ () => this.setState({ containersFilter: "all" }) }
+                showAll={ () => this.setState({ onlyRunning: false }) }
                 users={this.state.users}
             />
         );
@@ -651,8 +646,8 @@ class Application extends React.Component {
                 containers={loadingContainers ? null : this.state.containers}
                 pods={loadingPods ? null : this.state.pods}
                 containersStats={this.state.containersStats}
-                filter={this.state.containersFilter}
-                handleFilterChange={this.onContainerFilterChanged}
+                onlyRunning={this.state.onlyRunning}
+                handleOnlyRunningChange={this.onContainerOnlyRunningChanged}
                 textFilter={this.state.textFilter}
                 ownerFilter={this.state.ownerFilter}
                 users={this.state.users}

--- a/test/check-application
+++ b/test/check-application
@@ -229,11 +229,11 @@ class TestApplication(testlib.MachineCase):
                 self.waitContainer(container["id"], auth=system, name=container["name"], image=container["image"],
                                    cmd=container["command"], state=container["state"], pod=podName)
         else:
-            if self.browser.val("#containers-containers-filter") == "all":
-                self.browser.wait_in_text("#table-" + podName + " .pf-v5-c-empty-state", "No containers in this pod")
+            if self.browser.get_checked("#containers-containers-only-running"):
+                wait_text = "No running containers in this pod"
             else:
-                self.browser.wait_in_text("#table-" + podName + " .pf-v5-c-empty-state",
-                                          "No running containers in this pod")
+                wait_text = "No containers in this pod"
+            self.browser.wait_in_text("#table-" + podName + " .pf-v5-c-empty-state", wait_text)
 
     def waitContainerRow(self, container: str, *, present: bool = True) -> None:
         b = self.browser
@@ -307,7 +307,7 @@ WantedBy=multi-user.target default.target
 
         self.login()
 
-        self.filter_containers("running")
+        self.set_only_running(checked=True)
         if not self.machine.ostree_image:
             b.wait_in_text("#containers-containers", "No running containers")
 
@@ -315,7 +315,7 @@ WantedBy=multi-user.target default.target
         self.machine.execute("podman pod create --infra=false --name pod-1")
 
         self.waitPodRow("pod-1", present=False)
-        self.filter_containers("all")
+        self.set_only_running(checked=False)
         self.waitPodContainer("pod-1", [])
 
         def get_pod_cpu_usage(pod_name: str) -> float:
@@ -348,10 +348,10 @@ WantedBy=multi-user.target default.target
         self.machine.execute("podman pod stop -t0 pod-1")  # disable timeout, so test doesn't wait endlessly
         self.waitPodContainer("pod-1", [{"name": "test-pod-1-system", "image": IMG_ALPINE,
                                          "command": "sleep 100", "state": NOT_RUNNING, "id": containerId}])
-        self.filter_containers("running")
+        self.set_only_running(checked=True)
         self.waitPodRow("pod-1", present=False)
 
-        self.filter_containers("all")
+        self.set_only_running(checked=False)
         b.set_input_text('#containers-filter input', 'pod-1')
         self.waitPodContainer("pod-1", [{"name": "test-pod-1-system", "image": IMG_ALPINE,
                                          "command": "sleep 100", "state": NOT_RUNNING, "id": containerId}])
@@ -428,7 +428,7 @@ WantedBy=multi-user.target default.target
 
         # Test dropping and gaining privileges
         b.set_val("#containers-containers-owner", "all")
-        self.filter_containers("all")
+        self.set_only_running(checked=False)
         self.execute(False, "podman pod create --infra=false --name pod_user")
         self.execute(True, "podman pod create --infra=false --name pod_system")
 
@@ -636,7 +636,7 @@ WantedBy=multi-user.target default.target
         b.wait_not_present(hello_sel)
 
         # make sure no running containers shown; on CoreOS there's the cockpit/ws container
-        self.filter_containers('running')
+        self.set_only_running(checked=True)
         if auth and self.machine.ostree_image:
             self.waitContainerRow("ws")
         else:
@@ -665,7 +665,7 @@ WantedBy=multi-user.target default.target
             b.set_val("#containers-containers-owner", "0")
             verify_system()
             b.set_val("#containers-containers-owner", "all")
-            b.go("#/?owner=0")
+            b.go("#/?owner=0&running=true")
             verify_system()
 
             def verify_user() -> None:
@@ -677,12 +677,12 @@ WantedBy=multi-user.target default.target
             b.set_val("#containers-containers-owner", "user")
             verify_user()
             b.set_val("#containers-containers-owner", "all")
-            b.go("#/?owner=user")
+            b.go("#/?owner=user&running=true")
             verify_user()
 
             # changing to an invalid user keeps the current filter
-            b.go("#/?owner=huh")
-            b.wait_js_cond('window.location.hash === "#/?owner=user"')
+            b.go("#/?owner=huh&running=true")
+            b.wait_js_cond('window.location.hash === "#/?owner=user&running=true"')
             verify_user()
 
             b.set_val("#containers-containers-owner", "all")
@@ -742,7 +742,7 @@ WantedBy=multi-user.target default.target
         b.wait_collected_text("#containers-containers .container-name", ''.join(sorted(expected)))
 
         # show running container
-        self.filter_containers('running')
+        self.set_only_running(checked=True)
         if auth:
             self.waitContainer(system_containers["swamped-crate-system"], auth=True, name='swamped-crate-system',
                                image=IMG_BUSYBOX, cmd="sleep 1000", state='Running')
@@ -757,7 +757,7 @@ WantedBy=multi-user.target default.target
             self.confirm_modal("Force delete")
             self.waitContainerRow("swamped-crate-system", present=False)
 
-        self.filter_containers("all")
+        self.set_only_running(checked=False)
 
         self.performContainerAction("swamped-crate-user", "Delete")
         self.confirm_modal("Force delete")
@@ -958,7 +958,7 @@ WantedBy=multi-user.target default.target
         # run a container (will exit immediately) and test the display of commit modal
         self.execute(auth, f"podman run -d --name test-sh0 --stop-timeout 0 {IMG_ALPINE} sh -c 'ls -a'")
 
-        self.filter_containers("all")
+        self.set_only_running(checked=False)
         self.waitContainerRow("test-sh0")
         self.toggleExpandedContainer("test-sh0")
 
@@ -1361,7 +1361,7 @@ WantedBy=multi-user.target default.target
             self.allow_browser_errors("Failed to start system podman.socket.*")
 
         self.login()
-        self.filter_containers('all')
+        self.set_only_running(checked=False)
 
         # run a container
         self.execute(auth, f"""
@@ -1520,7 +1520,7 @@ WantedBy=multi-user.target default.target
         b = self.browser
 
         self.login()
-        self.filter_containers('all')
+        self.set_only_running(checked=False)
 
         if not self.has_criu:
             # On cgroupsv1 systems just check that we get expected error messages
@@ -2167,7 +2167,7 @@ WantedBy=multi-user.target default.target
             # podman ≥ 1.8 translates 0 default into actual value
             self.assertIn(cpuShares, ['0', '1024'])
 
-        b.set_val("#containers-containers-filter", "all")
+        self.set_only_running(checked=False)
 
         b.click(".pf-m-expanded button:contains('Console')")
         b.wait_in_text(".pf-m-expanded .xterm-accessibility-tree", "/ # ")
@@ -2203,7 +2203,7 @@ WantedBy=multi-user.target default.target
         self.check_images([IMG_ALPINE, IMG_BUSYBOX, IMG_REGISTRY], [])
         b.wait_js_cond('window.location.hash === "#/"')
 
-        self.filter_containers("running")
+        self.set_only_running(checked=True)
         id_with_tty = self.execute(auth, "podman inspect --format '{{.Id}}' busybox-with-tty").strip()
 
         container_sel = f'#containers-images tbody tr:contains("{IMG_BUSYBOX}")'
@@ -2211,13 +2211,13 @@ WantedBy=multi-user.target default.target
         # running container, just selects it, but leaves "Only running" alone
         b.click(f"{container_sel} + tr div.ct-listing-panel-body dt:contains('Used by') + dd button:contains('busybox-with-tty')")  # noqa: E501
         b.wait_js_cond('window.location.hash === "#' + id_with_tty + '"')
-        b.wait_val("#containers-containers-filter", "running")
+        b.wait_visible("#containers-containers-only-running:checked")
         # FIXME: expanding running container details does not actually work right now
         # b.wait_in_text("#containers-containers tr.pf-m-expanded .container-details", "sleep infinity")
         # stopped container, switches to showing all containers
 
         # Create a container without starting it
-        self.filter_containers("all")
+        self.set_only_running(checked=False)
         container_name = "busybox-not-started"
         b.wait_visible(f'#containers-images td[data-label="Image"]:contains("{IMG_BUSYBOX}")')
         b.click(f'#containers-images tbody tr:contains("{IMG_BUSYBOX}") .ct-container-create')
@@ -2233,12 +2233,12 @@ WantedBy=multi-user.target default.target
         sha = self.execute(auth, "podman inspect --format '{{.Id}}' " + container_name).strip()
         self.waitContainer(sha, auth=auth, name=container_name, image=IMG_BUSYBOX, state=['Configured', 'Created'])
 
-        self.filter_containers("running")
+        self.set_only_running(checked=True)
         b.wait_not_in_text("#containers-containers", "busybox-not-started")
         container_sel = f"#containers-images tbody tr:contains('{IMG_BUSYBOX}') + tr div.ct-listing-panel-body"
         b.click(f"{container_sel} dt:contains('Used by') + dd button:contains('busybox-not-started')")
         b.wait_js_cond(f"window.location.hash === '#{sha}'")
-        b.wait_val("#containers-containers-filter", "all")
+        b.wait_visible("#containers-containers-only-running:not(:checked)")
         b.wait_in_text("#containers-containers", "busybox-not-started")
         # auto-expands container details
         b.wait_in_text("#containers-containers tbody tr:contains('busybox-not-started') + tr", "sleep infinity")
@@ -2258,7 +2258,7 @@ WantedBy=multi-user.target default.target
                 self.execute(auth, "podman rm --all --force --time 0")
             self.execute(auth, "podman rmi -af")
             b.wait_in_text('#containers-containers .pf-v5-c-empty-state', 'No containers')
-            b.set_val("#containers-containers-filter", "running")
+            self.set_only_running(checked=True)
             b.wait_in_text('#containers-containers .pf-v5-c-empty-state', 'No running containers')
             b.wait_in_text('#containers-images .pf-v5-c-empty-state', 'No images')
 
@@ -2324,10 +2324,8 @@ WantedBy=multi-user.target default.target
                 state = [state]
             b.wait(lambda: b.text(sel + " td[data-label=State]") in state)
 
-    def filter_containers(self, value: str) -> None:
-        """Use dropdown menu in the header to filter containers"""
-        b = self.browser
-        b.set_val("#containers-containers-filter", value)
+    def set_only_running(self, *, checked: bool) -> None:
+        self.browser.set_checked("#containers-containers-only-running", checked)
 
     def confirm_modal(self, text: str) -> None:
         """Wait for the pop up window and click the button with text"""
@@ -2781,7 +2779,7 @@ WantedBy=multi-user.target default.target
 
         self.login(system=auth)
 
-        self.filter_containers('all')
+        self.set_only_running(checked=False)
         b.click(".create-container-in-pod")
 
         # the podname should be in the "Create container" header
@@ -2846,7 +2844,7 @@ WantedBy=multi-user.target default.target
         self.performContainerAction(container_name, "Pause")
 
         # show all containers and check status
-        self.filter_containers('all')
+        self.set_only_running(checked=False)
 
         # Check that container details are not lost when the container is paused
         b.click(".pf-m-expanded button:contains('Integration')")
@@ -2871,7 +2869,7 @@ WantedBy=multi-user.target default.target
         self.execute(auth, f"podman container create -t --name {container_name} {IMG_BUSYBOX}")
         self.login(system=auth)
 
-        self.filter_containers('all')
+        self.set_only_running(checked=False)
 
         self.waitContainerRow(container_name)
         self.toggleExpandedContainer(container_name)
@@ -3025,7 +3023,7 @@ WantedBy=multi-user.target default.target
             b.set_input_text('#create-pod-dialog-volume-1-container-path', '/tmp/rw')
 
         b.click("#create-pod-create-btn")
-        b.set_val("#containers-containers-filter", "all")
+        self.set_only_running(checked=False)
         self.waitPodContainer(pod_name, [])
 
         container_name = 'test-pod-1-system' if auth else 'test-pod-1'
@@ -3058,7 +3056,7 @@ WantedBy=multi-user.target default.target
             b.click("#create-pod-dialog-owner-admin")
             b.click("#create-pod-create-btn")
 
-            b.set_val("#containers-containers-filter", "all")
+            self.set_only_running(checked=False)
             self.waitPodContainer(pod_name, [])
 
     @testlib.skipImage("passthrough log driver not supported", "ubuntu-2204")


### PR DESCRIPTION
We should not have a select with only two options. Replace the "Show" filter with an "Only running" Switch.

Adjust the React state and URL parameters accordingly to reflect that it is actually a boolean value.

Fix the previous `onContainerFilterChanged` (now renamed to `onContainerOnlyRunningChanged`) to not directly manipulate the state, but work on a copy.

----

Before:

![running-before](https://github.com/user-attachments/assets/26aee5da-71ed-47b0-9dee-56048a3e7c49)

Now:

![image](https://github.com/user-attachments/assets/74d3b11d-0bee-4c0c-bdd3-bd2591714113)
![image](https://github.com/user-attachments/assets/107c24f8-92b6-4828-adad-6d0c23f77994)

@garrett We talked about this the other day. Can you please confirm that this is the direction you intended? Let's also discuss the string -- There are alternatives, like "Show stopped" (but that sounds odd in my ears) or longer text like "Only show running containers" / "Show stopped containers", but I'd prefer a short text (mobile/translations/etc.)

 Thanks!