### PR TITLE
Show link to logs page for quadlets

### DIFF
--- a/src/ContainerLogs.jsx
+++ b/src/ContainerLogs.jsx
@@ -19,6 +19,7 @@
 
 import React from 'react';
 
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { CanvasAddon } from '@xterm/addon-canvas';
 import { Terminal } from "@xterm/xterm";
@@ -165,8 +166,21 @@ class ContainerLogs extends React.Component {
 
     render() {
         let element = <div className="container-logs" ref={this.logRef} />;
-        if (this.state.errorMessage)
+        const { systemd_unit, uid } = this.props;
+
+        if (this.state.errorMessage) {
             element = <EmptyStatePanel icon={ExclamationCircleIcon} title={this.state.errorMessage} />;
+        } else if (uid === 0 && systemd_unit) {
+            element = (
+                <>
+                    {element}
+                    <Button variant="link" isInline className="pf-v6-u-mt-sm" onClick={
+                        () => cockpit.jump(`/system/logs/#/?priority=info&_SYSTEMD_UNIT=${systemd_unit}`)}>
+                        {cockpit.format(_("View $0 logs"), systemd_unit)}
+                    </Button>
+                </>
+            );
+        }
 
         return element;
     }
@@ -175,7 +189,8 @@ class ContainerLogs extends React.Component {
 ContainerLogs.propTypes = {
     containerId: PropTypes.string.isRequired,
     uid: PropTypes.number,
-    width: PropTypes.number.isRequired
+    width: PropTypes.number.isRequired,
+    systemd_unit: PropTypes.string
 };
 
 export default ContainerLogs;

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -452,7 +452,13 @@ class Containers extends React.Component {
                 tabs.push({
                     name: _("Logs"),
                     renderer: ContainerLogs,
-                    data: { containerId: container.Id, containerStatus: container.State.Status, width: this.state.width, uid: container.uid }
+                    data: {
+                        containerId: container.Id,
+                        containerStatus: container.State.Status,
+                        width: this.state.width,
+                        uid: container.uid,
+                        systemd_unit: container.Config?.Labels?.PODMAN_SYSTEMD_UNIT,
+                    }
                 });
                 tabs.push({
                     name: _("Console"),

--- a/test/check-application
+++ b/test/check-application
@@ -4,6 +4,7 @@
 # "class Browser" and "class MachineCase" for the available API.
 
 import json
+import os
 import re
 import sys
 import time
@@ -3322,6 +3323,7 @@ PodName={name}
 
         self.toggleExpandedContainer(service_name)
 
+        # Service link integration
         b.click(f"#containers-containers tbody tr:contains('{service_name}') button:contains({service_name}.service)")
         b.switch_to_top()
         if system:
@@ -3329,6 +3331,21 @@ PodName={name}
         else:
             b.wait_js_cond(f'window.location.hash === "#/{service_name}.service?owner=user"')
         b.wait_js_cond('window.location.pathname === "/system/services"')
+
+        # Logs page link integration
+        # HACK: Requires
+        # https://github.com/cockpit-project/cockpit/commit/ac0558c7dc5da8f97c7dcc43f3ad9e3d548b5c6b
+        # to land in a release and the TEST_OS_DEFAULT image.
+        if system and "devel" not in os.getenv("TEST_SCENARIO", ""):
+            b.go("/podman")
+            b.enter_page("/podman")
+            b.wait_visible("#app")
+
+            b.click(".pf-m-expanded button:contains('Logs')")
+            b.click(f"#containers-containers tbody button:contains(View {service_name}.service logs)")
+            b.switch_to_top()
+            b.wait_js_cond('window.location.pathname === "/system/logs"')
+            b.wait_js_cond(f'window.location.hash === "#/?priority=info&_SYSTEMD_UNIT={service_name}.service"')
 
     # HACK: quadlets broken on RHEL-8 https://issues.redhat.com/browse/RHEL-5870
     @testlib.skipImage("no quadlet support", "debian-stable", "ubuntu-2204", "rhel-8-10")


### PR DESCRIPTION
Quadlets are services managed by systemd and detailed logs including service restarts can only be seen in journald's logs. This functionality is now limited to only system services as Cockpit's log page has no `--user` support.

Related: #2055

We should investigate supporting user journal support in Cockpit, of course we cannot support the other (non-logged in) users.

---

# Link to logs page for quadlets

![image](https://github.com/user-attachments/assets/0dc515c4-b176-441d-b37a-a2ab6bbf05d4)
