### PR TITLE
pyproject.toml: rename rule TCH -> TH

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ select = [
     "RSE",     # flake8-raise
     "RUF",     # ruff rules
     "T10",     # flake8-debugger
-    "TCH",     # flake8-type-checking
+    "TC",      # flake8-type-checking
     "UP032",   # f-string
     "W",       # warnings (mostly whitespace)
     "YTT",     # flake8-2020


### PR DESCRIPTION
This was remapped in ruff 0.8:
https://github.com/astral-sh/ruff/releases/tag/0.8.0