### PR TITLE
move registries.conf format to v2

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -14,11 +14,23 @@ from lib.constants import DEFAULT_IDENTITY_PUB_FILE
 from machine.machine_core import ssh_connection
 
 REGISTRIES_CONF = """
-[registries.search]
-registries = ['localhost:5000', 'localhost:6000', 'subdomain.local.localhost:7000']
+unqualified-search-registries = ["localhost:5000", "localhost:6000", "subdomain.local.localhost:7000"]
 
-[registries.insecure]
-registries = ['localhost:80', 'localhost:5000', 'localhost:6000', 'subdomain.local.localhost:7000']
+[[registry]]
+  location = "localhost:80"
+  insecure = true
+
+[[registry]]
+  location = "localhost:5000"
+  insecure = true
+
+[[registry]]
+  location = "localhost:6000"
+  insecure = true
+
+[[registry]]
+  location = "subdomain.local.localhost:7000"
+  insecure = true
 """
 
 NOT_RUNNING = ["Exited", "Stopped"]


### PR DESCRIPTION
Podman 6 is going to drop support for reading the old v1 format in https://github.com/containers/container-libs/pull/773

The v2 format is supported for a long time already so this can just be switched and still works with older versions.