### PR TITLE
fix: correct container name validation regex

### DIFF
--- a/src/util.tsx
+++ b/src/util.tsx
@@ -159,7 +159,7 @@ export function image_name(image: { RepoTags?: string[] }): string {
 }
 
 export function is_valid_container_name(name: string): boolean {
-    return /^[a-zA-Z0-9][a-zA-Z0-9_\\.-]*$/.test(name);
+    return /^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/.test(name);
 }
 
 type ValidationState = Record<string, unknown>;


### PR DESCRIPTION
Corrected the `is_valid_container_name` regular expression to correctly validate allowed container name characters. The previous implementation incorrectly included a backslash (`\`) in the allowed characters and had an ambiguous hyphen character handling in the character class, which did not align with the stated requirements in the UI error message. This fix ensures that only alphanumeric characters, underscores, periods, and hyphens are permitted, improving input validation robustness. Closes #0