### PR TITLE
build.js: don't copy assets when the build is cancelled

### DIFF
--- a/build.js
+++ b/build.js
@@ -70,9 +70,11 @@ const context = await esbuild.context({
         {
             name: 'copy-assets',
             setup(build) {
-                build.onEnd(() => {
-                    fs.copyFileSync('./src/manifest.json', './dist/manifest.json');
-                    fs.copyFileSync('./src/index.html', './dist/index.html');
+                build.onEnd((output, _outputFiles) => {
+                    if (output?.errors.length === 0) {
+                        fs.copyFileSync('./src/manifest.json', './dist/manifest.json');
+                        fs.copyFileSync('./src/index.html', './dist/index.html');
+                    }
                 });
             }
         },


### PR DESCRIPTION
When the build is cancelled in watch mode, `dist` might not exist so copying to it will always fail and show a long useless traceback. Unfortunately esbuild errors don't give much information so we can't match the exact cancelled error.