### PR TITLE
workflows: Run browser integration tests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,5 @@
 name: CodeQL
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   analyze:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,56 @@
+name: Test
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # TODO: read from bots test map
+        test_os:
+          - centos-9-bootc
+          - fedora-43
+
+    steps:
+      - name: Set up /dev/kvm
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm --settle
+          ls -l /dev/kvm
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Start tasks container
+        run: |
+          podman run -d --rm --name tasks \
+            --user github \
+            --init \
+            --device /dev/kvm \
+            --shm-size=512m \
+            --env TEST_OS=${{ matrix.test_os }} \
+            --env HOME=/tmp/home \
+            -v ${{ github.workspace }}:/workspace:U \
+            -w /workspace \
+            $(< .cockpit-ci/container) sh -c 'sleep infinity'
+
+      - name: Create home dir
+        run: podman exec tasks mkdir -p /tmp/home
+
+      # https://github.blog/2022-04-12-git-security-vulnerability-announced/
+      - name: Pacify git's permission check
+        run: podman exec tasks git config --global --add safe.directory /workspace
+
+      - name: Build package and test VM
+        run: podman exec tasks make prepare-check
+
+      - name: Run integration tests
+        run: podman exec tasks make check


### PR DESCRIPTION
This is just a proof of concept. It's missing image/npm/pixel git cache and posting to S3.

---

Moreover, this is *slow*. See [this run on my fork](https://github.com/martinpitt/cockpit-podman/actions/runs/21989748043/job/63533286891). The "build package" is slow mostly because of the .qcow2 download (there is no caching). If we ever want to actually *do* that, we need a solution for an image cache for workflows.

But running the integration test (at two tests in parallel) takes 14 mins, whereas on our CI [it takes 5](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-2430-b6ed1db5-20260212-042305-fedora-43/log). So this is really only an option for small projects, like starter-kit and cockpit-{files,podman}.