### PR TITLE
test: Ignore occasional old C bridge "should not be reached" message

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -147,6 +147,10 @@ class TestApplication(testlib.MachineCase):
         self.allow_journal_messages("/run.*/podman/podman: couldn't connect.*")
         self.allow_journal_messages(".*/run.*/podman/podman.*Connection reset by peer")
 
+        # old C bridge sometimes does that; not fixable any more
+        if m.image.startswith('rhel-8') or m.image in ['debian-stable', 'ubuntu-2204']:
+            self.allow_journal_messages(".*cockpit_http_stream_close: code should not be reached")
+
         # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1008249
         # Fixed in crun 1.20-1
         self.has_criu = m.image not in ["debian-stable", "ubuntu-2204", "ubuntu-2404"]


### PR DESCRIPTION
These old distro releases are deeply frozen, and this isn't a critical bug, so it won't ever be fixed. Just ignore the message at this point.

---

Fixes [this flake](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-2185-1d38402d-20250711-035640-rhel-8-10/log.html#1), [another example](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-2191-b84909e6-20250716-044707-rhel-8-10/log.html)

That reminds me, we should move rhel 8 testing to beiboot. We should stop supporting main on the C bridge, we won't upload current releases to RHEL 8 any more anyway.