### PR TITLE
Don't use this.state in setState()

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -83,24 +83,21 @@ class Application extends React.Component {
     }
 
     onAddNotification(notification) {
-        notification.index = this.state.notifications.length;
-
-        this.setState(prevState => ({
-            notifications: [
-                ...prevState.notifications,
-                notification
-            ]
-        }));
+        this.setState(prevState => {
+            notification.index = prevState.notifications.length;
+            return {
+                notifications: [
+                    ...prevState.notifications,
+                    notification
+                ]
+            };
+        });
     }
 
     onDismissNotification(notificationIndex) {
-        const notificationsArray = this.state.notifications.concat();
-        const index = notificationsArray.findIndex(current => current.index == notificationIndex);
-
-        if (index !== -1) {
-            notificationsArray.splice(index, 1);
-            this.setState({ notifications: notificationsArray });
-        }
+        this.setState(prevState => ({
+            notifications: prevState.notifications.filter(current => current.index != notificationIndex)
+        }));
     }
 
     updateUrl(options) {

--- a/test/check-application
+++ b/test/check-application
@@ -1254,6 +1254,12 @@ Yaml={name}.yaml
 
                 return self
 
+            def dismissNotification(self) -> Self:
+                b.click('.pf-v6-c-alert-group.pf-m-toast .pf-v6-c-alert .pf-v6-c-alert__action button')
+                b.wait_not_present('.pf-v6-c-alert-group.pf-m-toast .pf-v6-c-alert')
+
+                return self
+
             def expectSearchErrorForNotExistingImage(self) -> Self:
                 b.wait_visible(f".pf-v6-c-modal-box__body:contains('No results for {self.imageName}')")
                 b.click(".pf-v6-c-modal-box button.btn-cancel")
@@ -1375,7 +1381,8 @@ Yaml={name}.yaml
         dialog.openDialog() \
               .fillDialog() \
               .selectImageAndDownload() \
-              .expectDownloadErrorForNonExistingTag()
+              .expectDownloadErrorForNonExistingTag() \
+              .dismissNotification()
 
     def testPullImage(self) -> None:
         b = self.browser


### PR DESCRIPTION
As setState runs asynchronously it might operate on an older state, using prevstate simplifies the code and avoids this issue.

Additionally add test coverage for dismissing a notification.