### PR TITLE
Disable container actions when there are none

### DIFF
--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -280,7 +280,7 @@ const ContainerActions = ({ con, container, onAddNotification, localImages, upda
         );
     }
 
-    return <KebabDropdown position="right" dropdownItems={actions} isDisabled={isDownloading} />;
+    return <KebabDropdown position="right" dropdownItems={actions} isDisabled={isDownloading || actions.length === 0} />;
 };
 
 export let onDownloadContainer = function funcOnDownloadContainer(container) {

--- a/test/check-application
+++ b/test/check-application
@@ -3696,6 +3696,8 @@ ContainerName=guitarq1
             b.wait_text("#containers-containers .container-name", "guitarq1")
             b.wait_text("#containers-containers [data-label='Owner']", "user: guitar")
             b.wait_visible("#containers-containers .ct-badge-service")
+            # Dropdown menu is disabled as no lifecycle actions are supported
+            b.wait_visible("#containers-containers td.pf-v6-c-table__action button:disabled")
 
             # No systemd service link is shown for quadlets from other users as
             # the services page doesn't support anything except the logged in/admin/root user.


### PR DESCRIPTION
When showing other users quadlets we don't support lifecycle actions so the menu is empty.