### PR TITLE
test: Fix test failure artifacts

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -177,6 +177,8 @@ class TestApplication(testlib.MachineCase):
                 self.execute('for c in $(podman ps -aq); do echo "---- $c ----" >&2; podman logs $c >&2; done',
                              system=auth)
 
+        super().tearDown()
+
         # HACK: avoid failing tests on oopses when cleaning up containers below
         if self.browser.have_test_api():
             self.browser.switch_to_top()
@@ -192,8 +194,6 @@ class TestApplication(testlib.MachineCase):
                 runuser -u $username -- env XDG_RUNTIME_DIR=/run/user/$u podman rm -f -t0 --all || true
             done
             """)
-
-        super().tearDown()
 
     def podman_version(self) -> tuple[int, ...]:
         version = self.execute("podman -v", system=False).strip().split(' ')[-1]


### PR DESCRIPTION
Commit 15c074163aa6 broke failure screenshots/HTML dumps: It *first* logged out of the session and shut it down, and *then* called the parent tearDown() which does the artifact dumping. That made the artifacts always show the login page, and thus useless.

---

See e.g. [this failure](https://cockpit-ci-logs.s3.us-east-1.amazonaws.com/pull-2541-6c3b96f3-20260520-120637-fedora-44-firefox/log.html#42-2) from #2541. I ran this locally, and `TestApplication-testRunImageUser-fedora-44-127.0.0.2-2201-FAIL.png` is correct again.