### PR TITLE
test: allow testing against a Cockpit Packit copr

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,4 +19,4 @@ jobs:
           mkdir -p ~/.config/cockpit-dev
           echo "${{ github.token }}" >> ~/.config/cockpit-dev/github-token
           TEST_OS=$(PYTHONPATH=bots python3 -c 'from lib.constants import TEST_OS_DEFAULT; print(TEST_OS_DEFAULT)')
-          bots/tests-trigger --force "-" "${TEST_OS}/updates-testing" "${TEST_OS}/podman-next"
+          bots/tests-trigger --force "-" "${TEST_OS}/updates-testing" "${TEST_OS}/copr/rhcontainerbot/podman-next"

--- a/HACKING.md
+++ b/HACKING.md
@@ -105,3 +105,11 @@ CI machinery do this on a draft pull request.
 Please see [Cockpit's test documentation](https://github.com/cockpit-project/cockpit/blob/main/test/README.md)
 for details how to run against existing VMs, interactive browser window,
 interacting with the test VM, and more.
+
+# Running tests against a Cockpit pull request
+
+The Cockpit testing infrastructure does not support testing a Cockpit pull
+request against a cockpit-podman pull request directly, but this can be
+achieved by using the packit copr build from the Cockpit pull request:
+
+    ./bots/tests-trigger fedora-42/copr/packit/cockpit-project-cockpit-$prid

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ VM_CUSTOMIZE_FLAGS =
 # the following scenarios need network access
 ifeq ("$(TEST_SCENARIO)","updates-testing")
 VM_CUSTOMIZE_FLAGS += --run-command 'dnf -y update --setopt=install_weak_deps=False --enablerepo=updates-testing >&2'
-else ifeq ("$(TEST_SCENARIO)","podman-next")
-VM_CUSTOMIZE_FLAGS += --run-command 'dnf -y copr enable rhcontainerbot/podman-next >&2; dnf -y update --repo "copr*" >&2'
+else ifneq ($(TEST_COPR),)
+VM_CUSTOMIZE_FLAGS += --run-command 'dnf -y copr enable $(TEST_COPR) >&2; dnf -y update --repo "copr*" >&2'
 else
 # default scenario does not install packages
 VM_CUSTOMIZE_FLAGS += --no-network

--- a/test/run
+++ b/test/run
@@ -9,6 +9,11 @@ export RUN_TESTS_OPTIONS=--track-naughties
 TEST_SCENARIO=${TEST_SCENARIO:-}
 [ "${TEST_SCENARIO}" = "${TEST_SCENARIO##firefox}" ] || export TEST_BROWSER=firefox
 
+if [[ "${TEST_SCENARIO}" =~ "copr" ]]; then
+    export TEST_COPR="${TEST_SCENARIO#*copr/}"
+    TEST_SCENARIO="${TEST_SCENARIO%%/copr*}"
+fi
+
 if [ "$TEST_SCENARIO" == "devel" ]; then
     export TEST_COVERAGE=yes
 fi


### PR DESCRIPTION
We can't currently test a Podman PR against a Cockpit PR easily, but as every Cockpit PR creates a Packit rpm build with a copr repository we can use this.

This is for example useful when debugging why clicking on a logs link from Podman throws an exception in the Cockpit logs page.

---

Been using a hack in here https://github.com/cockpit-project/cockpit-podman/pull/2120 but we can easily generalise this.

