### PR TITLE
pyproject: use rule name instead of code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ select = [
     "A",       # flake8-builtins
     "B",       # flake8-bugbear
     "C4",      # flake8-comprehensions
-    "D300",    # pydocstyle: Forbid ''' in docstrings
+    "triple-single-quotes",    # pydocstyle: Forbid ''' in docstrings
     "DTZ",     # flake8-datetimez
     "E",       # pycodestyle
     "EXE",     # flake8-executable
@@ -59,7 +59,7 @@ select = [
     "RUF",     # ruff rules
     "T10",     # flake8-debugger
     "TC",      # flake8-type-checking
-    "UP032",   # f-string
+    "f-string",   # f-string
     "W",       # warnings (mostly whitespace)
     "YTT",     # flake8-2020
 ]


### PR DESCRIPTION
Since Ruff 0.16 rule names are preferred.