### PR TITLE
Drop ct-table-empty css rule

### DIFF
--- a/src/Containers.scss
+++ b/src/Containers.scss
@@ -71,11 +71,6 @@
     }
 }
 
-.ct-table-empty td {
-    padding-block: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--lg);
-    padding-inline: var(--pf-t--global--spacer--md);
-}
-
 /* HACK - force DescriptionList to wrap but not fill the width */
 #container-details-healthcheck {
     display: flex;


### PR DESCRIPTION
When there are no rows we show the EmptyState component and the Table wouldn't be rendered so `ct-table-empty` is never shown.