### PR TITLE
create: Fix environment index calculations

### DIFF
--- a/src/Env.jsx
+++ b/src/Env.jsx
@@ -32,31 +32,34 @@ export function validateEnvVar(env, key) {
     }
 }
 
-const handleEnvValue = (key, value, idx, onChange, additem, _itemCount, companionField) => {
+const handleEnvValue = (key, value, idx, onChange, additem, itemCount, companionField) => {
     // Allow the input of KEY=VALUE separated value pairs for bulk import only if the other
     // field is not empty.
     if (value.includes('=') && !companionField) {
         const parts = value.trim().split(" ");
-        let index = idx;
-        for (const part of parts) {
+        for (const [i, part] of parts.entries()) {
             const [envKey, ...envVar] = part.split('=');
             if (!envKey || !envVar) {
                 continue;
             }
 
-            if (index !== idx) {
+            let index;
+            if (i > 0) {
                 additem();
+                index = itemCount - 1 + i; // additem always adds at the end
+            } else {
+                index = idx;
             }
+
             onChange(index, 'envKey', envKey);
             onChange(index, 'envValue', envVar.join('='));
-            index++;
         }
     } else {
         onChange(idx, key, value);
     }
 };
 
-export const EnvVar = ({ id, item, onChange, idx, removeitem, additem, itemCount, validationFailed, onValidationChange }) =>
+export const EnvVar = ({ id, item, onChange, idx, removeitem, additem, options, validationFailed, onValidationChange }) =>
     (
         <Grid hasGutter id={id}>
             <FormGroup className="pf-m-6-col-on-md"
@@ -71,7 +74,7 @@ export const EnvVar = ({ id, item, onChange, idx, removeitem, additem, itemCount
                        onChange={(_event, value) => {
                            utils.validationClear(validationFailed, "envKey", onValidationChange);
                            utils.validationDebounce(() => onValidationChange({ ...validationFailed, envKey: validateEnvVar(value, "envKey") }));
-                           handleEnvValue('envKey', value, idx, onChange, additem, itemCount, item.envValue);
+                           handleEnvValue('envKey', value, idx, onChange, additem, options.itemCount, item.envValue);
                        }} />
                 <FormHelper helperTextInvalid={validationFailed?.envKey} />
             </FormGroup>
@@ -86,7 +89,7 @@ export const EnvVar = ({ id, item, onChange, idx, removeitem, additem, itemCount
                        onChange={(_event, value) => {
                            utils.validationClear(validationFailed, "envValue", onValidationChange);
                            utils.validationDebounce(() => onValidationChange({ ...validationFailed, envValue: validateEnvVar(value, "envValue") }));
-                           handleEnvValue('envValue', value, idx, onChange, additem, itemCount, item.envKey);
+                           handleEnvValue('envValue', value, idx, onChange, additem, options.itemCount, item.envKey);
                        }} />
                 <FormHelper helperTextInvalid={validationFailed?.envValue} />
             </FormGroup>

--- a/src/ImageRunModal.jsx
+++ b/src/ImageRunModal.jsx
@@ -1074,7 +1074,11 @@ export class ImageRunModal extends React.Component {
                                  onChange={value => this.onValueChanged('env', value)}
                                  default={{ envKey: null, envValue: null }}
                                  helperText={_("Paste one or more lines of key=value pairs into any field for bulk import")}
-                                 itemcomponent={EnvVar} />
+                                 itemcomponent={EnvVar}
+                                 options={
+                                     { itemCount: this.state.env.length }
+                                 }
+                            />
                         </FormSection>
                     </Tab>
                     <Tab eventKey={2} title={<TabTitleText>{_("Health check")}</TabTitleText>} id="create-image-dialog-tab-healthcheck">

--- a/test/check-application
+++ b/test/check-application
@@ -2068,8 +2068,19 @@ Yaml={name}.yaml
         b.wait_val("#run-image-dialog-env-3-key", "RHUBARB")
         b.wait_val("#run-image-dialog-env-3-value", "STRAWBERRY")
 
-        # with copy&paste you can also set multiple variables
+        # With copy&paste you can also set multiple variables
+
         b.click('.env-form .btn-add')
+
+        # We make this more interesting by adding and deleting an
+        # extra slot.  This leads to sparse arrays in the dialog state
+        # which used to provoke a crash.
+        #
+        # See https://github.com/cockpit-project/cockpit-podman/issues/2637
+        #
+        b.click('.env-form .btn-add')
+        b.click('#run-image-dialog-env-5-btn-close')
+
         # focus
         b.click('#run-image-dialog-env-4-value')
         b.wait_visible('#run-image-dialog-env-4-value:focus')
@@ -2094,17 +2105,17 @@ Yaml={name}.yaml
 
         b.wait_val("#run-image-dialog-env-4-key", "DURIAN")
         b.wait_val("#run-image-dialog-env-4-value", "LEMON")
-        b.wait_val("#run-image-dialog-env-5-key", "TEST_URL")
-        b.wait_val("#run-image-dialog-env-5-value", "wss://cockpit/?start=1&stop=0")
+        b.wait_val("#run-image-dialog-env-6-key", "TEST_URL")
+        b.wait_val("#run-image-dialog-env-6-value", "wss://cockpit/?start=1&stop=0")
 
         b.click('.env-form .btn-add')
-        b.set_input_text('#run-image-dialog-env-6-key', 'HOSTNAME')
-        b.set_input_text('#run-image-dialog-env-6-value', 'busybox')
+        b.set_input_text('#run-image-dialog-env-7-key', 'HOSTNAME')
+        b.set_input_text('#run-image-dialog-env-7-value', 'busybox')
 
         # Test inputting a var with = in it doesn't reset key
         b.click('.env-form .btn-add')
-        b.set_input_text('#run-image-dialog-env-7-key', 'TEST')
-        b.set_input_text('#run-image-dialog-env-7-value', 'REBASE=1')
+        b.set_input_text('#run-image-dialog-env-8-key', 'TEST')
+        b.set_input_text('#run-image-dialog-env-8-value', 'REBASE=1')
 
         # Configure more volumes
         b.click('.volume-form .btn-add')


### PR DESCRIPTION
Calling additem() will always add the new row at the end, not after the one that gets pasted into.  We can compute which that is from the length of the state value.

This works also when the state value for the environment variables a sparse array.  Previously, we might have used an index that is actually a hole in the array and then crash.

Fixes #2637