### PR TITLE
Drop pf-m-redhat-font

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -29,7 +29,7 @@ along with this package; If not, see <http://www.gnu.org/licenses/>.
     <script type="text/javascript" src="../manifests.js"></script>
 </head>
 
-<body class="pf-m-redhat-font pf-v6-m-tabular-nums">
+<body class="pf-v6-m-tabular-nums">
     <div class="ct-page-fill" id="app">
     </div>
 </body>


### PR DESCRIPTION
This no longer exists as class in PF since the PF 3->4 migration.