### PR TITLE
test: generalise bootc check

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -38,7 +38,7 @@ fi
 podman images --format '{{.Repository}}:{{.Tag}}' | grep -Ev 'localhost/test-|pause|cockpit/ws' | xargs -r podman rmi -f
 
 # clean up cockpit/ws on Fedora images, as it "breaks" pixel tests; it's only relevant for OSTree images
-[ -n "${OSTREE_VERSION:-}" ] || podman rmi -f quay.io/cockpit/ws || true
+bootc status --booted || podman rmi -f quay.io/cockpit/ws || true
 
 # tests reset podman, save the images
 mkdir -p /var/lib/test-images


### PR DESCRIPTION
CentOS 9's bootc image no longer exposes `OSTREE_VERSION` in /etc/os-release. Likely due to Fedora CoreOS moving from ostree to composefs. As every image we test is moving to bootc the check whether cockpit-ws should be kept can be simplified to seeing if we booted into a bootc system.