### PR TITLE
Show systemd service links for quadlets

### DIFF
--- a/src/ContainerDetails.jsx
+++ b/src/ContainerDetails.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from "@patternfly/react-core/dist/esm/components/DescriptionList";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
 
@@ -41,6 +42,17 @@ const ContainerDetails = ({ container }) => {
                     <DescriptionListGroup>
                         <DescriptionListTerm>{_("Command")}</DescriptionListTerm>
                         <DescriptionListDescription>{utils.quote_cmdline(container.Config.Cmd)}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    }
+                    {Boolean(container.Config?.Labels?.PODMAN_SYSTEMD_UNIT) && (container.uid === 0 || container.uid === null) &&
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>{_("systemd service")}</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            <Button variant="link" isInline onClick={
+                                () => cockpit.jump(`/system/services#/${container.Config?.Labels?.PODMAN_SYSTEMD_UNIT}` + (container.uid === null ? "?owner=user" : ""))}>
+                                {cockpit.format(_("View $0"), container.Config?.Labels?.PODMAN_SYSTEMD_UNIT)}
+                            </Button>
+                        </DescriptionListDescription>
                     </DescriptionListGroup>
                     }
                 </DescriptionList>

--- a/test/check-application
+++ b/test/check-application
@@ -3292,6 +3292,16 @@ PodName={name}
             # Lifecycle operations are not available such as Start/Restart
             b.wait_visible(f"#pod-{podName}-{podOwner}-action-toggle:disabled")
 
+        self.toggleExpandedContainer(service_name)
+
+        b.click(f"#containers-containers tbody tr:contains('{service_name}') button:contains({service_name}.service)")
+        b.switch_to_top()
+        if system:
+            b.wait_js_cond(f'window.location.hash === "#/{service_name}.service"')
+        else:
+            b.wait_js_cond(f'window.location.hash === "#/{service_name}.service?owner=user"')
+        b.wait_js_cond('window.location.pathname === "/system/services"')
+
     # HACK: quadlets broken on RHEL-8 https://issues.redhat.com/browse/RHEL-5870
     @testlib.skipImage("no quadlet support", "debian-stable", "ubuntu-2204", "rhel-8-10")
     def testQuadletsSystem(self) -> None:
@@ -3433,6 +3443,13 @@ ContainerName=guitarq1
             b.wait_text("#containers-containers .container-name", "guitarq1")
             b.wait_text("#containers-containers [data-label='Owner']", "user: guitar")
             b.wait_visible("#containers-containers .ct-badge-service")
+
+            # No systemd service link is shown for quadlets from other users as
+            # the services page doesn't support anything except the logged in/admin/root user.
+            self.toggleExpandedContainer("guitarq1")
+            sel = "#containers-containers tbody tr:contains('guitarq1')"
+            b.wait_in_text(f"{sel} + tr", "sleep infinity")
+            b.wait_not_in_text(f"{sel} + tr", "systemd service")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Restart/Stop/Start support has been removed so users can't restart a container currently. With a link to the services page they can at least restart it without temporarily losing the container from the view.

---

# Show link to services page in container details

![image](https://github.com/user-attachments/assets/2a55e583-bc9a-4e63-8699-38bb6e3e1a3a)

