### PR TITLE
dependabot: ignore major xterm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,10 @@ updates:
       - dependency-name: "*react*"
         update-types: ["version-update:semver-major"]
 
+      # @xterm/addon-canvas is deprecated and requires xterm/xterm 5.x.x
+      - dependency-name: "@xterm/*"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     open-pull-requests-limit: 3


### PR DESCRIPTION
Closes: #2379

xterm/addon-canvas support was dropped and it requires xterm/xterm 5.x.x