### PR TITLE
spec: Make node tarball Source1 unconditional

### DIFF
--- a/packaging/cockpit-podman.spec.in
+++ b/packaging/cockpit-podman.spec.in
@@ -27,10 +27,8 @@ URL:            https://github.com/cockpit-project/cockpit-podman
 %define rebuild_bundle 1
 %endif
 
-Source0:        https://github.com/cockpit-project/%{name}/releases/download/%{version}/%{name}-%{version}.tar.xz
-%if %{defined rebuild_bundle}
+Source0: https://github.com/cockpit-project/%{name}/releases/download/%{version}/%{name}-%{version}.tar.xz
 Source1: https://github.com/cockpit-project/%{name}/releases/download/%{version}/%{name}-node-%{version}.tar.xz
-%endif
 
 BuildArch:      noarch
 %if 0%{?suse_version}


### PR DESCRIPTION
I originally made this conditional as it would be dead weight for CentOS/RHEL (where we can't/don't rebuild the bundle). But conditional sources are discouraged [1] and also seem to break packit downstream releases [2].

Thanks to Nikola Forró for the hint!

[1] https://docs.fedoraproject.org/en-US/packaging-guidelines/SourceURL/#_do_not_conditionalize_sources
[2] https://src.fedoraproject.org/rpms/cockpit-podman/pull-request/271#

----

@nforro thanks for having a look!

I'll apply the same treatment to c-files after this lands.