### PR TITLE
test: Allow installing updates from a vendor

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -14,7 +14,7 @@ fi
 main_builds_repo="$(ls /etc/yum.repos.d/*cockpit*main-builds* 2>/dev/null || true)"
 if [ -n "$main_builds_repo" ]; then
     echo 'priority=0' >> "$main_builds_repo"
-    dnf distro-sync -y --repo 'copr*' cockpit-podman
+    dnf distro-sync -y --setopt=allow_vendor_change=1 --repo 'copr*' cockpit-podman
 fi
 
 # Show critical package versions


### PR DESCRIPTION
New DNF5 policy does not allow switching vendors if in our example a COPR repository offers a newer version of cockpit-podman. We want to override this behaviour and in reverse dependency testing install the latest version of cockpit-podman (provided by @cockpit/main-builds).

We need the latest version of cockpit-podman in our reverse dependency test against podman so we can update to changes in podman's main repository.

https://fedoraproject.org/wiki/Changes/DisableVendorChangeByDefault

---

This should fix the recent fallout of podman reverse dependency testing failing on Fedora rawhide.