### PR TITLE
Update pixel tests

### DIFF
--- a/src/PruneUnusedImagesModal.jsx
+++ b/src/PruneUnusedImagesModal.jsx
@@ -78,9 +78,9 @@ const PruneUnusedImagesModal = ({ close, unusedImages, onAddNotification, users 
 
     const showCheckboxes = unusedOwners.length > 1;
 
-    const onCheckChange = (user, checked) => setDeleteOwners(
-        checked ? deleteOwners.concat([user]) : deleteOwners.filter(u => u !== user)
-    );
+    const onCheckChange = (user, checked) => setDeleteOwners(prevState => {
+        return checked ? prevState.concat([user]) : prevState.filter(u => u !== user);
+    });
 
     return (
         <Modal isOpen

--- a/src/PruneUnusedImagesModal.jsx
+++ b/src/PruneUnusedImagesModal.jsx
@@ -103,7 +103,7 @@ const PruneUnusedImagesModal = ({ close, unusedImages, onAddNotification, users 
                     <ImageOptions key={user.name}
                                   images={unusedImages.filter(image => image.uid === user.uid)}
                                   name={"deleteImages-" + user.name}
-                                  checked={deleteOwners.includes(user)}
+                                  checked={deleteOwners.some(u => u.uid === user.uid)}
                                   handleChange={checked => onCheckChange(user, checked)}
                                   showCheckbox={showCheckboxes}
                                   user={user} />))

--- a/test/check-application
+++ b/test/check-application
@@ -2402,6 +2402,8 @@ PodName={name}
             b.wait_js_func("ph_count_check", ".pf-v6-c-modal-box__body .pf-v6-c-list li",
                            self.user_images_count - leftover_images)
         if auth:
+            self.assertTrue(b.get_checked("#deleteImages-system"))
+            self.assertTrue(b.get_checked("#deleteImages-admin"))
             b.assert_pixels('.pf-v6-c-modal-box', "prune-modal", skip_layouts=["rtl", "mobile"])
         b.click(".pf-v6-c-modal-box button:contains(Prune)")
 


### PR DESCRIPTION
The prune image dialog pixel tests didn't have both checkboxes checked which caused flakes in CI. The prune image dialog should always have both checkboxes checked by default.

See the failure https://cockpit-logs.us-east-1.linodeobjects.com/pull-2083-3f2bbde9-20250404-152013-fedora-41/log.html