### PR TITLE
testOtherUsers timeout on ubuntu-stable

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -504,7 +504,7 @@ class Application extends React.Component {
         this.updatePods(con);
 
         client.streamEvents(con, message => this.handleEvent(message, con))
-                .catch(e => console.error("uid", uid, "streamEvents failed:", e.toString()))
+                .catch(e => console.error("uid", uid, "streamEvents failed:", JSON.stringify(e)))
                 .finally(() => {
                     console.log("uid", uid, "podman service closed");
                     this.cleanupAfterService(con);

--- a/src/client.js
+++ b/src/client.js
@@ -15,7 +15,7 @@ export const streamEvents = (con, callback) => con.monitor(VERSION + "libpod/eve
 
 export function getInfo(con) {
     return new Promise((resolve, reject) => {
-        const timeout = setTimeout(() => reject(new Error("timeout")), 5000);
+        const timeout = setTimeout(() => reject(new Error("timeout")), 10000);
         podmanJson(con, "libpod/info", "GET", {})
                 .then(reply => resolve(reply))
                 .catch(reject)


### PR DESCRIPTION
Investigating [this flake](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit-podman&days=5&test=%2Ftest%2Fcheck-application+TestApplication.testOtherUsers), [example log](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-2187-c20c469a-20250714-032558-ubuntu-stable/log.html#23). Also observed on [rhel-8-10](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-7982-84490583-20250711-232323-rhel-8-10-cockpit-project-cockpit-podman/log.html).

 The log seems pretty clear, and if podman keeps timing out there's not much that we can do about it:

> warn: init uid null getInfo failed: Error: timeout
> warn: init uid 0 getInfo failed: Error: timeout

 - [x] Run with amplified test to see how reproducible that is: rather well in the mornings: [failure one](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-2188-9a94693d-20250716-045915-ubuntu-stable/log.html), [two](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-2188-9a94693d-20250716-052126-ubuntu-stable-2/log.html), [three](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-2188-9a94693d-20250716-052122-ubuntu-stable-3/log.html), [four](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-2188-9a94693d-20250716-052119-ubuntu-stable-4/log.html). No luck in the afternoons, so PSI noisy neighbors?
 - [x] Increase timeout to 10s
 - [ ] ~If that doesn't help, add a naugthy~