### PR TITLE
healthcheck: Fix responsive DescriptionList layout on mobile

### DIFF
--- a/src/ContainerHealthLogs.jsx
+++ b/src/ContainerHealthLogs.jsx
@@ -41,7 +41,13 @@ const ContainerHealthLogs = ({ con, container, onAddNotification, state }) => {
         <>
             <Flex alignItems={{ default: "alignItemsFlexStart" }}>
                 <FlexItem grow={{ default: 'grow' }}>
-                    <DescriptionList isAutoFit id="container-details-healthcheck">
+                    <DescriptionList
+                        id="container-details-healthcheck"
+                        columnModifier={{
+                            default: '1Col', 
+                            md: '3Col',    
+                        }}
+                    >
                         <DescriptionListGroup>
                             <DescriptionListTerm>{_("Status")}</DescriptionListTerm>
                             <DescriptionListDescription>{state}</DescriptionListDescription>

--- a/src/ContainerHealthLogs.jsx
+++ b/src/ContainerHealthLogs.jsx
@@ -41,13 +41,7 @@ const ContainerHealthLogs = ({ con, container, onAddNotification, state }) => {
         <>
             <Flex alignItems={{ default: "alignItemsFlexStart" }}>
                 <FlexItem grow={{ default: 'grow' }}>
-                    <DescriptionList
-                        id="container-details-healthcheck"
-                        columnModifier={{
-                            default: '1Col', 
-                            md: '3Col',    
-                        }}
-                    >
+                    <DescriptionList id="container-details-healthcheck">
                         <DescriptionListGroup>
                             <DescriptionListTerm>{_("Status")}</DescriptionListTerm>
                             <DescriptionListDescription>{state}</DescriptionListDescription>

--- a/src/Containers.scss
+++ b/src/Containers.scss
@@ -72,11 +72,6 @@
     }
 }
 
-/* HACK - force DescriptionList to wrap but not fill the width */
-#container-details-healthcheck {
-    display: flex;
-    flex-wrap: wrap;
-}
 
 /* Upstream issue https://github.com/patternfly/patternfly/pull/7396
  * Will be fixed in PF v6.2.0

--- a/src/Containers.scss
+++ b/src/Containers.scss
@@ -72,6 +72,16 @@
     }
 }
 
+#container-details-healthcheck {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(5rem, max-content));
+
+    /* Prevent long command strings from inflating max-content beyond screen bounds */
+    .pf-v6-c-description-list__group {
+        min-width: 0;
+        word-break: break-word;
+    }
+}
 
 /* Upstream issue https://github.com/patternfly/patternfly/pull/7396
  * Will be fixed in PF v6.2.0


### PR DESCRIPTION
### Summary
Fixes an issue where health check metadata in the container details view wraps poorly on narrow viewports, causing text truncation and horizontal scrolling on mobile screens.

### Changes
* Removed custom `display: flex; flex-wrap: wrap;` CSS override on `#container-details-healthcheck` in `Containers.scss`.
* Updated `<DescriptionList>` in `ContainerHealthLogs.jsx` to use `columnModifier={{ default: '1Col', md: '3Col' }}` instead of `isAutoFit`.

### Screenshot
<img width="1038" height="758" alt="image" src="https://github.com/user-attachments/assets/1aaacaca-9990-456c-876c-f984e23a1748" />


### Verification
1. Open container details and navigate to the **Health check** tab.
2. Toggle device emulation in browser DevTools (e.g., iPhone SE / 375px width).
3. Verify metadata stacks into a single vertical column without horizontal scrollbars.
4. Expand viewport width above `768px` and verify the layout expands back to 3 columns.

Closes #2608