### PR TITLE
Only fetch last container logs in ContainerLogs component

### DIFF
--- a/src/ContainerLogs.jsx
+++ b/src/ContainerLogs.jsx
@@ -35,6 +35,8 @@ import "./ContainerTerminal.css";
 
 const _ = cockpit.gettext;
 
+const LOGS_MAX_SIZE = 1000;
+
 class ContainerLogs extends React.Component {
     constructor(props) {
         super(props);
@@ -51,7 +53,8 @@ class ContainerLogs extends React.Component {
             disableStdin: true,
             fontSize: 12,
             fontFamily: 'Menlo, Monaco, Consolas, monospace',
-            screenReaderMode: true
+            screenReaderMode: true,
+            scrollback: LOGS_MAX_SIZE,
         });
         this.view._core.cursorHidden = true;
         this.view.write(_("Loading logs..."));
@@ -115,7 +118,7 @@ class ContainerLogs extends React.Component {
 
         const connection = rest.connect(this.props.uid);
         connection.monitor(client.VERSION + "libpod/containers/" + this.props.containerId +
-                           "/logs?follow=true&stdout=true&stderr=true",
+                           `/logs?follow=true&stdout=true&stderr=true&tail=${LOGS_MAX_SIZE}`,
                            this.onStreamMessage, true)
                 .then(this.onStreamClose)
                 .catch(e => {


### PR DESCRIPTION
When we open the logs tab of a container, we fetch all container logs, which can take a while if it has many.
Even if we fetch all logs, we'll only display the last 1000 due to the Terminal component props.

In this PR I clarified the max Terminal scrollback size and fetched only the last 1000 logs from the container, so we don't wait a lot with the first fetch

Related to https://github.com/cockpit-project/cockpit-podman/issues/2362