### PR TITLE
Bump podman API version to 3.4.0

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1,4 +1,5 @@
-export const VERSION = "/v1.12/";
+// podman API version; oldest one that we support
+export const VERSION = "/v3.4.0/";
 
 const podmanCall = (con, name, method, args, body) => con.call({
     method,


### PR DESCRIPTION
We haven't updated this in years, and "1.12" as a version does not make sense. The intention as per Paul Holzinger [1] is to have a podman version there. The oldest one that we still support is 3.4.0 in Ubuntu 22.04 LTS.

[1] https://github.com/containers/podman/pull/24005#issuecomment-3058499967