### PR TITLE
Mention default scrollback size

### DIFF
--- a/src/ContainerLogs.jsx
+++ b/src/ContainerLogs.jsx
@@ -35,6 +35,7 @@ import "./ContainerTerminal.css";
 
 const _ = cockpit.gettext;
 
+// Default xterm.js scrollback size https://xtermjs.org/docs/api/terminal/interfaces/iterminaloptions/#optional-scrollback
 const LOGS_MAX_SIZE = 1000;
 
 class ContainerLogs extends React.Component {


### PR DESCRIPTION
Keep track of why we set the default amount of podman logs to fetch to 1000.