### PR TITLE
pyproject: set pyright extra import paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ module = [
     "testvm",
 ]
 
+[tool.pyright]
+strict = ["**"]
+extraPaths = ["test/common", "bots"]
+
 [tool.ruff]
 exclude = [
     ".git/",


### PR DESCRIPTION
Our custom test shebang is not compatible with pyright so we have to like mypy teach it about bots/ our custom testlib.