### PR TITLE
packit: Enable CentOS 10 image mode

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -26,7 +26,7 @@ jobs:
       centos-stream-9-x86_64:
         distros: ["centos-stream-9", "CentOS-Stream-9-image-mode"]
       centos-stream-9-aarch64: {}
-      centos-stream-10:
+      centos-stream-10-x86_64:
         distros: ["centos-stream-10", "CentOS-Stream-10-image-mode"]
 
   - job: copr_build


### PR DESCRIPTION
This only works with the arch suffix, see
https://github.com/packit/packit-service/issues/2834