### PR TITLE
Don't flag podman-compose containers as a service container

### DIFF
--- a/src/ContainerDetails.jsx
+++ b/src/ContainerDetails.jsx
@@ -44,7 +44,7 @@ const ContainerDetails = ({ container }) => {
                         <DescriptionListDescription>{utils.quote_cmdline(container.Config.Cmd)}</DescriptionListDescription>
                     </DescriptionListGroup>
                     }
-                    {Boolean(container.Config?.Labels?.PODMAN_SYSTEMD_UNIT) && (container.uid === 0 || container.uid === null) &&
+                    {utils.is_systemd_service(container.Config) && (container.uid === 0 || container.uid === null) &&
                     <DescriptionListGroup>
                         <DescriptionListTerm>{_("systemd service")}</DescriptionListTerm>
                         <DescriptionListDescription>

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -338,7 +338,7 @@ class Containers extends React.Component {
         const image = container.ImageName;
         const isToolboxContainer = container.Config?.Labels?.["com.github.containers.toolbox"] === "true";
         const isDistroboxContainer = container.Config?.Labels?.manager === "distrobox";
-        const isSystemdService = Boolean(container.Config?.Labels?.PODMAN_SYSTEMD_UNIT);
+        const isSystemdService = utils.is_systemd_service(container.Config);
         let localized_health = null;
 
         // this needs to get along with stub containers from image run dialog, where most properties don't exist yet

--- a/src/util.js
+++ b/src/util.js
@@ -169,3 +169,7 @@ export const validationClear = (validationFailed, key, onValidationChange) => {
 
 // This method needs to be outside of component as re-render would create a new instance of debounce
 export const validationDebounce = debounce(500, (validationHandler) => validationHandler());
+
+// Ignore podman-compose containers which like quadlets set PODMAN_SYSTEMD_UNIT.
+// https://github.com/containers/podman-compose/blob/0dcc864fdda280b410ad49ae4fa99740a4770cbb/podman_compose.py#L2263
+export const is_systemd_service = (container_config) => container_config?.Labels?.PODMAN_SYSTEMD_UNIT && !container_config.Labels.PODMAN_SYSTEMD_UNIT.startsWith('podman-compose@');


### PR DESCRIPTION
A podman-compose container cannot be managed via systemd but still sets a label PODMAN_SYSTEMD_UNIT with `podman-compose@$project`.

Restarting such a unit isn't even possible with systemd:

systemctl restart podman-compose@root.service
Failed to restart podman-compose@root.service: Unit podman-compose@root.service not found

Closes: #2112