### PR TITLE
test: Robustify admin user SSH key setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ exclude = [
 ignore_missing_imports = true
 module = [
     # run without bots checked out
+    "lib.constants.*",
     "machine.*",
     "testvm",
 ]

--- a/test/check-application
+++ b/test/check-application
@@ -10,6 +10,7 @@ import time
 from typing import Self
 
 import testlib
+from lib.constants import DEFAULT_IDENTITY_PUB_FILE
 from machine.machine_core import ssh_connection
 
 REGISTRIES_CONF = """
@@ -113,14 +114,9 @@ class TestApplication(testlib.MachineCase):
             """)
 
         # Create admin session
-        m.execute("""
-            if [ ! -d /home/admin/.ssh ]; then
-                mkdir /home/admin/.ssh
-                cp /root/.ssh/* /home/admin/.ssh
-                chown -R admin:admin /home/admin/.ssh
-                chmod -R go-wx /home/admin/.ssh
-            fi
-            """)
+        with open(DEFAULT_IDENTITY_PUB_FILE) as f:
+            authorized_keys = f.read()
+        m.write("/home/admin/.ssh/authorized_keys", authorized_keys, owner="admin:admin", perm="600")
         self.admin_s = ssh_connection.SSHConnection(user="admin",
                                                     address=m.ssh_address,
                                                     ssh_port=m.ssh_port,


### PR DESCRIPTION
This makes the admin setup independent from root's, and is easier.

---

See https://github.com/cockpit-project/cockpit-podman/pull/2024/files#r2010660027

Our bots images are already set up that way, but [it is required on TF](https://artifacts.dev.testing-farm.io/f22e32ed-1fde-469f-93c6-2efdddefa4d6/)