### PR TITLE
URL parameter support for the "download images" dialog

### DIFF
--- a/src/ImageSearchDialogOpener.jsx
+++ b/src/ImageSearchDialogOpener.jsx
@@ -1,0 +1,76 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+import React, { useState, useEffect } from 'react';
+
+import cockpit from 'cockpit';
+
+import { ImageSearchModal } from './ImageSearchModal.jsx';
+
+/**
+ * Component that renders the ImageSearchModal when URL parameters are present.
+ * Uses declarative rendering based on URL state (the URL is the single source of truth).
+ *
+ * Supported URL formats:
+ * - #?action=download-image
+ * - #?action=download-image&search=cockpit
+ * - #?action=download-image&registry=docker.io&search=cockpit&owner=user&tag=latest
+ *
+ * Parameters:
+ * - action: 'download-image' (required to open dialog)
+ * - registry: Registry to pre-select (optional)
+ * - search: Search term to pre-fill and auto-search (optional)
+ * - owner: 'system' or 'user' (optional, defaults to 'user')
+ * - tag: Tag to pre-fill (optional, defaults to 'latest')
+ */
+export const ImageSearchDialogOpener = ({ downloadImage, users }) => {
+    const [location, setLocation] = useState(cockpit.location);
+
+    useEffect(() => {
+        const handler = () => setLocation({ ...cockpit.location });
+        cockpit.addEventListener("locationchanged", handler);
+        return () => cockpit.removeEventListener("locationchanged", handler);
+    }, []);
+
+    const { options } = location;
+    const action = options.action;
+
+    // Determine if dialog should be shown
+    const showDialog = action === 'download-image';
+
+    // Don't render until users array is populated with connections to avoid flicker
+    // The users array is initialized with dummy data (con: null) and later updated with real connections
+    if (!showDialog || !users || users.length === 0 || !users[0].con) return null;
+
+    // Parse URL parameters
+    const initialRegistry = typeof options.registry === 'string' ? options.registry : undefined;
+    const initialSearchTerm = typeof options.search === 'string' ? options.search : undefined;
+    const initialTag = typeof options.tag === 'string' ? options.tag : 'latest';
+
+    // Parse owner parameter - default to 'user', validate it's either 'system' or 'user'
+    let initialOwner = 'user';
+    if (typeof options.owner === 'string') {
+        if (options.owner === 'system' || options.owner === 'user') {
+            initialOwner = options.owner;
+        }
+    }
+
+    // Close handler clears URL parameters
+    const handleClose = () => {
+        cockpit.location.replace(cockpit.location.path, {});
+    };
+
+    // Generate key from URL params to force re-mount when params change
+    const dialogKey = `${action}-${options.registry}-${options.search}-${options.owner}-${options.tag}`;
+
+    return (
+        <ImageSearchModal
+            key={dialogKey}
+            downloadImage={downloadImage}
+            users={users}
+            initialRegistry={initialRegistry}
+            initialSearchTerm={initialSearchTerm}
+            initialOwner={initialOwner}
+            initialTag={initialTag}
+            onExternalClose={handleClose}
+        />
+    );
+};

--- a/src/ImageSearchModal.jsx
+++ b/src/ImageSearchModal.jsx
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { Button } from "@patternfly/react-core/dist/esm/components/Button";
 import { DataList, DataListCell, DataListItem, DataListItemCells, DataListItemRow } from "@patternfly/react-core/dist/esm/components/DataList";
@@ -26,13 +26,25 @@ import './ImageSearchModal.css';
 
 const _ = cockpit.gettext;
 
-export const ImageSearchModal = ({ downloadImage, users }) => {
+export const ImageSearchModal = ({ downloadImage, users, initialSearchTerm = "", initialRegistry = "", initialOwner = "user", initialTag = "latest", onExternalClose }) => {
+    // Determine initial user based on initialOwner parameter
+    const getInitialUser = () => {
+        if (!users || users.length === 0) return users?.[0] || null;
+
+        if (initialOwner === 'system') {
+            return users.find(u => u.uid === 0) || users[0];
+        } else if (initialOwner === 'user') {
+            return users.find(u => u.uid === null) || users[0];
+        }
+        return users[0];
+    };
+
     const [searchInProgress, setSearchInProgress] = useState(false);
     const [searchFinished, setSearchFinished] = useState(false);
     const [imageIdentifier, setImageIdentifier] = useState('');
     const [imageList, setImageList] = useState([]);
     const [imageTag, setImageTag] = useState("");
-    const [user, setUser] = useState(users[0]);
+    const [user, setUser] = useState(getInitialUser);
     const [selectedRegistry, setSelectedRegistry] = useState("");
     const [selected, setSelected] = useState("");
     const [dialogError, setDialogError] = useState("");
@@ -45,21 +57,45 @@ export const ImageSearchModal = ({ downloadImage, users }) => {
     // Registries to use for searching
     const searchRegistries = registries?.search && registries.search.length !== 0 ? registries.search : fallbackRegistries;
 
+    // Handle initial search from URL parameters
+    useEffect(() => {
+        // Set initial tag
+        if (initialTag) {
+            setImageTag(initialTag);
+        }
+
+        // Set initial search - guard against null user
+        if (initialSearchTerm && user) {
+            setImageIdentifier(initialSearchTerm);
+            if (initialRegistry) {
+                setSelectedRegistry(initialRegistry);
+            }
+            // Pass initialSearchTerm directly to avoid race condition with setState
+            onSearchTriggered(initialRegistry || "", true, initialSearchTerm);
+        }
+        // Intentionally only run on mount - component is re-mounted via key when props change
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
     // Don't use on selectedRegistry state variable for finding out the
     // registry to search in as with useState we can only call something after a
     // state update with useEffect but as onSearchTriggered also changes state we
     // can't use that so instead we pass the selected registry.
-    const onSearchTriggered = (searchRegistry = "", forceSearch = false) => {
+    // searchTerm parameter allows passing the search term directly to avoid race conditions with setState
+    const onSearchTriggered = (searchRegistry = "", forceSearch = false, searchTerm = null) => {
         // When search re-triggers close any existing active connection
         activeConnection = rest.connect(user.uid);
         if (activeConnection)
             activeConnection.close();
         setSearchFinished(false);
 
+        // Use provided searchTerm or fall back to imageIdentifier state
+        const termToSearch = searchTerm !== null ? searchTerm : imageIdentifier;
+
         // Do not call the SearchImage API if the input string  is not at least 2 chars,
         // unless Enter is pressed, which should force start the search.
         // The comparison was done considering the fact that we miss always one letter due to delayed setState
-        if (imageIdentifier.length < 2 && !forceSearch)
+        if (termToSearch.length < 2 && !forceSearch)
             return;
 
         setSearchInProgress(true);
@@ -69,7 +105,7 @@ export const ImageSearchModal = ({ downloadImage, users }) => {
             queryRegistries = [searchRegistry];
         }
         // if a user searches for `docker.io/cockpit` let podman search in the user specified registry.
-        if (imageIdentifier.includes('/')) {
+        if (termToSearch.includes('/')) {
             queryRegistries = [""];
         }
 
@@ -80,7 +116,7 @@ export const ImageSearchModal = ({ downloadImage, users }) => {
                 path: `${client.VERSION}libpod/images/search`,
                 body: "",
                 params: {
-                    term: registry + imageIdentifier
+                    term: registry + termToSearch
                 }
             });
         });
@@ -124,13 +160,20 @@ export const ImageSearchModal = ({ downloadImage, users }) => {
         const selectedImageName = imageList[selected].Name;
         if (activeConnection)
             activeConnection.close();
-        Dialogs.close();
+        // Use onExternalClose if provided (URL-based rendering), otherwise use Dialogs.close (modal rendering)
+        if (onExternalClose) {
+            onExternalClose();
+        } else {
+            Dialogs.close();
+        }
         downloadImage(selectedImageName, imageTag, user.con);
     };
 
     const handleClose = () => {
         if (activeConnection)
             activeConnection.close();
+        if (onExternalClose)
+            onExternalClose();
         Dialogs.close();
     };
 
@@ -151,7 +194,7 @@ export const ImageSearchModal = ({ downloadImage, users }) => {
                                    label={u.name}
                                    id={`image-search-modal-owner-${u.name}`}
                                    onChange={onToggleUser}
-                                   isChecked={u === user} />))
+                                   isChecked={u.uid === user?.uid} />))
                         }
                     </FormGroup>}
                     <Flex spaceItems={{ default: 'inlineFlex', modifier: 'spaceItemsXl' }}>
@@ -219,7 +262,7 @@ export const ImageSearchModal = ({ downloadImage, users }) => {
                                onChange={(_event, value) => setImageTag(value)} />
                     </FormGroup>
                 </Form>
-                <Button variant='primary' isDisabled={selected === ""} onClick={onDownloadClicked}>
+                <Button variant='primary' isDisabled={selected === "" || !user} onClick={onDownloadClicked}>
                     {_("Download")}
                 </Button>
                 <Button variant='link' className='btn-cancel' onClick={handleClose}>

--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -7,6 +7,7 @@ import { Content, ContentVariants } from "@patternfly/react-core/dist/esm/compon
 import { DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown/index.js';
 import { ExpandableSection } from "@patternfly/react-core/dist/esm/components/ExpandableSection";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
+import { Spinner } from "@patternfly/react-core/dist/esm/components/Spinner";
 import { cellWidth, SortByDirection } from '@patternfly/react-table';
 import { KebabDropdown } from "cockpit-components-dropdown.jsx";
 import { useDialogs, DialogsContext } from "dialogs.jsx";
@@ -141,8 +142,14 @@ class Images extends React.Component {
         const user = this.props.users.find(user => user.uid === image.uid);
         cockpit.assert(user, `User not found for image uid ${image.uid}`);
 
+        const imageName = utils.image_name(image);
+        const isDownloading = this.state.imageDownloadInProgress.includes(imageName);
+        const imageNameDisplay = isDownloading
+            ? <><Spinner size="md" style={{ marginRight: '8px' }} />{imageName}</>
+            : imageName;
+
         const columns = [
-            { title: utils.image_name(image), header: true, props: { modifier: "breakWord" } },
+            { title: imageNameDisplay, header: true, props: { modifier: "breakWord" } },
             { title: (image.uid == 0) ? _("system") : <div><span className="ct-grey-text">{_("user:")} </span>{user.name}</div>, props: { className: "ignore-pixels", modifier: "nowrap" }, sortKey: user.name },
             { title: <utils.RelativeTime time={image.Created * 1000} />, props: { className: "image-created" }, sortKey: image.Created },
             { title: utils.truncate_id(image.Id), props: { className: "image-id" } },
@@ -356,7 +363,10 @@ class Images extends React.Component {
                     users={this.props.users} />
                     }
                     {this.state.imageDownloadInProgress.length > 0 && <CardFooter>
-                        <div className='download-in-progress'> {_("Pulling")} {this.state.imageDownloadInProgress.join(', ')}... </div>
+                        <div className='download-in-progress'>
+                            <Spinner size="md" style={{ marginRight: '8px' }} />
+                            {_("Pulling")} {this.state.imageDownloadInProgress.join(', ')}...
+                        </div>
                     </CardFooter>}
                 </Card>
             </>

--- a/src/Images.jsx
+++ b/src/Images.jsx
@@ -19,6 +19,7 @@ import { ImageDeleteModal } from './ImageDeleteModal.jsx';
 import ImageDetails from './ImageDetails.jsx';
 import ImageHistory from './ImageHistory.jsx';
 import { ImageRunModal } from './ImageRunModal.jsx';
+import { ImageSearchDialogOpener } from './ImageSearchDialogOpener.jsx';
 import { ImageSearchModal } from './ImageSearchModal.jsx';
 import PruneUnusedImagesModal from './PruneUnusedImagesModal.jsx';
 import * as client from './client.js';
@@ -306,35 +307,40 @@ class Images extends React.Component {
         );
 
         return (
-            <Card id="containers-images" key="images" className="containers-images">
-                <CardHeader>
-                    <Flex flexWrap={{ default: 'nowrap' }} className="pf-v6-u-w-100">
-                        <FlexItem grow={{ default: 'grow' }}>
-                            <Flex>
-                                <CardTitle>
-                                    <Content component={ContentVariants.h1} className="containers-images-title">{_("Images")}</Content>
-                                </CardTitle>
-                                <Flex className="ignore-pixels" style={{ rowGap: "var(--pf-t--global--spacer--xs)" }}>{imageTitleStats}</Flex>
-                            </Flex>
-                        </FlexItem>
-                        <FlexItem>
-                            <ImageOverActions handleDownloadNewImage={this.onOpenNewImagesDialog}
+            <>
+                <ImageSearchDialogOpener
+                    downloadImage={this.downloadImage}
+                    users={this.props.users}
+                />
+                <Card id="containers-images" key="images" className="containers-images">
+                    <CardHeader>
+                        <Flex flexWrap={{ default: 'nowrap' }} className="pf-v6-u-w-100">
+                            <FlexItem grow={{ default: 'grow' }}>
+                                <Flex>
+                                    <CardTitle>
+                                        <Content component={ContentVariants.h1} className="containers-images-title">{_("Images")}</Content>
+                                    </CardTitle>
+                                    <Flex className="ignore-pixels" style={{ rowGap: "var(--pf-t--global--spacer--xs)" }}>{imageTitleStats}</Flex>
+                                </Flex>
+                            </FlexItem>
+                            <FlexItem>
+                                <ImageOverActions handleDownloadNewImage={this.onOpenNewImagesDialog}
                                               handlePullAllImages={this.onPullAllImages}
                                               handlePruneUsedImages={this.onOpenPruneUnusedImagesDialog}
                                               unusedImages={unusedImages} />
-                        </FlexItem>
-                    </Flex>
-                </CardHeader>
-                <CardBody>
-                    {this.props.images && Object.keys(this.props.images).length
-                        ? <ExpandableSection toggleText={this.state.isExpanded ? _("Hide images") : _("Show images")}
+                            </FlexItem>
+                        </Flex>
+                    </CardHeader>
+                    <CardBody>
+                        {this.props.images && Object.keys(this.props.images).length
+                            ? <ExpandableSection toggleText={this.state.isExpanded ? _("Hide images") : _("Show images")}
                                              onToggle={() => this.setState(prevState => ({ isExpanded: !prevState.isExpanded }))}
                                              isExpanded={this.state.isExpanded}>
-                            {cardBody}
-                        </ExpandableSection>
-                        : cardBody}
-                </CardBody>
-                {/* The PruneUnusedImagesModal dialog needs to keep
+                                {cardBody}
+                            </ExpandableSection>
+                            : cardBody}
+                    </CardBody>
+                    {/* The PruneUnusedImagesModal dialog needs to keep
                   * its list of unused images in sync with reality at
                   * all times since the API call will delete whatever
                   * is unused at the exact time of call, and the
@@ -342,17 +348,18 @@ class Images extends React.Component {
                   * unused images at that time.  Thus, we can't use
                   * Dialog.show for it but include it here in the
                   * DOM. */}
-                { this.state.showPruneUnusedImagesModal &&
+                    { this.state.showPruneUnusedImagesModal &&
                     <PruneUnusedImagesModal
                     close={() => this.setState({ showPruneUnusedImagesModal: false })}
                     unusedImages={unusedImages}
                     onAddNotification={this.props.onAddNotification}
                     users={this.props.users} />
-                }
-                {this.state.imageDownloadInProgress.length > 0 && <CardFooter>
-                    <div className='download-in-progress'> {_("Pulling")} {this.state.imageDownloadInProgress.join(', ')}... </div>
-                </CardFooter>}
-            </Card>
+                    }
+                    {this.state.imageDownloadInProgress.length > 0 && <CardFooter>
+                        <div className='download-in-progress'> {_("Pulling")} {this.state.imageDownloadInProgress.join(', ')}... </div>
+                    </CardFooter>}
+                </Card>
+            </>
         );
     }
 }

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -776,6 +776,10 @@ class Application extends React.Component {
                 if (options.container) {
                     this.onContainerFilterChanged(options.container);
                 }
+                // Skip owner parameter processing when action=download-image (it's for the dialog, not the filter)
+                if (options.action === 'download-image') {
+                    return;
+                }
                 if (["all", undefined].includes(options.owner)) {
                     // disconnect all non-standard users
                     this.setState(prevState => ({


### PR DESCRIPTION
This is a POC of adding URL parameter support to the "download images" dialog. With the changes on this branch, you can open the dialog and pre-populate all the fields (owner, registry, search term, tag).

URL format: `#?action=download-image&search=<term>&registry=<registry>&owner=<system|user>&tag=<tag>`

All parameters except 'action' are optional. The dialog automatically:
- Pre-fills search term and triggers search (default: unspecified)
- Selects specified registry (default: unspecified, so "all registries")
- Chooses system or user owner (default: user)
- Pre-fills image tag (default: latest)

I know it convolutes this branch a little, but I also integrated a spinner as a separate commit. This part could be a less controversial and easy-to-merge change. If you like, I'd be happy to extract it into a separate pull request.