### PR TITLE
Sass warnings cleanups

### DIFF
--- a/src/ContainerHealthLogs.jsx
+++ b/src/ContainerHealthLogs.jsx
@@ -19,9 +19,9 @@
 
 import React from 'react';
 
-import { Icon } from '@patternfly/react-core';
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from "@patternfly/react-core/dist/esm/components/DescriptionList";
+import { Icon } from "@patternfly/react-core/dist/esm/components/Icon";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
 import { CheckCircleIcon, ErrorCircleOIcon } from "@patternfly/react-icons";
 

--- a/src/ImageRunModal.scss
+++ b/src/ImageRunModal.scss
@@ -1,4 +1,4 @@
-@import "global-variables";
+@use "global-variables" as *;
 
 // TODO @Venefilyn: This is needed as on mobile without it you won't get any spacing
 // between the right side of the screen - it also creates a width that's wider than

--- a/src/podman.scss
+++ b/src/podman.scss
@@ -1,8 +1,8 @@
 @use "ct-card.scss";
 @use "page.scss";
-@import "global-variables";
+@use "global-variables" as *;
 // For pf-v6-line-clamp
-@import "@patternfly/patternfly/sass-utilities/mixins.scss";
+@use "@patternfly/patternfly/sass-utilities/mixins.scss";
 
 #app .pf-v6-c-card.containers-containers, #app .pf-v6-c-card.containers-images {
     @extend .ct-card;


### PR DESCRIPTION
The barrel file fix in combination with https://github.com/cockpit-project/cockpit/pull/22375 reduces the bundle size with 0.4 MB