### PR TITLE
Show description, version and doc labels for images

### DIFF
--- a/src/ImageDetails.jsx
+++ b/src/ImageDetails.jsx
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 import React from 'react';
 
+import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from "@patternfly/react-core/dist/esm/components/DescriptionList";
 
 import cockpit from 'cockpit';
@@ -11,8 +12,36 @@ import * as utils from './util.js';
 const _ = cockpit.gettext;
 
 const ImageDetails = ({ containers, image, showAll }) => {
+    const labels = image?.Labels;
+
+    // https://specs.opencontainers.org/image-spec/annotations/?v=v1.1.1
+    const imageDescription = labels?.["org.opencontainers.image.description"];
+    const imageDocumentation = labels?.["org.opencontainers.image.documentation"];
+    const imageVersion = labels?.["org.opencontainers.image.version"];
     return (
         <DescriptionList className='image-details' isAutoFit>
+            {imageDescription &&
+            <DescriptionListGroup>
+                <DescriptionListTerm>{_("Description")}</DescriptionListTerm>
+                <DescriptionListDescription data-label="description">{imageDescription}</DescriptionListDescription>
+            </DescriptionListGroup>
+            }
+            {imageVersion &&
+            <DescriptionListGroup>
+                <DescriptionListTerm>{_("Version")}</DescriptionListTerm>
+                <DescriptionListDescription data-label="version">{imageVersion}</DescriptionListDescription>
+            </DescriptionListGroup>
+            }
+            {imageDocumentation &&
+            <DescriptionListGroup>
+                <DescriptionListTerm>{_("Links")}</DescriptionListTerm>
+                <DescriptionListDescription data-label="documentation">
+                    <Button variant="link" isInline component="a" href={imageDocumentation} target="_blank noreferrer">
+                        {_("Documentation")}
+                    </Button>
+                </DescriptionListDescription>
+            </DescriptionListGroup>
+            }
             {image.Command &&
             <DescriptionListGroup>
                 <DescriptionListTerm>{_("Command")}</DescriptionListTerm>

--- a/test/check-application
+++ b/test/check-application
@@ -3130,6 +3130,26 @@ Yaml={name}.yaml
             service_container = m.execute("podman ps --all --filter name=.*-service --format {{.Names}}").strip()
             b.wait_not_present(f"#containers-containers tbody tr[data-row-id=\"{service_container}\"]")
 
+        # opencontainer annotations https://specs.opencontainers.org/image-spec/annotations/
+        label_image = "localhost/label-image:latest"
+        tmpdir = self.execute("mktemp -d", system=True).strip()
+        self.execute(f"echo 'FROM {IMG_REGISTRY}\nRUN ls' > {tmpdir}/Containerfile", system=True)
+        doc_label = "--label org.opencontainers.image.documentation='https://cockpit-project.org'"
+        desc_label = "--label org.opencontainers.image.description='The Cockpit container running cockpit-ws'"
+        version_label = "--label org.opencontainers.image.version='355'"
+        m.execute(f"""podman build -t {label_image} {doc_label} {desc_label} {version_label} {tmpdir}""")
+        checkImage(b, label_image, "system")
+        img_id = m.execute(f"podman inspect --format '{{{{ .Id }}}}' {label_image}").strip()
+        b.click(f"#containers-images tr[data-row-id='0-{img_id}'] td.pf-v6-c-table__toggle button")
+        b.wait_text("#containers-images tbody.pf-m-expanded tr .image-details [data-label='version']", "355")
+        b.wait_text("#containers-images tbody.pf-m-expanded tr .image-details [data-label='description']",
+                    "The Cockpit container running cockpit-ws")
+        self.assertEqual(b.attr(
+                            "#containers-images tbody.pf-m-expanded tr .image-details [data-label='documentation'] a",
+                            "href"
+                         ),
+                         "https://cockpit-project.org")
+
     def testCreatePodSystem(self) -> None:
         self._createPod(auth=True)
 


### PR DESCRIPTION
The OpenContainers Annotations Spec specifies what standardised labels may exist on a container image. For now expose the description, documentation link and version in the image details tab. This is particularly useful showing the version of the software you run when using the `latest` tag.

---

# Podman: Show description, version and documentation image labels 

The image details tab now shows a select set of labels from the [opencontainers annotations specification](https://specs.opencontainers.org/image-spec/annotations/). This is particularly useful to find out what version the `latest` tag of an image is.

<img width="1333" height="252" alt="image" src="https://github.com/user-attachments/assets/6d02d554-bab2-4437-bb5a-4c8d488a5d14" />
