### PR TITLE
move registries.conf into drop in directory

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -324,7 +324,8 @@ class TestApplication(testlib.MachineCase):
         """)
 
         # Add local insecure registry into registries conf
-        m.write("/etc/containers/registries.conf", REGISTRIES_CONF)
+        m.execute("mkdir -p /etc/containers/registries.conf.d")
+        m.write("/etc/containers/registries.conf.d/99-cockpit-podman-test.conf", REGISTRIES_CONF)
         m.execute("systemctl stop podman.service")
 
     def createQuadlet(self, name: str, podName: str | None = None, containerName: str | None = None,


### PR DESCRIPTION
Follow up to[1], with the packaging changes for new config file work[2] we now have vendor overwrites as drop 00-vendor.conf. That file is parsed after /etc/containers/registries.conf and as such the unqualified-search-registries setting is overwritten again.

To ensure the cockpit test file is parsed last put it into the drop in directory as 99-cockpit-podman-test.conf which should also help to make it clear what own/created the file.

This /etc/containers/registries.conf.d directory has been supported for a while already so this works not just with podman 6 but also the previous ones making so not version logic is needed here.

[1] 772987d (move registries.conf format to v2)
[2] https://github.com/containers/container-libs/pull/795