### PR TITLE
packaging: require /usr/bin/node as buildrequires for Fedora rawhidu

### DIFF
--- a/packaging/cockpit-podman.spec.in
+++ b/packaging/cockpit-podman.spec.in
@@ -44,6 +44,7 @@ BuildRequires: libappstream-glib-devel
 %endif
 %if %{defined rebuild_bundle}
 BuildRequires: nodejs
+BuildRequires: %{_bindir}/node
 BuildRequires: nodejs-esbuild
 %endif
 


### PR DESCRIPTION
Depend on the binary as rawhide transitioned into providing `nodejs` via a `nodejs-bin`.

https://fedoraproject.org/wiki/Changes/NodejsAlternativesSystem