### PR TITLE
packit: Fix for multiple tarballs

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -50,8 +50,8 @@ jobs:
       # HACK: tarball for releases (copr_build, koji, etc.), copying spec's Source0; this
       # really should be the default, see https://github.com/packit/packit-service/issues/1505
       fix-spec-file:
-        - sh -exc "curl -L -O https://github.com/cockpit-project/cockpit-podman/releases/download/${PACKIT_PROJECT_VERSION}/${PACKIT_PROJECT_NAME_VERSION}.tar.xz"
-        - sh -exc "curl -L -O https://github.com/cockpit-project/cockpit-files/releases/download/${PACKIT_PROJECT_VERSION}/cockpit-files-node-${PACKIT_PROJECT_VERSION}.tar.xz"
+        - sh -exc "curl -L --fail -O https://github.com/cockpit-project/cockpit-podman/releases/download/${PACKIT_PROJECT_VERSION}/${PACKIT_PROJECT_NAME_VERSION}.tar.xz"
+        - sh -exc "curl -L --fail -O https://github.com/cockpit-project/cockpit-files/releases/download/${PACKIT_PROJECT_VERSION}/cockpit-files-node-${PACKIT_PROJECT_VERSION}.tar.xz"
 
   - job: copr_build
     trigger: commit


### PR DESCRIPTION
Commit 0e6a2671 forgot to adjust the packit recipe. We missed to update Source1: to the locally built -node tarball. So up to now it was using the tarball from the latest release. That *happened* to work so far, but once we change package.json it's not going to any more.

Also update the upstream release COPR build rule.

----

See [recent build log](https://download.copr.fedorainfracloud.org/results/packit/cockpit-project-cockpit-podman-2349/fedora-42-x86_64/09853036-cockpit-podman/builder-live.log.gz):

> INFO: Downloading cockpit-podman-node-118.tar.xz

Oops!

@jelly spotted that in https://github.com/cockpit-project/cockpit/pull/22634#discussion_r2576991746