### PR TITLE
test: Fix subuid hack for RHEL

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -31,7 +31,8 @@ chmod 600 /root/.ssh/authorized_keys
 
 # HACK: unbreak subuid assignment for new users; see
 # https://bugzilla.redhat.com/show_bug.cgi?id=2382662
-sed -i '/^SUB_.ID_COUNT/ s/ 0/ 65536/' /etc/login.defs
+# https://issues.redhat.com/browse/RHEL-103765
+sed -i '/^SUB_.ID_COUNT/ s/\b0/65536/' /etc/login.defs
 
 # create user account for logging in
 if ! id admin 2>/dev/null; then

--- a/test/vm.install
+++ b/test/vm.install
@@ -38,8 +38,13 @@ done
 mkdir -p /etc/systemd/user/podman-user-wait-network-online.service.d
 printf '[Service]\nExecStart=\nExecStart=/bin/true\n' > /etc/systemd/user/podman-user-wait-network-online.service.d/disable.conf
 
-# HACK: unbreak subuid assignment for new users; see
+# HACK: unbreak subuid assignment for current and new users; see
 # https://bugzilla.redhat.com/show_bug.cgi?id=2382662
+# https://issues.redhat.com/browse/RHEL-103765
 if [ -e /etc/login.defs ]; then
-    sed -i '/^SUB_.ID_COUNT/ s/ 0/ 65536/' /etc/login.defs
+    sed -i '/^SUB_.ID_COUNT/ s/\b0/65536/' /etc/login.defs
+fi
+if ! grep -q admin /etc/subuid; then
+    usermod --add-subuids 100000-165535 admin
+    usermod --add-subgids 100000-165535 admin
 fi


### PR DESCRIPTION
Stop assuming that the number is preceded by a space; it's a tab in RHEL 9. Just require a word boundary.

Also, with the most recent image refreshes, the `admin` user already doesn't have subuids, so we have to add them back as well.

---

Fixes https://github.com/cockpit-project/bots/pull/8042