### PR TITLE
test: Add ws-container scenario

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -66,6 +66,7 @@ podman rmi $CONTAINER
 
 # image setup, shared with upstream tests
 sh -x test/vm.install
+sh -x test/vm-ws-package.install
 
 systemctl enable --now cockpit.socket
 

--- a/test/check-application
+++ b/test/check-application
@@ -3235,10 +3235,13 @@ Yaml={name}.yaml
         self.login_and_go(None)
         b.wait_in_text("#host-apps .pf-m-current", "Overview")
 
-        if m.image.startswith("rhel-8") or m.image.startswith("centos-8") or \
-           m.image == "debian-stable" or m.image == "ubuntu-2204":
+        if (m.image.startswith("rhel-8") or
+                m.image.startswith("centos-8") or
+                m.image in ["debian-stable", "ubuntu-2204"]) and not m.ws_container:
+            # C bridge does not understand manifest conditions yet, and still shows the menu
             self.assertIn("Podman", b.text("#host-apps"))
         else:
+            # Python bridge understands manifest conditions, and hides the menu
             self.assertNotIn("Podman", b.text("#host-apps"))
 
     @testlib.skipImage("nginx not installed", "centos-*", "rhel-*", "debian-*", "ubuntu-*", "arch")

--- a/test/check-application
+++ b/test/check-application
@@ -2479,7 +2479,7 @@ Yaml={name}.yaml
 
         leftover_images = 1
         # cockpit-ws image
-        if self.machine.ws_container and auth:
+        if self.machine.ws_container and (auth or root):
             leftover_images += 1
 
         # By default we have 3 unused images, start one.

--- a/test/check-application
+++ b/test/check-application
@@ -382,7 +382,7 @@ Yaml={name}.yaml
         self.login()
 
         self.filter_containers("running")
-        if not self.machine.ostree_image:
+        if not self.machine.ws_container:
             b.wait_in_text("#containers-containers", "No running containers")
 
         # Run a pods as system
@@ -602,7 +602,7 @@ Yaml={name}.yaml
 
         b.logout()
 
-        if self.machine.ostree_image:
+        if self.machine.ws_container:
             self.machine.execute("echo foobar | passwd --stdin root")
             self.write_file("/etc/ssh/sshd_config.d/99-root-password.conf", "PermitRootLogin yes",
                             post_restore_action="systemctl try-restart sshd")
@@ -642,7 +642,7 @@ Yaml={name}.yaml
             self.allow_browser_errors("Failed to start system podman.socket.*")
 
         expected_ws = ""
-        if auth and self.machine.ostree_image:
+        if auth and self.machine.ws_container:
             expected_ws += "ws"
 
         self.login(system=auth)
@@ -713,7 +713,7 @@ Yaml={name}.yaml
 
         # make sure no running containers shown; on CoreOS there's the cockpit/ws container
         self.filter_containers('running')
-        if auth and self.machine.ostree_image:
+        if auth and self.machine.ws_container:
             self.waitContainerRow("ws")
         else:
             b.wait_in_text("#containers-containers", "No running containers")
@@ -2375,7 +2375,7 @@ Yaml={name}.yaml
         b.wait_in_text('#containers-images .pf-v6-c-empty-state', 'No images that match the current filter')
         b.click('#containers-filter button[aria-label="Reset"]')
 
-        if not auth or not self.machine.ostree_image:  # don't kill ws container
+        if not auth or not self.machine.ws_container:  # don't kill ws container
             # Ubuntu 22.04 has old podman that does not know about --time
             if m.image != 'ubuntu-2204':
                 # Remove all containers first as it is not possible to set --time 0 to rmi command
@@ -2479,7 +2479,7 @@ Yaml={name}.yaml
 
         leftover_images = 1
         # cockpit-ws image
-        if self.machine.ostree_image and auth:
+        if self.machine.ws_container and auth:
             leftover_images += 1
 
         # By default we have 3 unused images, start one.
@@ -2532,7 +2532,7 @@ Yaml={name}.yaml
 
         # Admin / user images are selected
         expected_images = self.user_images_count + self.system_images_count
-        if self.machine.ostree_image:
+        if self.machine.ws_container:
             expected_images -= 1
         b.wait_js_func("ph_count_check", ".pf-v6-c-modal-box__body .pf-v6-c-list li", expected_images)
         # Select user images
@@ -2549,9 +2549,9 @@ Yaml={name}.yaml
         b.click("#image-actions-dropdown")
         b.click("button:contains(Prune unused images)")
         b.wait_js_func("ph_count_check", ".pf-v6-c-modal-box__body .pf-v6-c-list li",
-                       self.system_images_count - 1 if self.machine.ostree_image else self.system_images_count)
+                       self.system_images_count - 1 if self.machine.ws_container else self.system_images_count)
         b.click(".pf-v6-c-modal-box button:contains(Prune)")
-        self.waitNumImages(1 if self.machine.ostree_image else 0)
+        self.waitNumImages(1 if self.machine.ws_container else 0)
 
         # Prune button should now be disabled
         b.click("#image-actions-dropdown")
@@ -2785,7 +2785,7 @@ Yaml={name}.yaml
         self.waitContainer(unhealthy_sha, auth=auth, state='RunningUnhealthy')
         # Unhealthy should be first
         expected_ws = ""
-        if auth and self.machine.ostree_image:
+        if auth and self.machine.ws_container:
             expected_ws = "ws"
         b.wait_collected_text("#containers-containers .container-name", "healthysick" + expected_ws)
 

--- a/test/vm-beiboot.install
+++ b/test/vm-beiboot.install
@@ -1,0 +1,20 @@
+#!/bin/sh
+# image-customize script to prepare a bots VM for cockpit-podman testing
+# This part applies to cockpit/ws container with beibooting
+set -eu
+
+# back up original ws image
+podman save -o /var/tmp/cockpit-ws-original.tar quay.io/cockpit/ws:latest
+
+# update ws container with our current code
+cd /var/tmp
+tar --strip-components=1 -xvf cockpit-podman*.tar.* cockpit-podman/dist
+
+podman build -f - -t quay.io/cockpit/ws:latest . <<EOF
+FROM quay.io/cockpit/ws
+RUN rm -rf /usr/share/cockpit/podman
+COPY dist /usr/share/cockpit/podman
+EOF
+
+# remove preinstalled rpms
+dnf -C remove -y cockpit-bridge cockpit-ws

--- a/test/vm-ws-package.install
+++ b/test/vm-ws-package.install
@@ -1,0 +1,8 @@
+#!/bin/sh
+# image-customize script to prepare a bots VM for cockpit-podman testing
+# This part applies to cockpit-ws package
+set -eu
+
+# don't force https:// (self-signed cert)
+mkdir -p /etc/cockpit
+printf "[WebService]\\nAllowUnencrypted=true\\n" > /etc/cockpit/cockpit.conf

--- a/test/vm.install
+++ b/test/vm.install
@@ -1,5 +1,6 @@
 #!/bin/sh
 # image-customize script to prepare a bots VM for cockpit-podman testing
+# This part applies to any scenario, cockpit-ws package or cockpit/ws container with beiboot
 set -eu
 
 if grep -q ID.*suse /usr/lib/os-release; then
@@ -12,10 +13,6 @@ Delegate=cpu cpuset io memory pids
 EOF
 fi
 
-# don't force https:// (self-signed cert)
-mkdir -p /etc/cockpit
-printf "[WebService]\\nAllowUnencrypted=true\\n" > /etc/cockpit/cockpit.conf
-
 if systemctl is-active -q firewalld.service; then
     firewall-cmd --add-service=cockpit --permanent
 fi
@@ -24,8 +21,10 @@ fi
 # Since 4.0 podman now ships the pause image
 podman images --format '{{.Repository}}:{{.Tag}}' | grep -Ev 'localhost/test-|pause|cockpit/ws' | xargs -r podman rmi -f
 
-# clean up cockpit/ws on Fedora images, as it "breaks" pixel tests; it's only relevant for OSTree images
-bootc status --booted || podman rmi -f quay.io/cockpit/ws || true
+# clean up cockpit/ws on Fedora images, as it "breaks" pixel tests; it's only relevant for OSTree images and rhel-8 beiboot
+if grep -q '^ID=.*fedora' /usr/lib/os-release && ! bootc status --booted; then
+    podman rmi -f quay.io/cockpit/ws || true
+fi
 
 # tests reset podman, save the images
 mkdir -p /var/lib/test-images


### PR DESCRIPTION
Let's deprecate the "native rpm" rhel-8-10 scenario. We won't ever update RHEL 8 to the current upstream versions. Instead, let's make sure that RHEL 8 keeps working with recent cockpit/ws containers or the flatpak in beiboot mode.

Split off the rpm/beiboot specific bits of test image preparation into their own scripts.

---

 - [x] Builds on top of #2191
