### PR TITLE
podman: preserve health row scope and disposition

### DIFF
--- a/src/ContainerDetails.jsx
+++ b/src/ContainerDetails.jsx
@@ -7,6 +7,7 @@ import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex";
 
 import cockpit from 'cockpit';
 
+import { containerScope } from './health.js';
 import * as utils from './util.js';
 
 const _ = cockpit.gettext;
@@ -19,6 +20,11 @@ const render_container_state = (container) => {
 };
 
 const ContainerDetails = ({ container }) => {
+    const scope = containerScope(container);
+    const ownerText = scope.ownerUid === null
+        ? _("session user")
+        : cockpit.format(_("UID $0"), scope.ownerUid);
+    const scopeText = cockpit.format(_("$0 · $1"), scope.context, ownerText);
     const networkOptions = (
         [
             container.NetworkSettings?.IPAddress,
@@ -33,7 +39,21 @@ const ContainerDetails = ({ container }) => {
                 <DescriptionList className='container-details-basic'>
                     <DescriptionListGroup>
                         <DescriptionListTerm>{_("ID")}</DescriptionListTerm>
-                        <DescriptionListDescription className="ignore-pixels">{utils.truncate_id(container.Id)}</DescriptionListDescription>
+                        <DescriptionListDescription className="ignore-pixels container-id-short" title={scope.fullId || scope.id || ""}>
+                            {utils.truncate_id(container.Id)}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>{_("Full ID")}</DescriptionListTerm>
+                        <DescriptionListDescription className="container-id-full" data-container-full-id={scope.fullId || ""}>
+                            {scope.fullId || scope.id || _("Unavailable")}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>{_("Owner")}</DescriptionListTerm>
+                        <DescriptionListDescription className="container-owner-scope" data-container-scope={scopeText}>
+                            {scopeText}
+                        </DescriptionListDescription>
                     </DescriptionListGroup>
                     <DescriptionListGroup>
                         <DescriptionListTerm>{_("Image")}</DescriptionListTerm>

--- a/src/ContainerHealthLogs.jsx
+++ b/src/ContainerHealthLogs.jsx
@@ -16,6 +16,7 @@ import cockpit from 'cockpit';
 import { ListingTable } from "cockpit-components-table";
 
 import * as client from './client.js';
+import { containerScope, healthAge, healthDetail, normalizeExitCode } from './health.js';
 import * as utils from './util.js';
 
 const _ = cockpit.gettext;
@@ -43,36 +44,61 @@ const ContainerHealthLogs = ({ con, container, onAddNotification, state, assessm
     const healthState = container.State?.Healthcheck ?? container.State?.Health ?? {}; // not-covered: only on old version
     const logs = [...(healthState.Log || [])].reverse(); // not-covered: Log should always exist, belt-and-suspenders
     const hasConfiguredHealthCheck = assessment?.configured ?? Boolean(healthCheck.Test?.length);
+    const detail = healthDetail(assessment);
     const statusReason = (() => {
-        switch (assessment?.status) {
+        switch (detail.code) {
+        case "healthy":
+            return null;
+        case "unhealthy":
+            return _("Health check failed");
+        case "latest-check-failed":
+            return _("Latest health check failed");
+        case "details-pending":
+            return _("Health details are still loading");
+        case "starting":
+            return _("Health check is in its startup grace period");
         case "missing":
             return _("No health check configured");
         case "stale":
             return _("The last health check is stale");
-        case "unknown":
-            if (assessment.reason === "scheduler-coverage-missing")
-                return _("No active matching health schedule");
-            if (assessment.reason === "scheduler-unavailable" || assessment.reason === "scheduler-unknown")
-                return _("Scheduler freshness is unknown");
-            if (assessment.reason === "latest-check-unknown")
-                return _("Latest health result is invalid");
-            return assessment.reason === "freshness-unknown"
-                ? _("Health result is present, but scheduler freshness is unknown")
-                : _("No health result recorded");
+        case "scheduler-coverage-missing":
+            return _("No active matching health schedule");
+        case "scheduler-unavailable":
+        case "scheduler-unknown":
+            return _("Scheduler freshness is unknown");
+        case "latest-check-unknown":
+            return _("Latest health result is invalid");
+        case "timestamp-future":
+            return _("Health result timestamp is in the future");
+        case "freshness-unknown":
+            return _("Health result is present, but scheduler freshness is unknown");
+        case "no-result":
+            return _("No health result recorded");
+        case "scheduler-error":
+            return _("Health scheduler metadata is unavailable");
+        case "collection-timeout":
+            return _("Health data collection timed out");
+        case "collection-error":
         case "error":
-            return assessment.reason === "scheduler-error"
-                ? _("Health scheduler metadata is unavailable")
-                : assessment.reason === "collection-timeout"
-                    ? _("Health data collection timed out")
-                    : _("Health data collection failed");
+            return _("Health data collection failed");
         case "stopped":
-            return _("Container is stopped; health result is not live");
+            return detail.reason || _("Container is stopped; health result is not live");
         case "completed":
-            return _("Container completed; health result is not live");
+            return detail.reason || _("Container completed; health result is not live");
+        case "retired":
+            return detail.reason || _("Container is retired; health result is not live");
+        case "infrastructure":
+            return detail.reason || _("Infrastructure container; application health is not applicable");
         default:
-            return null;
+            return _("Health status is unavailable");
         }
     })();
+    const scope = assessment?.scope || containerScope(container);
+    const age = healthAge(assessment);
+    const ownerText = scope.ownerUid === null
+        ? _("session user")
+        : cockpit.format(_("UID $0"), scope.ownerUid);
+    const scopeText = cockpit.format(_("$0 · $1"), scope.context, ownerText);
 
     return (
         <>
@@ -85,14 +111,32 @@ const ContainerHealthLogs = ({ con, container, onAddNotification, state, assessm
                         </DescriptionListGroup>
                         {statusReason && <DescriptionListGroup>
                             <DescriptionListTerm>{_("Reason")}</DescriptionListTerm>
-                            <DescriptionListDescription className="healthcheck-reason">{statusReason}</DescriptionListDescription>
+                            <DescriptionListDescription className="healthcheck-reason" data-health-detail={statusReason}>{statusReason}</DescriptionListDescription>
                         </DescriptionListGroup>}
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>{_("Scope")}</DescriptionListTerm>
+                            <DescriptionListDescription className="healthcheck-scope" data-health-scope={scope.fullId
+                                ? `${scope.context}:${scope.ownerUid ?? "session"}:${scope.fullId}`
+                                : ""}>{scopeText}</DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>{_("Container ID")}</DescriptionListTerm>
+                            <DescriptionListDescription className="healthcheck-container-id" title={scope.fullId || scope.id || ""}>
+                                {scope.fullId || scope.id || _("Unavailable")}
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
                         {assessment?.lastChecked !== null && assessment?.lastChecked !== undefined && <DescriptionListGroup>
                             <DescriptionListTerm>{_("Last checked")}</DescriptionListTerm>
                             <DescriptionListDescription className="healthcheck-last-checked">
                                 <utils.RelativeTime time={new Date(assessment.lastChecked)} />
                             </DescriptionListDescription>
                         </DescriptionListGroup>}
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>{_("Health age")}</DescriptionListTerm>
+                            <DescriptionListDescription className="healthcheck-age" data-health-age-ms={age === null ? "" : age}>
+                                {age === null ? _("Unavailable") : format_seconds(Math.floor(age / 1000))}
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
                         {assessment?.schedule && <DescriptionListGroup>
                             <DescriptionListTerm>{_("Effective schedule")}</DescriptionListTerm>
                             <DescriptionListDescription className="healthcheck-schedule">
@@ -158,29 +202,30 @@ const ContainerHealthLogs = ({ con, container, onAddNotification, state, assessm
                           className="health-logs"
                           variant='compact'
                           columns={[_("Last 5 runs"), _("Started at")]}
-                          rows={
-                              logs.map(log => {
-                                  const id = `hc${log.Start}${container.Id}`;
-                                  return {
-                                      expandedContent: log.Output ? <pre>{log.Output}</pre> : null,
-                                      columns: [
-                                          {
-                                              title: <Flex flexWrap={{ default: 'nowrap' }} spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
-                                                  {log.ExitCode === 0 ? <Icon status="success"><CheckCircleIcon className="green" /></Icon> : <Icon status="danger"><ErrorCircleOIcon className="red" /></Icon>}
-                                                  <span>{log.ExitCode === 0 ? _("Passed health run") : _("Failed health run")}</span>
-                                              </Flex>
-                                          },
-                                          {
-                                              title: <utils.RelativeTime time={log.Start} />
-                                          }
-                                      ],
-                                      props: {
-                                          key: id,
-                                          "data-row-id": id,
+                      rows={
+                          logs.map(log => {
+                              const id = `hc${log.Start}${container.Id}`;
+                              const exitCode = normalizeExitCode(log.ExitCode);
+                              return {
+                                  expandedContent: log.Output ? <pre>{log.Output}</pre> : null,
+                                  columns: [
+                                      {
+                                          title: <Flex flexWrap={{ default: 'nowrap' }} spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+                                              {exitCode === 0 ? <Icon status="success"><CheckCircleIcon className="green" /></Icon> : <Icon status="danger"><ErrorCircleOIcon className="red" /></Icon>}
+                                              <span>{exitCode === 0 ? _("Passed health run") : _("Failed health run")}</span>
+                                          </Flex>
                                       },
-                                  };
-                              })
-                          } />
+                                      {
+                                          title: <utils.RelativeTime time={log.Start} />
+                                      }
+                                  ],
+                                  props: {
+                                      key: id,
+                                      "data-row-id": id,
+                                  },
+                              };
+                          })
+                      } />
         </>
     );
 };

--- a/src/ContainerHealthLogs.jsx
+++ b/src/ContainerHealthLogs.jsx
@@ -25,6 +25,12 @@ const format_nanoseconds = (ns) => {
     return cockpit.format(cockpit.ngettext("$0 second", "$0 seconds", seconds), seconds);
 };
 
+const format_seconds = (seconds) => {
+    if (!Number.isFinite(seconds))
+        return _("unknown");
+    return cockpit.format(cockpit.ngettext("$0 second", "$0 seconds", seconds), seconds);
+};
+
 const HealthcheckOnFailureActionText = {
     none: _("No action"),
     restart: _("Restart"),
@@ -32,10 +38,41 @@ const HealthcheckOnFailureActionText = {
     kill: _("Force stop"),
 };
 
-const ContainerHealthLogs = ({ con, container, onAddNotification, state }) => {
+const ContainerHealthLogs = ({ con, container, onAddNotification, state, assessment }) => {
     const healthCheck = container.Config?.Healthcheck ?? container.Config?.Health ?? {}; // not-covered: only on old version
     const healthState = container.State?.Healthcheck ?? container.State?.Health ?? {}; // not-covered: only on old version
     const logs = [...(healthState.Log || [])].reverse(); // not-covered: Log should always exist, belt-and-suspenders
+    const hasConfiguredHealthCheck = assessment?.configured ?? Boolean(healthCheck.Test?.length);
+    const statusReason = (() => {
+        switch (assessment?.status) {
+        case "missing":
+            return _("No health check configured");
+        case "stale":
+            return _("The last health check is stale");
+        case "unknown":
+            if (assessment.reason === "scheduler-coverage-missing")
+                return _("No active matching health schedule");
+            if (assessment.reason === "scheduler-unavailable" || assessment.reason === "scheduler-unknown")
+                return _("Scheduler freshness is unknown");
+            if (assessment.reason === "latest-check-unknown")
+                return _("Latest health result is invalid");
+            return assessment.reason === "freshness-unknown"
+                ? _("Health result is present, but scheduler freshness is unknown")
+                : _("No health result recorded");
+        case "error":
+            return assessment.reason === "scheduler-error"
+                ? _("Health scheduler metadata is unavailable")
+                : assessment.reason === "collection-timeout"
+                    ? _("Health data collection timed out")
+                    : _("Health data collection failed");
+        case "stopped":
+            return _("Container is stopped; health result is not live");
+        case "completed":
+            return _("Container completed; health result is not live");
+        default:
+            return null;
+        }
+    })();
 
     return (
         <>
@@ -46,9 +83,37 @@ const ContainerHealthLogs = ({ con, container, onAddNotification, state }) => {
                             <DescriptionListTerm>{_("Status")}</DescriptionListTerm>
                             <DescriptionListDescription>{state}</DescriptionListDescription>
                         </DescriptionListGroup>
+                        {statusReason && <DescriptionListGroup>
+                            <DescriptionListTerm>{_("Reason")}</DescriptionListTerm>
+                            <DescriptionListDescription className="healthcheck-reason">{statusReason}</DescriptionListDescription>
+                        </DescriptionListGroup>}
+                        {assessment?.lastChecked !== null && assessment?.lastChecked !== undefined && <DescriptionListGroup>
+                            <DescriptionListTerm>{_("Last checked")}</DescriptionListTerm>
+                            <DescriptionListDescription className="healthcheck-last-checked">
+                                <utils.RelativeTime time={new Date(assessment.lastChecked)} />
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>}
+                        {assessment?.schedule && <DescriptionListGroup>
+                            <DescriptionListTerm>{_("Effective schedule")}</DescriptionListTerm>
+                            <DescriptionListDescription className="healthcheck-schedule">
+                                {assessment.schedule.effective_interval_seconds === null || assessment.schedule.effective_interval_seconds === undefined
+                                    ? _("Unavailable")
+                                    : format_seconds(assessment.schedule.effective_interval_seconds)}
+                                {(assessment.schedule.schedule_source || assessment.schedule.schedules?.[0]?.schedule_source) &&
+                                    ` (${assessment.schedule.schedule_source || assessment.schedule.schedules[0].schedule_source})`}
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>}
+                        {assessment?.staleAfterMs !== null && assessment?.staleAfterMs !== undefined && <DescriptionListGroup>
+                            <DescriptionListTerm>{_("Freshness window")}</DescriptionListTerm>
+                            <DescriptionListDescription className="healthcheck-freshness-window">
+                                {format_seconds(assessment.staleAfterMs / 1000)}
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>}
                         <DescriptionListGroup>
                             <DescriptionListTerm>{_("Command")}</DescriptionListTerm>
-                            <DescriptionListDescription className="healthcheck-command">{utils.quote_cmdline(healthCheck.Test)}</DescriptionListDescription>
+                            <DescriptionListDescription className="healthcheck-command">
+                                {hasConfiguredHealthCheck ? utils.quote_cmdline(healthCheck.Test) : _("Not configured")}
+                            </DescriptionListDescription>
                         </DescriptionListGroup>
                         {healthCheck.Interval && <DescriptionListGroup>
                             <DescriptionListTerm>{_("Interval")}</DescriptionListTerm>
@@ -76,7 +141,7 @@ const ContainerHealthLogs = ({ con, container, onAddNotification, state }) => {
                         </DescriptionListGroup>}
                     </DescriptionList>
                 </FlexItem>
-                { container.State.Status === "running" &&
+                { hasConfiguredHealthCheck && container.State.Status === "running" &&
                     <FlexItem>
                         <Button variant="secondary" onClick={() => {
                             client.runHealthcheck(con, container.Id)

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -328,6 +328,10 @@ const localize_health_assessment = (assessment) => {
         return _("Stopped");
     case healthStates.completed:
         return _("Completed");
+    case healthStates.retired:
+        return _("Retired");
+    case healthStates.infrastructure:
+        return _("Infrastructure");
     default:
         return _("Health unknown");
     }

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -557,8 +557,8 @@ class Containers extends React.Component {
                     {isDistroboxContainer && <Badge className='ct-badge-distrobox'>distrobox</Badge>}
                     {isSystemdService && <Badge className='ct-badge-service'>{_("service")}</Badge>}
                 </Flex>
-                <small>{image}</small>
-                <small>{utils.quote_cmdline(container.Config?.Cmd)}</small>
+                <small className="container-image">{image}</small>
+                <small className="container-command">{utils.quote_cmdline(container.Config?.Cmd)}</small>
                 <small className="container-scope" data-container-scope={scopeText}>{scopeText}</small>
             </div>
         );

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -40,7 +40,7 @@ import { PodActions } from './PodActions.jsx';
 import { PodCreateModal } from './PodCreateModal.jsx';
 import PruneUnusedContainersModal from './PruneUnusedContainersModal.jsx';
 import * as client from './client.js';
-import { healthAssessment, healthStates } from './health.js';
+import { containerScope, healthAge, healthAssessment, healthDetail, healthStates } from './health.js';
 import * as utils from './util.js';
 
 import './Containers.scss';
@@ -334,37 +334,52 @@ const localize_health_assessment = (assessment) => {
 };
 
 const health_reason = (assessment) => {
-    switch (assessment.status) {
-    case healthStates.starting:
-        return assessment.reason === "details-pending"
-            ? _("Health details are still loading")
-            : null;
-    case healthStates.missing:
-        return _("No health check configured");
-    case healthStates.stale:
-        return _("The last health check is stale");
-    case healthStates.unknown:
-        if (assessment.reason === "scheduler-coverage-missing")
-            return _("No active matching health schedule");
-        if (assessment.reason === "scheduler-unavailable" || assessment.reason === "scheduler-unknown")
-            return _("Scheduler freshness is unknown");
-        if (assessment.reason === "latest-check-unknown")
-            return _("Latest health result is invalid");
-        return assessment.reason === "freshness-unknown"
-            ? _("Health result is present, but scheduler freshness is unknown")
-            : _("No health result recorded");
-    case healthStates.error:
-        return assessment.reason === "scheduler-error"
-            ? _("Health scheduler metadata is unavailable")
-            : assessment.reason === "collection-timeout"
-                ? _("Health data collection timed out")
-                : _("Health data collection failed");
-    case healthStates.stopped:
-        return _("Container is stopped; health result is not live");
-    case healthStates.completed:
-        return _("Container completed; health result is not live");
-    default:
+    const detail = healthDetail(assessment);
+    switch (detail.code) {
+    case "healthy":
         return null;
+    case "unhealthy":
+        return _("Health check failed");
+    case "latest-check-failed":
+        return _("Latest health check failed");
+    case "details-pending":
+        return _("Health details are still loading");
+    case "starting":
+        return _("Health check is in its startup grace period");
+    case "missing":
+        return _("No health check configured");
+    case "stale":
+        return _("The last health check is stale");
+    case "scheduler-coverage-missing":
+        return _("No active matching health schedule");
+    case "scheduler-unavailable":
+    case "scheduler-unknown":
+        return _("Scheduler freshness is unknown");
+    case "latest-check-unknown":
+        return _("Latest health result is invalid");
+    case "timestamp-future":
+        return _("Health result timestamp is in the future");
+    case "freshness-unknown":
+        return _("Health result is present, but scheduler freshness is unknown");
+    case "no-result":
+        return _("No health result recorded");
+    case "scheduler-error":
+        return _("Health scheduler metadata is unavailable");
+    case "collection-timeout":
+        return _("Health data collection timed out");
+    case "collection-error":
+    case "error":
+        return _("Health data collection failed");
+    case "stopped":
+        return detail.reason || _("Container is stopped; health result is not live");
+    case "completed":
+        return detail.reason || _("Container completed; health result is not live");
+    case "retired":
+        return detail.reason || _("Container is retired; health result is not live");
+    case "infrastructure":
+        return detail.reason || _("Infrastructure container; application health is not applicable");
+    default:
+        return _("Health status is unavailable");
     }
 };
 
@@ -490,6 +505,11 @@ class Containers extends React.Component {
             this.props.contextErrors?.[container.uid] || null;
         const scheduler = this.props.schedulerCoverage?.[container.key] || null;
         const assessment = healthAssessment(container, this.state.now, collectionError, scheduler);
+        const scope = assessment.scope || containerScope(container);
+        const ownerText = scope.ownerUid === null
+            ? _("session user")
+            : cockpit.format(_("UID $0"), scope.ownerUid);
+        const scopeText = cockpit.format(_("$0 · $1"), scope.context, ownerText);
 
         let proc = "";
         let mem = "";
@@ -535,6 +555,7 @@ class Containers extends React.Component {
                 </Flex>
                 <small>{image}</small>
                 <small>{utils.quote_cmdline(container.Config?.Cmd)}</small>
+                <small className="container-scope" data-container-scope={scopeText}>{scopeText}</small>
             </div>
         );
 
@@ -553,17 +574,22 @@ class Containers extends React.Component {
             ? `ct-badge-container-${assessment.status}`
             : "";
         state.push(
-            <Badge key={`health-${assessment.status}`} isRead className={`${health_badge_class(assessment.status)} ${legacyHealthClass}`} title={reason || localizedHealth}>
+            <Badge key={`health-${assessment.status}`} isRead className={`${health_badge_class(assessment.status)} ${legacyHealthClass}`}
+                   title={reason || localizedHealth}
+                   aria-label={cockpit.format(_("Health: $0"), localizedHealth)}>
                 {localizedHealth}
             </Badge>
         );
-        if (assessment.lastChecked !== null) {
-            state.push(
-                <span key="health-last-checked" className="health-last-checked">
-                    {_("Last checked:")} <utils.RelativeTime time={new Date(assessment.lastChecked)} />
-                </span>
-            );
-        }
+        if (reason)
+            state.push(<small key="health-detail" className="container-health-detail" data-health-detail={reason}>{reason}</small>);
+        state.push(
+            <span key="health-last-checked" className="health-last-checked"
+                  data-health-age-ms={healthAge(assessment) === null ? "" : healthAge(assessment)}>
+                {assessment.lastChecked === null
+                    ? _("Last checked: unavailable")
+                    : <>{_("Last checked:")} <utils.RelativeTime time={new Date(assessment.lastChecked)} /></>}
+            </span>
+        );
 
         const user = this.props.users.find(user => user.uid === container.uid);
         cockpit.assert(user, `User not found for container uid ${container.uid}`);
@@ -665,6 +691,12 @@ class Containers extends React.Component {
                 ...(container.IsQuadlet ? { "data-quadlet-id": container.Id } : { "data-container-id": container.Id }),
                 "data-health-status": assessment.status,
                 "data-health-last-checked": assessment.lastChecked === null ? "" : assessment.lastChecked,
+                "data-health-age-ms": healthAge(assessment) === null ? "" : healthAge(assessment),
+                "data-health-detail": reason || "",
+                "data-health-scope": scope.fullId
+                    ? `${scope.context}:${scope.ownerUid ?? "session"}:${scope.fullId}`
+                    : "",
+                ...(scope.fullId ? { "data-container-full-id": scope.fullId } : {}),
                 "data-row-name": `${container.uid === null ? 'user' : container.uid}-${container.Name}`
             },
         };

--- a/src/Containers.jsx
+++ b/src/Containers.jsx
@@ -40,6 +40,7 @@ import { PodActions } from './PodActions.jsx';
 import { PodCreateModal } from './PodCreateModal.jsx';
 import PruneUnusedContainersModal from './PruneUnusedContainersModal.jsx';
 import * as client from './client.js';
+import { healthAssessment, healthStates } from './health.js';
 import * as utils from './util.js';
 
 import './Containers.scss';
@@ -307,17 +308,67 @@ export let onDownloadContainerFinished = function funcOnDownloadContainerFinishe
     }));
 };
 
-const localize_health = (state) => {
-    if (state === "healthy")
+const localize_health_assessment = (assessment) => {
+    switch (assessment.status) {
+    case healthStates.healthy:
         return _("Healthy");
-    else if (state === "unhealthy")
+    case healthStates.unhealthy:
         return _("Unhealthy");
-    else if (state === "starting")
+    case healthStates.starting:
         return _("Checking health");
-    else
-        console.error("Unexpected health check status", state);
-    return null;
+    case healthStates.missing:
+        return _("No health check");
+    case healthStates.stale:
+        return _("Stale health");
+    case healthStates.unknown:
+        return _("Health unknown");
+    case healthStates.error:
+        return _("Health unavailable");
+    case healthStates.stopped:
+        return _("Stopped");
+    case healthStates.completed:
+        return _("Completed");
+    default:
+        return _("Health unknown");
+    }
 };
+
+const health_reason = (assessment) => {
+    switch (assessment.status) {
+    case healthStates.starting:
+        return assessment.reason === "details-pending"
+            ? _("Health details are still loading")
+            : null;
+    case healthStates.missing:
+        return _("No health check configured");
+    case healthStates.stale:
+        return _("The last health check is stale");
+    case healthStates.unknown:
+        if (assessment.reason === "scheduler-coverage-missing")
+            return _("No active matching health schedule");
+        if (assessment.reason === "scheduler-unavailable" || assessment.reason === "scheduler-unknown")
+            return _("Scheduler freshness is unknown");
+        if (assessment.reason === "latest-check-unknown")
+            return _("Latest health result is invalid");
+        return assessment.reason === "freshness-unknown"
+            ? _("Health result is present, but scheduler freshness is unknown")
+            : _("No health result recorded");
+    case healthStates.error:
+        return assessment.reason === "scheduler-error"
+            ? _("Health scheduler metadata is unavailable")
+            : assessment.reason === "collection-timeout"
+                ? _("Health data collection timed out")
+                : _("Health data collection failed");
+    case healthStates.stopped:
+        return _("Container is stopped; health result is not live");
+    case healthStates.completed:
+        return _("Container completed; health result is not live");
+    default:
+        return null;
+    }
+};
+
+const health_badge_class = status => `ct-badge-container-health-${status}`;
 
 const ContainerOverActions = ({ handlePruneUnusedContainers, unusedContainers }) => {
     const actions = [
@@ -361,9 +412,11 @@ class Containers extends React.Component {
         this.state = {
             width: 0,
             memTotal: 0,
+            now: Date.now(),
             downloadingContainers: [],
             showPruneUnusedContainersModal: false,
         };
+        this.healthTimer = null;
         this.renderRow = this.renderRow.bind(this);
         this.onWindowResize = this.onWindowResize.bind(this);
         this.podStats = this.podStats.bind(this);
@@ -387,10 +440,15 @@ class Containers extends React.Component {
 
     componentDidMount() {
         this.onWindowResize();
+        // Health results become stale without a Podman event. Keep the age and
+        // stale badge truthful while avoiding a per-container polling loop.
+        this.healthTimer = window.setInterval(() => this.setState({ now: Date.now() }), 10000);
     }
 
     componentWillUnmount() {
         window.removeEventListener('resize', this.onWindowResize);
+        if (this.healthTimer !== null)
+            window.clearInterval(this.healthTimer);
     }
 
     createPod() {
@@ -426,13 +484,12 @@ class Containers extends React.Component {
         const isToolboxContainer = container.Config?.Labels?.["com.github.containers.toolbox"] === "true";
         const isDistroboxContainer = container.Config?.Labels?.manager === "distrobox";
         const isSystemdService = utils.is_systemd_service(container.Config);
-        let localized_health = null;
-
         // this needs to get along with stub containers from image run dialog, where most properties don't exist yet
-        // HACK: Podman renamed `Healthcheck` to `Health` randomly
-        // https://github.com/containers/podman/commit/119973375
-        const healthcheck = container.State?.Health?.Status ?? container.State?.Healthcheck?.Status; // not-covered: only on old version
         const status = container.State?.Status ?? ""; // not-covered: race condition
+        const collectionError = this.props.containerErrors?.[container.key] ||
+            this.props.contextErrors?.[container.uid] || null;
+        const scheduler = this.props.schedulerCoverage?.[container.key] || null;
+        const assessment = healthAssessment(container, this.state.now, collectionError, scheduler);
 
         let proc = "";
         let mem = "";
@@ -487,11 +544,25 @@ class Containers extends React.Component {
 
         const containerState = status.charAt(0).toUpperCase() + status.slice(1);
 
-        const state = [<Badge key={containerState} isRead className={containerStateClass}>{_(containerState)}</Badge>]; // States are defined in util.js
-        if (healthcheck) {
-            localized_health = localize_health(healthcheck);
-            if (localized_health)
-                state.push(<Badge key={healthcheck} isRead className={`ct-badge-container-${healthcheck}`}>{localized_health}</Badge>);
+        const state = [<Badge key={containerState} isRead className={`${containerStateClass} ct-badge-container-state`}>{_(containerState)}</Badge>]; // States are defined in util.js
+        const localizedHealth = localize_health_assessment(assessment);
+        const reason = health_reason(assessment);
+        // Keep the existing selectors/classes for native Podman states while
+        // giving the new display-only states their own namespace.
+        const legacyHealthClass = [healthStates.healthy, healthStates.unhealthy, healthStates.starting].includes(assessment.status)
+            ? `ct-badge-container-${assessment.status}`
+            : "";
+        state.push(
+            <Badge key={`health-${assessment.status}`} isRead className={`${health_badge_class(assessment.status)} ${legacyHealthClass}`} title={reason || localizedHealth}>
+                {localizedHealth}
+            </Badge>
+        );
+        if (assessment.lastChecked !== null) {
+            state.push(
+                <span key="health-last-checked" className="health-last-checked">
+                    {_("Last checked:")} <utils.RelativeTime time={new Date(assessment.lastChecked)} />
+                </span>
+            );
         }
 
         const user = this.props.users.find(user => user.uid === container.uid);
@@ -567,11 +638,17 @@ class Containers extends React.Component {
             }
         }
 
-        if (healthcheck) {
+        if (container.State && user.con !== null) {
             tabs.push({
                 name: _("Health check"),
                 renderer: ContainerHealthLogs,
-                data: { con: user.con, container, onAddNotification: this.props.onAddNotification, state: localized_health }
+                data: {
+                    con: user.con,
+                    container,
+                    onAddNotification: this.props.onAddNotification,
+                    state: localizedHealth,
+                    assessment,
+                }
             });
         }
 
@@ -582,7 +659,12 @@ class Containers extends React.Component {
             props: {
                 key: container.key,
                 "data-row-id": container.key,
+                "data-row-type": container.IsQuadlet ? "quadlet" : "container",
                 "data-started-at": container.State?.StartedAt,
+                "data-owner-uid": container.uid ?? "user",
+                ...(container.IsQuadlet ? { "data-quadlet-id": container.Id } : { "data-container-id": container.Id }),
+                "data-health-status": assessment.status,
+                "data-health-last-checked": assessment.lastChecked === null ? "" : assessment.lastChecked,
                 "data-row-name": `${container.uid === null ? 'user' : container.uid}-${container.Name}`
             },
         };
@@ -727,19 +809,30 @@ class Containers extends React.Component {
         filtered = filtered.filter(id => !containers[id].IsInfra && !containers[id].IsService);
 
         const getHealth = id => {
-            const state = containers[id]?.State;
-            return state?.Health?.Status || state?.Healthcheck?.Status;
+            const collectionError = this.props.containerErrors?.[containers[id].key] ||
+                this.props.contextErrors?.[containers[id].uid] || null;
+            const scheduler = this.props.schedulerCoverage?.[containers[id].key] || null;
+            return healthAssessment(containers[id], this.state.now, collectionError, scheduler).status;
         };
 
         filtered.sort((a, b) => {
-            // Show unhealthy containers first
+            // Show confirmed failures and unavailable/stale data first. A
+            // missing or empty health result must never sort as healthy.
             const a_health = getHealth(a);
             const b_health = getHealth(b);
             if (a_health !== b_health) {
-                if (a_health === "unhealthy")
-                    return -1;
-                if (b_health === "unhealthy")
-                    return 1;
+                const order = {
+                    [healthStates.unhealthy]: 0,
+                    [healthStates.error]: 1,
+                    [healthStates.stale]: 2,
+                    [healthStates.starting]: 3,
+                    [healthStates.unknown]: 4,
+                    [healthStates.missing]: 5,
+                    [healthStates.healthy]: 6,
+                    [healthStates.completed]: 7,
+                    [healthStates.stopped]: 8,
+                };
+                return (order[a_health] ?? 7) - (order[b_health] ?? 7);
             }
             // User containers are in front of system ones
             if (containers[a].uid !== containers[b].uid)
@@ -955,6 +1048,14 @@ class Containers extends React.Component {
                 </CardHeader>
                 <CardBody>
                     <Flex direction={{ default: 'column' }}>
+                        {Object.keys(this.props.contextErrors || {}).length > 0 &&
+                            <Content component={ContentVariants.p} className="container-context-error" role="alert">
+                                {_("Container collection is unavailable for one or more owners; cached health is marked unavailable.")}
+                            </Content>}
+                        {Object.keys(this.props.schedulerErrors || {}).length > 0 &&
+                            <Content component={ContentVariants.p} className="container-context-error" role="alert">
+                                {_("Health scheduler metadata is unavailable for one or more owners; freshness is marked unavailable.")}
+                            </Content>}
                         {(!isLoaded)
                             ? <ListingTable variant='compact'
                                             aria-label={_("Containers")}

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -24,10 +24,84 @@ import Containers from './Containers.jsx';
 import Images from './Images.jsx';
 import * as client from './client.js';
 import detect_quadlets from './detect-quadlets.py';
+import scheduler_collector from './health-scheduler.py';
+import { isValidHealthDetails, shouldInspectHealth } from './health.js';
 import rest from './rest.js';
+import { KeyedRequestGate, mapWithConcurrency, OwnerRefreshGate, RequestConcurrencyGate, SchedulerRequestGate, withTimeout } from './scheduler-request.js';
 import { makeKey, WithPodmanInfo, debug } from './util.js';
 
 const _ = cockpit.gettext;
+
+const errorText = error => error?.message || error?.toString() || "Unknown error";
+const FULL_CONTAINER_ID = /^[0-9a-f]{64}$/;
+const SCHEDULER_SCHEMA = "train-health-scheduler-coverage/v1";
+const SCHEDULER_FAILURE = "scheduler-collector-failed";
+const SCHEDULER_INCOMPLETE = "scheduler-coverage-incomplete";
+const SCHEDULER_STATUSES = new Set(["covered", "covered-with-errors", "uncovered", "error"]);
+const HEALTH_REFRESH_INTERVAL_MS = 15000;
+const HEALTH_REFRESH_TIMEOUT_MS = 15000;
+const HEALTH_INSPECT_TIMEOUT_MS = 5000;
+const HEALTH_EVENT_INSPECT_TIMEOUT_MS = 5000;
+const HEALTH_INSPECT_CONCURRENCY = 8;
+const HEALTH_SCHEDULER_TIMEOUT_MS = 8000;
+const CONTAINER_INSPECT_INVALID = "Container inspect response is invalid";
+// Stats are streamed independently for every owner. Coalesce a burst into a
+// single render while keeping the displayed values boundedly fresh.
+const CONTAINER_STATS_FLUSH_INTERVAL_MS = 100;
+
+const isContainerInventoryRow = container => container !== null &&
+    typeof container === "object" && !Array.isArray(container) &&
+    typeof container.Id === "string" && container.Id.trim().length > 0;
+
+const containerFromInventory = (inventory, uid, key, current = null) => {
+    const inventoryState = typeof inventory?.State === "string"
+        ? { Status: inventory.State.toLowerCase() }
+        : (inventory?.State || {});
+    const state = {
+        ...(current?.State || {}),
+        ...inventoryState,
+        // Podman's list response keeps the exit code at the top level.
+        // Preserve it when rendering a completed job without an inspect.
+        ...(Object.prototype.hasOwnProperty.call(inventory, "ExitCode") ? { ExitCode: inventory.ExitCode } : {}),
+    };
+    const id = inventory.Id;
+    const name = inventory.Names?.[0]?.replace(/^\//, "") || inventory.Name || current?.Name || id;
+    const inventoryConfig = inventory.Config || {};
+    const currentConfig = current?.Config || {};
+    const config = {
+        ...inventoryConfig,
+        ...currentConfig,
+        Labels: {
+            ...(inventory.Labels || {}),
+            ...(inventoryConfig.Labels || {}),
+            ...(currentConfig.Labels || {}),
+        },
+        Env: currentConfig.Env || inventoryConfig.Env || inventory.Env || [],
+        Cmd: currentConfig.Cmd || inventoryConfig.Cmd || inventory.Command || [],
+    };
+    const networkSettings = {
+        ...(inventory.NetworkSettings || {}),
+        ...(current?.NetworkSettings || {}),
+        Ports: current?.NetworkSettings?.Ports || inventory.NetworkSettings?.Ports || {},
+    };
+    return {
+        ...inventory,
+        ...(current || {}),
+        Id: id,
+        Name: name,
+        ImageName: inventory.ImageName || inventory.Image || current?.ImageName || current?.Image || id,
+        Config: config,
+        NetworkSettings: networkSettings,
+        Mounts: current?.Mounts || inventory.Mounts || [],
+        State: state,
+        uid,
+        key,
+        // An inventory-only row has enough data for lifecycle rendering but
+        // must remain pending until its first full inspect establishes health
+        // configuration and the native result.
+        healthDetailsLoaded: current?.healthDetailsLoaded === true,
+    };
+};
 
 // sort order of "users" state for dialogs: system, session user, then other users by ascending name
 function compareUser(a, b) {
@@ -51,6 +125,16 @@ class Application extends React.Component {
             users: [{ con: null, uid: 0, name: _("system"), dbus: null }, { con: null, uid: null, name: _("user"), dbus: null }],
             images: null,
             containers: null,
+            // A failed inspect invalidates any previously cached health result
+            // for the same (owner, full container ID) key.
+            containerErrors: {},
+            // A context-level failure covers every cached row belonging to the
+            // affected Podman socket until a successful refresh clears it.
+            contextErrors: {},
+            // Effective systemd/native scheduler metadata is keyed by the
+            // display's owner-scoped full container ID.
+            schedulerCoverage: {},
+            schedulerErrors: {},
             containersFilter: "all",
             containersStats: {},
             // Mapping of quadlet containers and pods on the system to show
@@ -80,6 +164,26 @@ class Application extends React.Component {
         this.onNavigate = this.onNavigate.bind(this);
 
         this.pendingUpdateContainer = {}; // key (uid-id) → promise
+        this.containerEventGenerations = new Map();
+        this.containerEventActions = new Map();
+        this.containerEventRequests = new SchedulerRequestGate();
+        this.schedulerRequests = new SchedulerRequestGate();
+        this.healthRefreshGate = new OwnerRefreshGate();
+        // A timer tick that lands during a running refresh must result in one
+        // follow-up pass. OwnerRefreshGate coalesces that tick by design, so
+        // retain the request here instead of allowing a slow owner to miss a
+        // polling interval indefinitely.
+        this.healthRefreshFollowups = new Map();
+        // Keep all owner refreshes and event-driven inspects within one
+        // bounded Podman HTTP request pool. Per-request deadlines start when
+        // a queued request actually reaches the transport.
+        this.containerRequestGate = new RequestConcurrencyGate(HEALTH_INSPECT_CONCURRENCY);
+        this.containerInspectRequests = new KeyedRequestGate(operation => this.containerRequestGate.run(operation));
+        this.pendingContainerStats = new Map();
+        this.containerStatsTimers = new Map();
+        this.ownerConnections = new Map();
+        this.healthRefreshTimer = null;
+        this.sessionUser = null;
     }
 
     onAddNotification(notification) {
@@ -151,13 +255,543 @@ class Application extends React.Component {
         });
     }
 
+    schedulerUid(con) {
+        return con.uid === null ? this.sessionUser?.id ?? null : con.uid;
+    }
+
+    isCurrentConnection(con) {
+        return this.ownerConnections.get(con.uid) === con;
+    }
+
+    markContainerEvent(con, id, action) {
+        const key = makeKey(con.uid, id);
+        const generation = (this.containerEventGenerations.get(key) || 0) + 1;
+        this.containerEventGenerations.set(key, generation);
+        this.containerEventActions.set(key, action || "update");
+        return generation;
+    }
+
+    invalidateOwner(con) {
+        const uid = typeof con === "object" ? con.uid : con;
+        if (typeof con === "object" && this.ownerConnections.get(uid) !== con)
+            return false;
+        this.healthRefreshFollowups.delete(uid === null ? "user" : String(uid));
+        this.healthRefreshGate.invalidate(uid);
+        this.schedulerRequests.begin(uid);
+        const ownerPrefix = `${uid ?? "user"}-`;
+        for (const key of this.containerEventGenerations.keys()) {
+            if (key.startsWith(ownerPrefix)) {
+                this.containerEventGenerations.delete(key);
+                this.containerEventActions.delete(key);
+            }
+        }
+        for (const key of this.containerEventRequests.generations.keys()) {
+            if (key.startsWith(ownerPrefix))
+                this.containerEventRequests.begin(key);
+        }
+        for (const key of Object.keys(this.pendingUpdateContainer)) {
+            if (key.startsWith(ownerPrefix))
+                delete this.pendingUpdateContainer[key];
+        }
+        this.containerInspectRequests.closeWhere(metadata => metadata.con === con ||
+                                                        (typeof con !== "object" && metadata.con.uid === uid),
+                                                 "owner-disconnected");
+        if (typeof con === "object" && this.ownerConnections.get(uid) === con)
+            this.ownerConnections.delete(uid);
+        return true;
+    }
+
+    refreshHealthOwners() {
+        for (const user of this.state.users) {
+            if (user.con && user.containersLoaded)
+                this.refreshOwnerHealth(user.con);
+        }
+    }
+
+    refreshOwnerHealth(con) {
+        const ownerKey = con.uid === null ? "user" : String(con.uid);
+        const running = this.healthRefreshGate.running.get(ownerKey);
+        const entry = this.healthRefreshGate.start(con.uid, request => this.collectOwnerHealth(con, request));
+        if (running && entry === running)
+            this.healthRefreshFollowups.set(ownerKey, con);
+        else
+            // A new or queued entry is itself the requested follow-up.
+            this.healthRefreshFollowups.delete(ownerKey);
+
+        return entry.promise.catch(error => {
+            console.warn("periodic health refresh failed", { uid: con.uid, stage: "health-refresh", error: error?.message || "unknown" });
+            this.markOwnerHealthUnavailable(con, entry.request, error);
+        }).finally(() => {
+            if (this.healthRefreshFollowups.get(ownerKey) !== con)
+                return;
+            this.healthRefreshFollowups.delete(ownerKey);
+            // Let OwnerRefreshGate remove the completed entry before starting
+            // the guaranteed follow-up; otherwise start() would coalesce it
+            // back onto the just-finished promise.
+            setTimeout(() => {
+                if (this.isCurrentConnection(con) &&
+                    this.state.users.find(user => user.uid === con.uid)?.containersLoaded)
+                    this.refreshOwnerHealth(con);
+            }, 0);
+        });
+    }
+
+    inspectContainer(con, id) {
+        const key = makeKey(con.uid, id);
+        const generation = this.containerEventGenerations.get(key) || 0;
+        return this.containerInspectRequests.request(
+            key,
+            { con, generation },
+            () => client.inspectContainer(con, id),
+            metadata => metadata.con === con && metadata.generation === generation,
+        );
+    }
+
+    getContainerInventory(con) {
+        return this.containerRequestGate.run(() => client.getContainers(con));
+    }
+
+    async withContainerRequestTimeout(request, timeoutMs, message) {
+        // If the queued request is canceled while waiting for a shared slot,
+        // its promise rejects before the result timeout is installed below.
+        // Observe that rejection immediately so a canceled inspect cannot
+        // become an unhandled rejection while we wait on request.started.
+        const observedRequest = Promise.resolve(request);
+        observedRequest.catch(() => undefined);
+        const startedAt = Date.now();
+        if (request.started) {
+            const started = await withTimeout(request.started, timeoutMs, message,
+                                              () => request.close?.("timeout"));
+            if (!started)
+                throw new Error(message);
+        }
+        return withTimeout(observedRequest,
+                           Math.max(1, timeoutMs - (Date.now() - startedAt)),
+                           message,
+                           () => request.close?.("timeout"));
+    }
+
+    markOwnerHealthUnavailable(con, refreshRequest, error) {
+        if (!this.isCurrentConnection(con) ||
+            (refreshRequest && !this.healthRefreshGate.isCurrent(con.uid, refreshRequest)))
+            return;
+
+        // A failed refresh must invalidate both the context-level health result
+        // and any scheduler result from the previous inventory.  Otherwise a
+        // rejected refresh can leave an old green row visible indefinitely.
+        const schedulerRequest = this.schedulerRequests.begin(con.uid);
+        const reason = errorText(error) || "health collection failed";
+        const containers = Object.values(this.state.containers || {})
+                .filter(container => container.uid === con.uid);
+        this.setState(prevState => {
+            if (!this.isCurrentConnection(con) ||
+                (refreshRequest && !this.healthRefreshGate.isCurrent(con.uid, refreshRequest)))
+                return null;
+            return { contextErrors: { ...prevState.contextErrors, [con.uid]: reason } };
+        });
+        this.applySchedulerCoverage(con, this.schedulerUid(con), containers, null,
+                                    SCHEDULER_FAILURE, schedulerRequest);
+    }
+
+    async collectOwnerHealth(con, request) {
+        if (!this.isCurrentConnection(con) || !this.healthRefreshGate.isCurrent(con.uid, request))
+            return;
+
+        const refreshDeadline = Date.now() + HEALTH_REFRESH_TIMEOUT_MS;
+        const initialEventGenerations = new Map();
+        const initialEventActions = new Map();
+        const ownerPrefix = `${con.uid ?? "user"}-`;
+        for (const [key, generation] of this.containerEventGenerations) {
+            if (key.startsWith(ownerPrefix)) {
+                initialEventGenerations.set(key, generation);
+                initialEventActions.set(key, this.containerEventActions.get(key));
+            }
+        }
+        let containerList;
+        try {
+            const inventoryRequest = this.getContainerInventory(con);
+            containerList = await this.withContainerRequestTimeout(inventoryRequest,
+                                                                   Math.max(1, refreshDeadline - Date.now()),
+                                                                   "Container inventory refresh timed out");
+            if (!Array.isArray(containerList))
+                throw new Error("container inventory is not an array");
+        } catch (error) {
+            this.markOwnerHealthUnavailable(con, request, error);
+            return;
+        }
+
+        const validInventory = containerList.filter(isContainerInventoryRow);
+        const invalidInventoryRow = validInventory.length !== containerList.length;
+        let schedulerPromise = null;
+        if (!invalidInventoryRow) {
+            const schedulerRequest = this.schedulerRequests.begin(con.uid);
+            // Scheduler metadata uses the inventory identity and can run
+            // independently while the bounded inspect workers collect the
+            // detailed health state. Both results carry the same owner and
+            // refresh generations, so a topology event discards stale output.
+            schedulerPromise = this.updateSchedulerCoverage(con, validInventory, schedulerRequest, request,
+                                                            HEALTH_SCHEDULER_TIMEOUT_MS);
+        }
+
+        // The inventory response is sufficient for lifecycle and identity
+        // updates.  A full inspect is reserved for running rows whose health
+        // details are pending or configured; rows already known to have no
+        // check, and every stopped/completed row, can be rendered without
+        // another expensive request.
+        const inspectList = validInventory.filter(container => {
+            const key = makeKey(con.uid, container.Id);
+            return shouldInspectHealth(container, this.state.containers?.[key]);
+        });
+        const results = await mapWithConcurrency(inspectList, async container => {
+            if (!isContainerInventoryRow(container))
+                return { container, error: new Error("Container inventory row is invalid") };
+            const remaining = Math.min(HEALTH_INSPECT_TIMEOUT_MS, refreshDeadline - Date.now());
+            if (remaining <= 0)
+                return { container, error: new Error("Container health refresh timed out") };
+            try {
+                const inspectRequest = this.inspectContainer(con, container.Id);
+                const detail = await this.withContainerRequestTimeout(inspectRequest, remaining,
+                                                                      "Container inspect timed out");
+                return { container, detail };
+            } catch (error) {
+                return { container, error };
+            }
+        }, HEALTH_INSPECT_CONCURRENCY);
+        if (!this.isCurrentConnection(con) || !this.healthRefreshGate.isCurrent(con.uid, request))
+            return;
+
+        const resultByKey = new Map();
+        for (const result of results) {
+            if (isContainerInventoryRow(result.container))
+                resultByKey.set(makeKey(con.uid, result.container.Id), result);
+        }
+
+        const snapshot = [];
+        const errors = {};
+        for (const inventory of containerList) {
+            if (!isContainerInventoryRow(inventory)) {
+                continue;
+            }
+            const id = inventory.Id;
+            const key = makeKey(con.uid, id);
+            const result = resultByKey.get(key);
+            if (result?.error) {
+                const old = this.state.containers?.[key] || null;
+                const failed = containerFromInventory(inventory, con.uid, key, old);
+                failed.healthDetailsLoaded = false;
+                snapshot.push(failed);
+                errors[key] = errorText(result.error);
+            } else if (result && !isValidHealthDetails(inventory, result.detail)) {
+                const old = this.state.containers?.[key] || null;
+                const failed = containerFromInventory(inventory, con.uid, key, old);
+                failed.healthDetailsLoaded = false;
+                snapshot.push(failed);
+                errors[key] = CONTAINER_INSPECT_INVALID;
+            } else if (result?.detail) {
+                const detail = { ...result.detail, uid: con.uid, key };
+                detail.healthDetailsLoaded = true;
+                snapshot.push(detail);
+            } else {
+                const old = this.state.containers?.[key] || null;
+                snapshot.push(containerFromInventory(inventory, con.uid, key, old));
+            }
+        }
+
+        this.setState(prevState => {
+            if (!this.isCurrentConnection(con) || !this.healthRefreshGate.isCurrent(con.uid, request))
+                return null;
+
+            const containers = {};
+            const containerErrors = {};
+            Object.entries(prevState.containers || {}).forEach(([key, container]) => {
+                if (container.uid !== con.uid) {
+                    containers[key] = container;
+                    if (prevState.containerErrors?.[key])
+                        containerErrors[key] = prevState.containerErrors[key];
+                }
+            });
+            const listedKeys = new Set(snapshot.map(container => container.key));
+            Object.entries(prevState.containers || {}).forEach(([key, container]) => {
+                if (container.uid !== con.uid || listedKeys.has(key))
+                    return;
+                const snapshotGeneration = initialEventGenerations.get(key) || 0;
+                const currentGeneration = this.containerEventGenerations.get(key) || 0;
+                const eventAction = currentGeneration === snapshotGeneration
+                    ? initialEventActions.get(key)
+                    : this.containerEventActions.get(key);
+                if (eventAction === "remove" || currentGeneration === snapshotGeneration)
+                    return;
+                containers[key] = container;
+                if (prevState.containerErrors?.[key])
+                    containerErrors[key] = prevState.containerErrors[key];
+            });
+            snapshot.forEach(container => {
+                const key = container.key;
+                const snapshotGeneration = initialEventGenerations.get(key) || 0;
+                const currentGeneration = this.containerEventGenerations.get(key) || 0;
+                const eventAction = currentGeneration === snapshotGeneration
+                    ? initialEventActions.get(key)
+                    : this.containerEventActions.get(key);
+                if (eventAction === "remove")
+                    return;
+                if (currentGeneration !== snapshotGeneration) {
+                    const current = prevState.containers?.[key];
+                    if (current) {
+                        containers[key] = current;
+                        if (prevState.containerErrors?.[key])
+                            containerErrors[key] = prevState.containerErrors[key];
+                        return;
+                    }
+                }
+                containers[container.key] = container;
+                if (errors[container.key])
+                    containerErrors[container.key] = errors[container.key];
+            });
+            const contextErrors = { ...prevState.contextErrors };
+            if (invalidInventoryRow)
+                contextErrors[con.uid] = "Container inventory row is invalid";
+            else
+                delete contextErrors[con.uid];
+            return { containers, containerErrors, contextErrors };
+        });
+
+        if (!this.isCurrentConnection(con) || !this.healthRefreshGate.isCurrent(con.uid, request))
+            return;
+        if (invalidInventoryRow) {
+            const schedulerRequest = this.schedulerRequests.begin(con.uid);
+            this.applySchedulerCoverage(con, this.schedulerUid(con), snapshot, null,
+                                        SCHEDULER_FAILURE, schedulerRequest);
+            return;
+        }
+        await schedulerPromise;
+    }
+
+    schedulerErrorRecord(con, container, contextUid, reason) {
+        return {
+            key: makeKey(con.uid, container.Id),
+            uid: contextUid,
+            container_id: container.Id,
+            name: container.Name,
+            active_coverage_count: 0,
+            coverage_count: 0,
+            effective_interval_seconds: null,
+            effective_interval_source: null,
+            jitter_seconds: null,
+            accuracy_seconds: null,
+            schedules: [],
+            coverage_status: "error",
+            coverage_reason: "collector-error",
+            collector_errors: [reason],
+        };
+    }
+
+    applySchedulerCoverage(con, contextUid, containers, coverage, failure = null, request = null) {
+        if (!this.isCurrentConnection(con))
+            return false;
+        if (request && !this.schedulerRequests.isCurrent(con.uid, request))
+            return false;
+        // Collector diagnostics are intentionally reduced to static codes at
+        // the UI boundary.  Cockpit errors can contain URLs, command lines,
+        // and health output; none belongs in a badge, title, or reason.
+        const sourceErrors = Array.isArray(coverage?.collector_errors) ? coverage.collector_errors : [];
+        const topErrors = failure ? [SCHEDULER_FAILURE] : (sourceErrors.length > 0 ? [SCHEDULER_INCOMPLETE] : []);
+        const rawRecords = coverage?.containers && typeof coverage.containers === "object"
+            ? coverage.containers
+            : {};
+        const records = {};
+        for (const container of containers) {
+            const id = container.Id;
+            const key = makeKey(con.uid, id);
+            const candidate = FULL_CONTAINER_ID.test(id)
+                ? rawRecords[`${contextUid}-${id}`]
+                : null;
+            let record = candidate && typeof candidate === "object" && !Array.isArray(candidate) &&
+                SCHEDULER_STATUSES.has(candidate.coverage_status)
+                ? candidate
+                : null;
+            if (!record) {
+                record = this.schedulerErrorRecord(con, container, contextUid,
+                                                   FULL_CONTAINER_ID.test(id)
+                                                       ? (candidate ? "scheduler-record-invalid" : "scheduler-record-missing")
+                                                       : "scheduler-container-id-invalid");
+            } else {
+                record = { ...record, key };
+            }
+            if (topErrors.length > 0) {
+                record = {
+                    ...record,
+                    coverage_status: "error",
+                    coverage_reason: "collector-error",
+                    collector_errors: [...(record.collector_errors || []), ...topErrors],
+                };
+            }
+            const recordErrors = Array.isArray(record.collector_errors) && record.collector_errors.length > 0
+                ? [SCHEDULER_INCOMPLETE]
+                : [];
+            record.collector_errors = [...new Set([...recordErrors, ...topErrors])];
+            records[key] = record;
+        }
+
+        const ownerPrefix = `${con.uid ?? "user"}-`;
+        this.setState(prevState => {
+            if (request && !this.schedulerRequests.isCurrent(con.uid, request))
+                return null;
+            const schedulerCoverage = {};
+            Object.entries(prevState.schedulerCoverage || {}).forEach(([key, value]) => {
+                if (!key.startsWith(ownerPrefix))
+                    schedulerCoverage[key] = value;
+            });
+            Object.assign(schedulerCoverage, records);
+            const schedulerErrors = { ...(prevState.schedulerErrors || {}) };
+            if (topErrors.length > 0)
+                schedulerErrors[con.uid] = topErrors[0];
+            else
+                delete schedulerErrors[con.uid];
+            return { schedulerCoverage, schedulerErrors };
+        });
+        return true;
+    }
+
+    async updateSchedulerCoverage(con, containers, request = null, refreshRequest = null, timeoutMs = HEALTH_SCHEDULER_TIMEOUT_MS) {
+        if (!this.isCurrentConnection(con) ||
+            (refreshRequest && !this.healthRefreshGate.isCurrent(con.uid, refreshRequest)))
+            return;
+        request ||= this.schedulerRequests.begin(con.uid);
+        const contextUid = this.schedulerUid(con);
+        if (!Number.isInteger(contextUid) || contextUid < 0) {
+            this.applySchedulerCoverage(con, null, containers, null, "Session user UID is unavailable", request);
+            return;
+        }
+
+        const identity = {
+            containers: containers.map(container => ({
+                uid: contextUid,
+                id: container.Id,
+                name: container.Name || container.Names?.[0]?.replace(/^\//, "") || null,
+            })),
+        };
+        const owner = this.state.users.find(user => user.uid === con.uid);
+        const options = {
+            err: "message",
+            environ: ["LC_ALL=C"],
+        };
+        let process;
+        try {
+            if (con.uid === null || con.uid === 0) {
+                if (con.uid === 0)
+                    options.superuser = "require";
+                process = python.spawn(scheduler_collector,
+                                       ["--uid", String(contextUid), "--timeout", "8"], options);
+            } else {
+                // A numeric --uid alone must never make root's systemctl --user
+                // manager look like another user's manager. Run the helper in
+                // the actual service user's bridge context instead.
+                if (!owner?.name)
+                    throw new Error("Service user name is unavailable");
+                process = cockpit.spawn([
+                    "runuser", "--preserve-environment", "-u", owner.name, "--",
+                    "/usr/bin/python3", "-c", scheduler_collector,
+                    "--uid", String(contextUid), "--timeout", "8",
+                ], {
+                    ...options,
+                    superuser: "require",
+                    environ: ["LC_ALL=C", `XDG_RUNTIME_DIR=/run/user/${contextUid}`],
+                });
+            }
+            process.input(JSON.stringify(identity));
+            process.input(null);
+            const output = JSON.parse(await withTimeout(process, timeoutMs,
+                                                        "Scheduler coverage collection timed out",
+                                                        () => process?.close?.()));
+            if (refreshRequest && !this.healthRefreshGate.isCurrent(con.uid, refreshRequest))
+                return;
+            if (output.schema !== SCHEDULER_SCHEMA || output.uid !== contextUid ||
+                !output.containers || typeof output.containers !== "object")
+                throw new Error("Scheduler collector returned an invalid schema");
+            this.applySchedulerCoverage(con, contextUid, containers, output, null, request);
+        } catch {
+            if (refreshRequest && !this.healthRefreshGate.isCurrent(con.uid, refreshRequest))
+                return;
+            console.warn("scheduler coverage collection failed", { uid: con.uid, stage: "scheduler-collector" });
+            this.applySchedulerCoverage(con, contextUid, containers, null, SCHEDULER_FAILURE, request);
+        }
+    }
+
+    queueContainerStats(con, stats) {
+        if (!this.isCurrentConnection(con))
+            return;
+        if (!Array.isArray(stats) || stats.length === 0)
+            return;
+
+        const uid = con.uid;
+        let pending = this.pendingContainerStats.get(uid);
+        if (pending && pending.con !== con) {
+            const oldTimer = this.containerStatsTimers.get(uid);
+            if (oldTimer !== undefined) {
+                clearTimeout(oldTimer);
+                this.containerStatsTimers.delete(uid);
+            }
+            pending = null;
+        }
+        if (!pending)
+            pending = { con, values: {} };
+
+        for (const stat of stats) {
+            if (!stat || typeof stat.ContainerID !== "string")
+                continue;
+            pending.values[makeKey(uid, stat.ContainerID)] = stat;
+        }
+        if (Object.keys(pending.values).length === 0)
+            return;
+        this.pendingContainerStats.set(uid, pending);
+
+        if (this.containerStatsTimers.has(uid))
+            return;
+        const timer = setTimeout(() => {
+            this.containerStatsTimers.delete(uid);
+            const current = this.pendingContainerStats.get(uid);
+            if (!current || current !== pending)
+                return;
+            this.pendingContainerStats.delete(uid);
+            if (!this.isCurrentConnection(con))
+                return;
+            this.setState(prevState => ({
+                containersStats: { ...prevState.containersStats, ...current.values },
+            }));
+        }, CONTAINER_STATS_FLUSH_INTERVAL_MS);
+        this.containerStatsTimers.set(uid, timer);
+    }
+
+    clearContainerStats(con, removeState = false) {
+        const uid = con.uid;
+        const timer = this.containerStatsTimers.get(uid);
+        if (timer !== undefined) {
+            clearTimeout(timer);
+            this.containerStatsTimers.delete(uid);
+        }
+        const pending = this.pendingContainerStats.get(uid);
+        if (!pending || pending.con === con)
+            this.pendingContainerStats.delete(uid);
+        if (!removeState)
+            return;
+
+        this.setState(prevState => {
+            const ownerPrefix = `${uid ?? "user"}-`;
+            const containersStats = {};
+            Object.entries(prevState.containersStats || {}).forEach(([key, value]) => {
+                if (!key.startsWith(ownerPrefix))
+                    containersStats[key] = value;
+            });
+            return { containersStats };
+        });
+    }
+
     updateContainerStats(con) {
         client.streamContainerStats(con, reply => {
             if (reply.Error != null) // executed when container stop
                 console.warn("Failed to update container stats:", JSON.stringify(reply.message));
-            else {
-                reply.Stats.forEach(stat => this.updateState("containersStats", makeKey(con.uid, stat.ContainerID), stat));
-            }
+            else
+                this.queueContainerStats(con, reply.Stats);
         }).catch(ex => {
             if (ex.cause == "no support for CGroups V1 in rootless environments" || ex.cause == "Container stats resource only available for cgroup v2") {
                 console.log("This OS does not support CgroupsV2. Some information may be missing.");
@@ -167,30 +801,160 @@ class Application extends React.Component {
     }
 
     initContainers(con) {
-        return client.getContainers(con)
-                .then(containerList => Promise.all(
-                    containerList.map(container => client.inspectContainer(con, container.Id))
-                ))
-                .then(containerDetails => {
-                    this.setState(prevState => {
-                        // keep/copy the containers of other users
-                        const copyContainers = {};
-                        Object.entries(prevState.containers || {}).forEach(([id, container]) => {
-                            if (container.uid !== con.uid)
-                                copyContainers[id] = container;
-                        });
-                        for (const detail of containerDetails) {
-                            detail.uid = con.uid;
-                            detail.key = makeKey(con.uid, detail.Id);
-                            copyContainers[detail.key] = detail;
-                        }
+        // Initial inventory and deferred health work use the same global owner
+        // gate as periodic refreshes. This prevents startup from launching an
+        // unbounded burst across every discovered Podman context.
+        this.healthRefreshGate.invalidate(con.uid);
+        const entry = this.healthRefreshGate.start(con.uid, refreshRequest =>
+            this.collectInitialContainers(con, refreshRequest));
+        return entry.promise.then(() => {
+            // An event can invalidate the initial inventory after Podman has
+            // returned it but before the guarded state commit.  The old
+            // generation then resolves without marking the owner loaded; make
+            // that lifecycle self-healing instead of leaving the page in a
+            // permanent container-loading state.
+            if (this.isCurrentConnection(con) &&
+                !this.healthRefreshGate.isCurrent(con.uid, entry.request) &&
+                !this.state.users.find(user => user.uid === con.uid)?.containersLoaded)
+                return this.initContainers(con);
 
-                        const users = prevState.users.map(u => u.uid === con.uid ? { ...u, containersLoaded: true } : u);
-                        return { containers: copyContainers, users };
-                    });
-                    this.updateContainerStats(con);
-                })
-                .catch(e => console.warn("initContainers uid", con.uid, "getContainers failed:", e.toString()));
+            // Inventory rows are committed before the expensive detail pass.
+            // Start that pass only after the initial gate has settled so the
+            // first render is not held behind one inspect per container.
+            if (this.isCurrentConnection(con)) {
+                setTimeout(() => {
+                    if (this.isCurrentConnection(con))
+                        this.refreshOwnerHealth(con);
+                }, 0);
+            }
+        }).catch(error => {
+            console.warn("initContainers uid", con.uid, "failed:", error?.toString?.() || error);
+            this.markOwnerHealthUnavailable(con, entry.request, error);
+            this.setState(prevState => {
+                if (!this.isCurrentConnection(con) || !this.healthRefreshGate.isCurrent(con.uid, entry.request))
+                    return null;
+                const users = prevState.users.map(u => u.uid === con.uid ? { ...u, containersLoaded: true } : u);
+                return { users };
+            });
+        });
+    }
+
+    async collectInitialContainers(con, refreshRequest) {
+        const request = this.schedulerRequests.begin(con.uid);
+        const deadline = Date.now() + HEALTH_REFRESH_TIMEOUT_MS;
+        const initialEventGenerations = new Map();
+        const initialEventActions = new Map();
+        const ownerPrefix = `${con.uid ?? "user"}-`;
+        for (const [key, generation] of this.containerEventGenerations) {
+            if (key.startsWith(ownerPrefix)) {
+                initialEventGenerations.set(key, generation);
+                initialEventActions.set(key, this.containerEventActions.get(key));
+            }
+        }
+        try {
+            const inventoryRequest = this.getContainerInventory(con);
+            const containerList = await this.withContainerRequestTimeout(inventoryRequest,
+                                                                         Math.max(1, deadline - Date.now()),
+                                                                         "Initial container inventory timed out");
+            if (!Array.isArray(containerList))
+                throw new Error("container inventory is not an array");
+            const validInventory = containerList.filter(isContainerInventoryRow);
+            const invalidInventoryRow = validInventory.length !== containerList.length;
+            if (!this.isCurrentConnection(con))
+                return;
+
+            this.setState(prevState => {
+                const stillLoading = !prevState.users.find(user => user.uid === con.uid)?.containersLoaded;
+                if (!this.isCurrentConnection(con) ||
+                    (!this.healthRefreshGate.isCurrent(con.uid, refreshRequest) && !stillLoading))
+                    return null;
+                // keep/copy the containers of other users
+                const copyContainers = {};
+                const copyContainerErrors = {};
+                Object.entries(prevState.containers || {}).forEach(([id, container]) => {
+                    if (container.uid !== con.uid) {
+                        copyContainers[id] = container;
+                        if (prevState.containerErrors?.[id])
+                            copyContainerErrors[id] = prevState.containerErrors[id];
+                    }
+                });
+                const listedKeys = new Set(validInventory.map(container => makeKey(con.uid, container.Id)));
+                Object.entries(prevState.containers || {}).forEach(([key, container]) => {
+                    if (container.uid !== con.uid || listedKeys.has(key))
+                        return;
+                    const snapshotGeneration = initialEventGenerations.get(key) || 0;
+                    const currentGeneration = this.containerEventGenerations.get(key) || 0;
+                    const eventAction = currentGeneration === snapshotGeneration
+                        ? initialEventActions.get(key)
+                        : this.containerEventActions.get(key);
+                    if (eventAction === "remove" || currentGeneration === snapshotGeneration)
+                        return;
+                    copyContainers[key] = container;
+                    if (prevState.containerErrors?.[key])
+                        copyContainerErrors[key] = prevState.containerErrors[key];
+                });
+                for (const inventory of validInventory) {
+                    const id = inventory.Id;
+                    const key = makeKey(con.uid, id);
+                    const snapshotGeneration = initialEventGenerations.get(key) || 0;
+                    const currentGeneration = this.containerEventGenerations.get(key) || 0;
+                    const eventAction = currentGeneration === snapshotGeneration
+                        ? initialEventActions.get(key)
+                        : this.containerEventActions.get(key);
+                    if (eventAction === "remove")
+                        continue;
+                    if (currentGeneration !== snapshotGeneration) {
+                        const current = prevState.containers?.[key];
+                        if (current) {
+                            copyContainers[key] = current;
+                            if (prevState.containerErrors?.[key])
+                                copyContainerErrors[key] = prevState.containerErrors[key];
+                            continue;
+                        }
+                    }
+                    // The inventory call is deliberately the first render
+                    // source. It supplies lifecycle and identity while the
+                    // owner health refresh obtains the optional detail.
+                    const current = prevState.containers?.[key] || null;
+                    copyContainers[key] = containerFromInventory(inventory, con.uid, key, current);
+                    if (current && prevState.containerErrors?.[key])
+                        copyContainerErrors[key] = prevState.containerErrors[key];
+                }
+
+                const users = prevState.users.map(u => u.uid === con.uid ? { ...u, containersLoaded: true } : u);
+                const contextErrors = { ...prevState.contextErrors };
+                if (invalidInventoryRow)
+                    contextErrors[con.uid] = "Container inventory row is invalid";
+                else
+                    delete contextErrors[con.uid];
+                return { containers: copyContainers, containerErrors: copyContainerErrors, contextErrors, users };
+            });
+            this.updateContainerStats(con);
+            if (invalidInventoryRow) {
+                const schedulerRequest = this.schedulerRequests.begin(con.uid);
+                this.applySchedulerCoverage(con, this.schedulerUid(con), validInventory, null,
+                                            SCHEDULER_FAILURE, schedulerRequest);
+            }
+            // The deferred owner health pass starts scheduler collection from
+            // the same inventory snapshot as its bounded detail requests.
+        } catch (error) {
+            if (!this.isCurrentConnection(con))
+                return;
+            console.warn("initContainers uid", con.uid, "getContainers failed:", error?.toString?.() || error);
+            this.setState(prevState => {
+                const stillLoading = !prevState.users.find(user => user.uid === con.uid)?.containersLoaded;
+                if (!this.isCurrentConnection(con) ||
+                    (!this.healthRefreshGate.isCurrent(con.uid, refreshRequest) && !stillLoading))
+                    return null;
+                const users = prevState.users.map(u => u.uid === con.uid ? { ...u, containersLoaded: true } : u);
+                return {
+                    containers: prevState.containers || {},
+                    contextErrors: { ...prevState.contextErrors, [con.uid]: errorText(error) },
+                    users,
+                };
+            });
+            this.applySchedulerCoverage(con, this.schedulerUid(con), [], null, SCHEDULER_FAILURE, request);
+        }
     }
 
     updateImages(con) {
@@ -246,24 +1010,84 @@ class Application extends React.Component {
     }
 
     updateContainer(con, id, event) {
+        if (!this.isCurrentConnection(con))
+            return Promise.resolve();
+        const key = makeKey(con.uid, id);
+        this.markContainerEvent(con, id, event?.Action);
+        // A Podman event is newer than a periodic snapshot that may still be
+        // in flight.  Invalidate that snapshot and let the serialized inspect
+        // below become the owner-scoped source of truth.
+        if (!["health_status", "exec_died"].includes(event?.Action))
+            this.healthRefreshGate.invalidate(con.uid);
+        const request = this.containerEventRequests.begin(key);
+        const schedulerRequest = ["create", "rename", "start"].includes(event?.Action)
+            ? this.schedulerRequests.begin(con.uid)
+            : null;
         /* when firing off multiple calls in parallel, podman can return them in a random order.
          * This messes up the state. So we need to serialize them for a particular container. */
-        const key = makeKey(con.uid, id);
         const wait = this.pendingUpdateContainer[key] ?? Promise.resolve();
 
-        const new_wait = wait.then(() => client.inspectContainer(con, id))
+        const new_wait = wait.catch(() => undefined).then(() => {
+            // A newer event may have arrived while this container's previous
+            // inspect was queued. Do not spend another global request slot on
+            // an event whose result is already obsolete.
+            if (!this.isCurrentConnection(con) || !this.containerEventRequests.isCurrent(key, request))
+                return;
+            const inspectRequest = this.inspectContainer(con, id);
+            return this.withContainerRequestTimeout(inspectRequest,
+                                                    HEALTH_EVENT_INSPECT_TIMEOUT_MS,
+                                                    "Container event inspect timed out");
+        })
                 .then(details => {
+                    if (!this.isCurrentConnection(con) || !this.containerEventRequests.isCurrent(key, request))
+                        return;
+                    if (!isValidHealthDetails({ Id: id }, details)) {
+                        this.setState(prevState => {
+                            if (!this.isCurrentConnection(con) || !this.containerEventRequests.isCurrent(key, request))
+                                return null;
+                            return { containerErrors: { ...prevState.containerErrors, [key]: CONTAINER_INSPECT_INVALID } };
+                        });
+                        return;
+                    }
                     details.uid = con.uid;
                     details.key = key;
+                    details.healthDetailsLoaded = true;
                     // HACK: during restart State never changes from "running"
                     //       override it to reconnect console after restart
                     if (event?.Action === "restart")
                         details.State.Status = "restarting";
-                    this.updateState("containers", key, details);
+                    this.setState(prevState => {
+                        if (!this.isCurrentConnection(con) || !this.containerEventRequests.isCurrent(key, request))
+                            return null;
+                        const containerErrors = { ...prevState.containerErrors };
+                        delete containerErrors[key];
+                        return {
+                            containers: { ...prevState.containers, [key]: details },
+                            containerErrors,
+                        };
+                    }, () => {
+                        if (["create", "rename", "start"].includes(event?.Action) &&
+                            this.isCurrentConnection(con) && this.containerEventRequests.isCurrent(key, request)) {
+                            const containers = Object.values(this.state.containers || {})
+                                    .filter(container => container.uid === con.uid);
+                            this.updateSchedulerCoverage(con, containers, schedulerRequest);
+                        }
+                    });
                 })
-                .catch(e => console.warn("updateContainer uid", con.uid, "inspectContainer failed:", e.toString()));
+                .catch(e => {
+                    if (!this.isCurrentConnection(con) || !this.containerEventRequests.isCurrent(key, request))
+                        return;
+                    console.warn("updateContainer uid", con.uid, "inspectContainer failed:", e.toString());
+                    this.setState(prevState => ({
+                        containerErrors: { ...prevState.containerErrors, [key]: errorText(e) }
+                    }));
+                });
         this.pendingUpdateContainer[key] = new_wait;
-        new_wait.finally(() => { delete this.pendingUpdateContainer[key] });
+        const clearPending = () => {
+            if (this.pendingUpdateContainer[key] === new_wait)
+                delete this.pendingUpdateContainer[key];
+        };
+        new_wait.then(clearPending, clearPending);
 
         return new_wait;
     }
@@ -362,10 +1186,21 @@ class Application extends React.Component {
             this.updateContainer(con, id, event);
             break;
 
-        case 'remove':
+        case 'remove': {
+            this.markContainerEvent(con, id, event?.Action || "remove");
+            // Invalidate an inspect started for an earlier event before
+            // removing the row.  Otherwise its late response could
+            // resurrect a container that Podman has already deleted.
+            this.containerEventRequests.begin(makeKey(con.uid, id));
+            this.healthRefreshGate.invalidate(con.uid);
+            const request = this.schedulerRequests.begin(con.uid);
             this.setState(prevState => {
                 const containers = { ...prevState.containers };
                 delete containers[makeKey(con.uid, id)];
+                const containerErrors = { ...prevState.containerErrors };
+                delete containerErrors[makeKey(con.uid, id)];
+                const schedulerCoverage = { ...prevState.schedulerCoverage };
+                delete schedulerCoverage[makeKey(con.uid, id)];
                 let pods;
 
                 if (event.Actor.Attributes.podId) {
@@ -379,10 +1214,19 @@ class Application extends React.Component {
                     pods = prevState.pods;
                     this.updatePods(con);
                 }
-
-                return { containers, pods };
+                return { containers, containerErrors, schedulerCoverage, pods };
+            }, () => {
+                // Read the post-removal state from the setState callback.  The
+                // old immediate read could feed the deleted container back to
+                // the scheduler and resurrect stale coverage.
+                if (!this.isCurrentConnection(con) || !this.schedulerRequests.isCurrent(con.uid, request))
+                    return;
+                const remaining = Object.values(this.state.containers || {})
+                        .filter(container => container.uid === con.uid && container.Id !== id);
+                this.updateSchedulerCoverage(con, remaining, request);
             });
             break;
+        }
 
         // only needs to update the Image list, this ought to be an image event
         case 'commit':
@@ -432,17 +1276,37 @@ class Application extends React.Component {
     }
 
     cleanupAfterService(con) {
+        if (!this.invalidateOwner(con))
+            return;
+        this.clearContainerStats(con, true);
         debug("cleanupAfterService", con.uid, "current owner filter:", this.state.ownerFilter);
-        ["images", "containers", "pods"].forEach(t => {
-            if (this.state[t])
-                this.setState(prevState => {
-                    const copy = {};
-                    Object.entries(prevState[t] || {}).forEach(([id, v]) => {
-                        if (v.uid !== con.uid)
-                            copy[id] = v;
-                    });
-                    return { [t]: copy };
+        this.setState(prevState => {
+            const next = {};
+            ["images", "containers", "pods"].forEach(t => {
+                if (!prevState[t])
+                    return;
+                next[t] = {};
+                Object.entries(prevState[t]).forEach(([id, value]) => {
+                    if (value.uid !== con.uid)
+                        next[t][id] = value;
                 });
+            });
+
+            const containerErrors = {};
+            Object.entries(prevState.containerErrors || {}).forEach(([id, error]) => {
+                if (!id.startsWith(`${con.uid ?? "user"}-`))
+                    containerErrors[id] = error;
+            });
+            const contextErrors = { ...prevState.contextErrors };
+            delete contextErrors[con.uid];
+            const schedulerCoverage = {};
+            Object.entries(prevState.schedulerCoverage || {}).forEach(([id, value]) => {
+                if (!id.startsWith(`${con.uid ?? "user"}-`))
+                    schedulerCoverage[id] = value;
+            });
+            const schedulerErrors = { ...prevState.schedulerErrors };
+            delete schedulerErrors[con.uid];
+            return { ...next, containerErrors, contextErrors, schedulerCoverage, schedulerErrors };
         });
 
         // keep dummy (null) connections from other users, only remove valid ones
@@ -533,6 +1397,9 @@ class Application extends React.Component {
                     uid: con.uid,
                     key: container_key,
                     Id: key,
+                    // This is a display-only row synthesized from a systemd
+                    // unit; it does not have a Podman container ID.
+                    IsQuadlet: true,
                     IsService: false,
                     IsInfra: false,
                     Name: quadlet.name,
@@ -633,6 +1500,7 @@ class Application extends React.Component {
             await cockpit.spawn(start_args, { superuser: uid === null ? null : "require", err: "message", environ });
             con = rest.connect(uid);
             const reply = await client.getInfo(con);
+            this.ownerConnections.set(uid, con);
             this.setState(prevState => {
                 const users = prevState.users.filter(u => u.uid !== uid);
                 users.push({ con, uid, name: username, containersLoaded: false, podsLoaded: false, imagesLoaded: false, quadletsLoaded: false });
@@ -674,9 +1542,11 @@ class Application extends React.Component {
     }
 
     componentDidMount() {
+        this.healthRefreshTimer = window.setInterval(() => this.refreshHealthOwners(), HEALTH_REFRESH_INTERVAL_MS);
         superuser.addEventListener("changed", () => this.init(0, _("system")));
 
         cockpit.user().then(user => {
+            this.sessionUser = user;
             // there is no "user service" for root, ignore that
             if (user.id === 0) {
                 // clear the dummy init user, otherwise UI waits forever for initialization
@@ -751,6 +1621,17 @@ class Application extends React.Component {
 
     componentWillUnmount() {
         cockpit.removeEventListener("locationchanged", this.onNavigate);
+
+        if (this.healthRefreshTimer !== null)
+            window.clearInterval(this.healthRefreshTimer);
+        for (const con of this.ownerConnections.values()) {
+            this.invalidateOwner(con);
+            this.clearContainerStats(con);
+        }
+        this.pendingContainerStats.clear();
+        this.containerStatsTimers.forEach(timer => clearTimeout(timer));
+        this.containerStatsTimers.clear();
+        this.ownerConnections.clear();
 
         // Cleanup DBus subscriptions
         this.state.users.forEach(user => {
@@ -894,6 +1775,10 @@ class Application extends React.Component {
                 version={this.state.version}
                 images={loadingImages ? null : this.state.images}
                 containers={loadingContainers ? null : this.state.containers}
+                containerErrors={this.state.containerErrors}
+                contextErrors={this.state.contextErrors}
+                schedulerCoverage={this.state.schedulerCoverage}
+                schedulerErrors={this.state.schedulerErrors}
                 pods={loadingPods ? null : this.state.pods}
                 containersStats={this.state.containersStats}
                 filter={this.state.containersFilter}

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -698,7 +698,10 @@ class Application extends React.Component {
                     environ: ["LC_ALL=C", `XDG_RUNTIME_DIR=/run/user/${contextUid}`],
                 });
             }
-            process.input(JSON.stringify(identity));
+            // Keep the request body open while writing the identity. The
+            // following null input sends the single stream EOF; omitting the
+            // stream flag here sends EOF once for this call and again below.
+            process.input(JSON.stringify(identity), true);
             process.input(null);
             const output = JSON.parse(await withTimeout(process, timeoutMs,
                                                         "Scheduler coverage collection timed out",

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -53,7 +53,25 @@ const isContainerInventoryRow = container => container !== null &&
     typeof container === "object" && !Array.isArray(container) &&
     typeof container.Id === "string" && container.Id.trim().length > 0;
 
-const containerFromInventory = (inventory, uid, key, current = null) => {
+const isValidOwnerUid = uid => Number.isInteger(uid) && uid >= 0;
+
+// `uid === null` identifies the session-user Cockpit route, but it is not the
+// Podman owner identity. Keep the verified session UID and namespace on every
+// row so scope and lifecycle metadata remain attributable to the real owner.
+const ownerScope = (uid, ownerUid = undefined, context = undefined) => {
+    const resolvedOwnerUid = isValidOwnerUid(ownerUid)
+        ? ownerUid
+        : isValidOwnerUid(uid) ? uid : null;
+    const resolvedContext = context === "rootful" || context === "rootless"
+        ? context
+        : resolvedOwnerUid === 0 ? "rootful" : resolvedOwnerUid === null ? "unknown" : "rootless";
+    return { ownerUid: resolvedOwnerUid, context: resolvedContext };
+};
+
+const containerFromInventory = (inventory, uid, key, current = null, connection = null) => {
+    const scope = ownerScope(uid,
+                            connection?.ownerUid ?? current?.ownerUid,
+                            connection?.context ?? current?.context);
     const inventoryState = typeof inventory?.State === "string"
         ? { Status: inventory.State.toLowerCase() }
         : (inventory?.State || {});
@@ -96,6 +114,7 @@ const containerFromInventory = (inventory, uid, key, current = null) => {
         State: state,
         uid,
         key,
+        ...scope,
         // An inventory-only row has enough data for lifecycle rendering but
         // must remain pending until its first full inspect establishes health
         // configuration and the native result.
@@ -477,13 +496,13 @@ class Application extends React.Component {
             const result = resultByKey.get(key);
             if (result?.error) {
                 const old = this.state.containers?.[key] || null;
-                const failed = containerFromInventory(inventory, con.uid, key, old);
+                const failed = containerFromInventory(inventory, con.uid, key, old, con);
                 failed.healthDetailsLoaded = false;
                 snapshot.push(failed);
                 errors[key] = errorText(result.error);
             } else if (result && !isValidHealthDetails(inventory, result.detail)) {
                 const old = this.state.containers?.[key] || null;
-                const failed = containerFromInventory(inventory, con.uid, key, old);
+                const failed = containerFromInventory(inventory, con.uid, key, old, con);
                 failed.healthDetailsLoaded = false;
                 snapshot.push(failed);
                 errors[key] = CONTAINER_INSPECT_INVALID;
@@ -493,7 +512,7 @@ class Application extends React.Component {
                 snapshot.push(detail);
             } else {
                 const old = this.state.containers?.[key] || null;
-                snapshot.push(containerFromInventory(inventory, con.uid, key, old));
+                snapshot.push(containerFromInventory(inventory, con.uid, key, old, con));
             }
         }
 
@@ -919,7 +938,7 @@ class Application extends React.Component {
                     // source. It supplies lifecycle and identity while the
                     // owner health refresh obtains the optional detail.
                     const current = prevState.containers?.[key] || null;
-                    copyContainers[key] = containerFromInventory(inventory, con.uid, key, current);
+                    copyContainers[key] = containerFromInventory(inventory, con.uid, key, current, con);
                     if (current && prevState.containerErrors?.[key])
                         copyContainerErrors[key] = prevState.containerErrors[key];
                 }
@@ -1053,6 +1072,8 @@ class Application extends React.Component {
                         return;
                     }
                     details.uid = con.uid;
+                    details.ownerUid = con.ownerUid;
+                    details.context = con.context;
                     details.key = key;
                     details.healthDetailsLoaded = true;
                     // HACK: during restart State never changes from "running"
@@ -1398,6 +1419,8 @@ class Application extends React.Component {
                 // Mock podman container state
                 const container = {
                     uid: con.uid,
+                    ownerUid: con.ownerUid,
+                    context: con.context,
                     key: container_key,
                     Id: key,
                     // This is a display-only row synthesized from a systemd
@@ -1502,6 +1525,7 @@ class Application extends React.Component {
             const environ = is_other_user ? [`XDG_RUNTIME_DIR=/run/user/${uid}`] : [];
             await cockpit.spawn(start_args, { superuser: uid === null ? null : "require", err: "message", environ });
             con = rest.connect(uid);
+            Object.assign(con, ownerScope(uid, uid === null ? this.sessionUser?.id : uid));
             const reply = await client.getInfo(con);
             this.ownerConnections.set(uid, con);
             this.setState(prevState => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,19 +1,23 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 import type { JsonObject, JsonValue } from "cockpit";
 
-import type { Connection, MonitorCallback } from "./rest.ts";
+import type { CancellablePromise, Connection, MonitorCallback } from "./rest.ts";
 
 // podman API version; oldest one that we support
 export const VERSION = "/v3.4.0/";
 
 const podmanCall = (con: Connection, name: string, method: string, args: JsonObject, body?: string):
-                   Promise<string> =>
+                   CancellablePromise<string> =>
     con.call({ method, path: VERSION + name, body: body || "", params: args, });
 
 const podmanJson = (con: Connection, name: string, method: string, args: JsonObject, body?: string):
-                   Promise<JsonObject|JsonValue> =>
-    podmanCall(con, name, method, args, body)
-            .then(reply => JSON.parse(reply));
+                   CancellablePromise<JsonObject|JsonValue> => {
+    const request = podmanCall(con, name, method, args, body);
+    const result = request.then(reply => JSON.parse(reply)) as CancellablePromise<JsonObject|JsonValue>;
+    if (request.close)
+        result.close = request.close;
+    return result;
+};
 
 export const streamEvents = (con: Connection, callback: MonitorCallback) =>
     con.monitor(`${VERSION}libpod/events`, callback);

--- a/src/health-scheduler.py
+++ b/src/health-scheduler.py
@@ -1,0 +1,1003 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Read-only systemd schedule metadata for the Cockpit Podman health view.
+
+The caller supplies the already-collected Podman inventory for one owner
+context on stdin.  This program only reads that inventory and the matching
+systemd manager.  It never calls a healthcheck, changes a unit, or writes a
+state file.
+
+The systemd manager is selected from the owner UID: UID 0 uses the system
+manager and every other UID uses that user's manager (``systemctl --user``).
+For a non-zero UID this program is intended to run in that user's Cockpit
+bridge context; it does not attempt to impersonate another user.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import selectors
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping, Sequence
+
+SCHEMA = "train-health-scheduler-coverage/v1"
+DEFAULT_TIMEOUT = 8.0
+DEFAULT_MAX_UNITS = 512
+# The limit applies to stdout and stderr together.  A malicious helper must
+# not bypass the bound by splitting output across the two pipes.
+MAX_OUTPUT_BYTES = 8 * 1024 * 1024
+
+CONTAINER_ID_RE = re.compile(r"[0-9a-f]{64}\Z")
+CONTAINER_NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]*\Z")
+UNIT_RE = re.compile(r"[^\s=]+\.(?:timer|service)\Z")
+
+# A unit property list is deliberately finite.  Keeping the list explicit
+# makes the subprocess output bounded and documents what the display trusts.
+TIMER_PROPERTIES = (
+    "Id",
+    "ActiveState",
+    "SubState",
+    "Unit",
+    "Triggers",
+    "OnUnitActiveUSec",
+    "OnUnitActiveSec",
+    "OnUnitInactiveUSec",
+    "OnUnitInactiveSec",
+    "TimersMonotonic",
+    "OnCalendar",
+    "RandomizedDelayUSec",
+    "RandomizedDelaySec",
+    "AccuracyUSec",
+    "AccuracySec",
+    "LastTriggerUSec",
+    "LastTriggerUSecRealtime",
+    "NextElapseUSecRealtime",
+    "NextElapseUSecMonotonic",
+)
+SERVICE_PROPERTIES = ("Id", "ExecStart", "ExecStartEx", "ActiveState", "SubState")
+
+
+class CollectorInputError(ValueError):
+    """The caller supplied an unsafe or unusable inventory."""
+
+
+@dataclass(frozen=True)
+class ContainerRef:
+    uid: int
+    container_id: str
+    name: str | None
+    source_index: int
+
+    @property
+    def key(self) -> str:
+        # Keep this in lockstep with cockpit-podman's makeKey(uid, id).
+        return f"{self.uid}-{self.container_id}"
+
+
+@dataclass
+class ContainerCoverage:
+    ref: ContainerRef
+    schedules: list[dict[str, Any]] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class CommandResult:
+    argv: list[str]
+    returncode: int
+    stdout: str
+    stderr: str
+    timed_out: bool = False
+
+
+def _number(value: float | None) -> int | float | None:
+    """Emit integral durations as JSON integers while retaining fractions."""
+
+    if value is None:
+        return None
+    if value.is_integer():
+        return int(value)
+    return value
+
+
+def _command_error(prefix: str, result: CommandResult) -> str:
+    # Never return systemctl stderr/stdout to the display.  It may contain
+    # command lines, URLs, or application output.  Keep only a bounded,
+    # allowlisted stage and the process outcome needed for diagnosis.
+    stages = {
+        "systemd timer inventory failed": "systemd-timer-inventory",
+        "systemd timer metadata failed": "systemd-timer-metadata",
+        "systemd health service metadata failed": "systemd-health-service-metadata",
+    }
+    stage = stages.get(prefix, "systemd-collector")
+    if result.timed_out:
+        return f"{stage}:timeout"
+    return f"{stage}:exit-{result.returncode}"
+
+
+def run_bounded(argv: Sequence[str], timeout: float) -> CommandResult:
+    """Run one read-only command with a deadline and bounded pipe reads.
+
+    ``subprocess.run(capture_output=True)`` accumulates arbitrary stdout and
+    stderr before a caller can enforce a limit.  Read both pipes through a
+    selector instead, terminate the process group at the first timeout or
+    overflow, and close every descriptor on every exit path.
+    """
+
+    command = list(argv)
+
+    def terminate(process: subprocess.Popen[bytes]) -> None:
+        try:
+            if hasattr(os, "killpg"):
+                os.killpg(process.pid, signal.SIGKILL)
+            else:
+                process.kill()
+        except (ProcessLookupError, OSError):
+            pass
+        try:
+            process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
+            try:
+                process.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                # The process group has already been killed. Do not block the
+                # collector forever on a broken child reaper.
+                pass
+
+    try:
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+    except OSError as exc:
+        return CommandResult(command, 127, "", str(exc))
+
+    selector = selectors.DefaultSelector()
+    buffers: dict[str, bytearray] = {"stdout": bytearray(), "stderr": bytearray()}
+    total_output_bytes = 0
+    streams = (("stdout", process.stdout), ("stderr", process.stderr))
+    for name, stream in streams:
+        if stream is not None:
+            selector.register(stream, selectors.EVENT_READ, name)
+
+    timed_out = False
+    overflow = False
+    deadline = time.monotonic() + timeout
+    try:
+        while selector.get_map():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
+                terminate(process)
+                break
+            events = selector.select(remaining)
+            if not events:
+                timed_out = True
+                terminate(process)
+                break
+            for key, _ in events:
+                stream = key.fileobj
+                chunk = os.read(stream.fileno(), 64 * 1024)
+                if not chunk:
+                    selector.unregister(stream)
+                    stream.close()
+                    continue
+                name = key.data
+                if total_output_bytes + len(chunk) > MAX_OUTPUT_BYTES:
+                    overflow = True
+                    terminate(process)
+                    break
+                buffers[name].extend(chunk)
+                total_output_bytes += len(chunk)
+            if timed_out or overflow:
+                break
+
+        if not timed_out and not overflow:
+            returncode = process.wait(timeout=max(0.1, deadline - time.monotonic()))
+        else:
+            returncode = 124 if timed_out else 75
+        if timed_out:
+            return CommandResult(command, returncode, "", "", timed_out=True)
+        if overflow:
+            return CommandResult(command, returncode, "", "output exceeded collector limit")
+        return CommandResult(
+            command,
+            returncode,
+            bytes(buffers["stdout"]).decode("utf-8", "replace"),
+            bytes(buffers["stderr"]).decode("utf-8", "replace"),
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        terminate(process)
+        return CommandResult(command, 124, "", "", timed_out=True)
+    finally:
+        selector.close()
+        for _, stream in streams:
+            if stream is not None and not stream.closed:
+                stream.close()
+        if process.poll() is None:
+            terminate(process)
+
+
+def parse_systemd_duration(value: str | None) -> float | None:
+    """Parse a systemd ``*USec``/``*Sec`` duration into seconds.
+
+    ``systemctl show`` normally returns values such as ``30s`` and ``1min``.
+    The parser also accepts compound values and the microsecond spellings that
+    systemd may expose on older versions.  ``infinity``, ``-`` and zero mean
+    that a timer expression is disabled and therefore return ``None``.
+    """
+
+    if value is None:
+        return None
+    text = value.strip().lower()
+    if not text or text in {"-", "infinity", "inf", "n/a", "na"}:
+        return None
+
+    # A bare integer from a *USec field is interpreted as microseconds.  A
+    # bare integer from a *Sec fixture is handled by the caller by appending s.
+    if re.fullmatch(r"[+]?(?:\d+(?:\.\d*)?|\.\d+)", text):
+        try:
+            raw = float(text)
+        except ValueError:
+            return None
+        return raw / 1_000_000 if raw > 0 else None
+
+    units = {
+        "us": 1e-6,
+        "\u00b5s": 1e-6,
+        "μs": 1e-6,
+        "microseconds": 1e-6,
+        "ms": 1e-3,
+        "milliseconds": 1e-3,
+        "s": 1.0,
+        "sec": 1.0,
+        "secs": 1.0,
+        "second": 1.0,
+        "seconds": 1.0,
+        "m": 60.0,
+        "min": 60.0,
+        "mins": 60.0,
+        "minute": 60.0,
+        "minutes": 60.0,
+        "h": 3600.0,
+        "hr": 3600.0,
+        "hrs": 3600.0,
+        "hour": 3600.0,
+        "hours": 3600.0,
+        "d": 86400.0,
+        "day": 86400.0,
+        "days": 86400.0,
+        "w": 604800.0,
+        "week": 604800.0,
+        "weeks": 604800.0,
+    }
+    pattern = re.compile(r"([+]?(?:\d+(?:\.\d*)?|\.\d+))\s*([a-z\u00b5μ]+)")
+    position = 0
+    total = 0.0
+    matched = False
+    for match in pattern.finditer(text):
+        if text[position : match.start()].strip():
+            return None
+        unit = units.get(match.group(2))
+        if unit is None:
+            return None
+        total += float(match.group(1)) * unit
+        matched = True
+        position = match.end()
+    if text[position:].strip() or not matched or total <= 0:
+        return None
+    return total
+
+
+def _property_values(properties: Mapping[str, str], name: str) -> list[str]:
+    direct = [value.strip() for value in properties.get(name, "").splitlines() if value.strip()]
+    if direct:
+        return direct
+    # systemd 255 exposes monotonic timer expressions through the
+    # TimersMonotonic array; the direct OnUnit* properties are not emitted for
+    # those units.  Keep this extraction local to recurring expressions so a
+    # nested next_elapse value is never mistaken for a configured interval.
+    if name in {"OnUnitActiveUSec", "OnUnitInactiveUSec", "OnUnitActiveSec", "OnUnitInactiveSec"}:
+        nested: list[str] = []
+        pattern = re.compile(rf"(?:^|[ {{;]){re.escape(name)}=([^;}}]+)")
+        for line in properties.get("TimersMonotonic", "").splitlines():
+            match = pattern.search(line)
+            if match:
+                nested.append(match.group(1).strip())
+        return nested
+    return []
+
+
+def _duration_value(properties: Mapping[str, str], names: Iterable[str]) -> tuple[float | None, str | None]:
+    """Return the first finite recurring timer expression and its property."""
+
+    for name in names:
+        for value in _property_values(properties, name):
+            # A bare numeric *Sec value is seconds; a bare *USec value is
+            # handled by parse_systemd_duration as microseconds.
+            if (
+                name.endswith("Sec")
+                and not name.endswith("USec")
+                and re.fullmatch(r"[+]?(?:\d+(?:\.\d*)?|\.\d+)", value)
+            ):
+                value = f"{value}s"
+            parsed = parse_systemd_duration(value)
+            if parsed is not None:
+                return parsed, name
+    return None, None
+
+
+def parse_unit_list(output: str) -> list[str]:
+    """Parse the first (unit) column of ``systemctl list-units`` output."""
+
+    units: list[str] = []
+    seen: set[str] = set()
+    for line in output.splitlines():
+        fields = line.split()
+        if not fields:
+            continue
+        unit = fields[0]
+        if not unit.endswith(".timer") or not UNIT_RE.fullmatch(unit):
+            continue
+        if unit not in seen:
+            units.append(unit)
+            seen.add(unit)
+    return units
+
+
+def parse_show_sections(output: str) -> dict[str, dict[str, str]]:
+    """Parse multi-unit ``systemctl show`` output keyed by ``Id``.
+
+    systemd separates units with a blank line.  Handling an ``Id=`` transition
+    as well keeps this parser compatible with versions that omit blank lines
+    when only a small property set was requested.
+    """
+
+    sections: dict[str, dict[str, str]] = {}
+    current: dict[str, str] = {}
+
+    def finish() -> None:
+        nonlocal current
+        unit_id = current.get("Id", "").strip()
+        if unit_id:
+            sections[unit_id] = dict(current)
+        current = {}
+
+    for raw_line in output.splitlines():
+        line = raw_line.rstrip("\r")
+        if not line:
+            finish()
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        if key == "Id" and current.get("Id"):
+            finish()
+        # TimersMonotonic is an array-like property and systemd emits one
+        # property line for each monotonic expression (for example OnBootSec
+        # and OnUnitActiveSec). Preserve repeated properties rather than
+        # allowing the last line to hide the actual recurring expression.
+        if key in current and key not in {"Id"}:
+            current[key] = f"{current[key]}\n{value}"
+        else:
+            current[key] = value
+    finish()
+    return sections
+
+
+def _inventory_rows(payload: Any) -> list[Any]:
+    if isinstance(payload, list):
+        return payload
+    if not isinstance(payload, Mapping):
+        raise CollectorInputError("inventory must be a JSON array or object")
+    rows = payload.get("containers", payload.get("items"))
+    if isinstance(rows, list):
+        return rows
+    if isinstance(rows, Mapping):
+        result: list[Any] = []
+        for key, value in rows.items():
+            if not isinstance(value, Mapping):
+                result.append(value)
+                continue
+            copied = dict(value)
+            if not any(field in copied for field in ("id", "Id", "ID", "container_id", "ContainerID")):
+                match = re.fullmatch(r"(?:\d+|user)-([0-9a-f]{64})", str(key))
+                if match:
+                    copied["id"] = match.group(1)
+            result.append(copied)
+        return result
+    raise CollectorInputError("inventory object must contain a containers array or map")
+
+
+def _first_field(row: Mapping[str, Any], fields: Sequence[str]) -> Any:
+    for field_name in fields:
+        if field_name in row:
+            return row[field_name]
+    return None
+
+
+def _normalise_name(value: Any) -> str | None:
+    if isinstance(value, list):
+        value = value[0] if value else None
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if value.startswith("/"):
+        value = value[1:]
+    return value or None
+
+
+def parse_inventory(payload: Any, uid: int) -> list[ContainerRef]:
+    """Validate a single owner-context inventory before any systemd query."""
+
+    refs: list[ContainerRef] = []
+    seen_ids: set[str] = set()
+    for index, raw in enumerate(_inventory_rows(payload)):
+        if not isinstance(raw, Mapping):
+            raise CollectorInputError(f"inventory row {index} is not an object")
+        raw_id = _first_field(raw, ("container_id", "ContainerID", "id", "Id", "ID"))
+        if not isinstance(raw_id, str):
+            raise CollectorInputError(f"inventory row {index} has no container ID")
+        container_id = raw_id.strip().lower()
+        if CONTAINER_ID_RE.fullmatch(container_id) is None:
+            raise CollectorInputError(f"inventory row {index} does not contain a full 64-character container ID")
+        if container_id in seen_ids:
+            raise CollectorInputError(f"inventory contains duplicate container ID {container_id}")
+
+        raw_uid = _first_field(raw, ("uid", "Uid", "UID", "owner_uid"))
+        row_uid = uid if raw_uid is None else raw_uid
+        if isinstance(row_uid, bool) or not isinstance(row_uid, int):
+            raise CollectorInputError(f"inventory row {index} has a non-integer UID")
+        if row_uid != uid:
+            raise CollectorInputError(f"inventory row {index} UID {row_uid} does not match collector UID {uid}")
+
+        name = _normalise_name(_first_field(raw, ("name", "Name", "Names", "container_name")))
+        if name is not None and CONTAINER_NAME_RE.fullmatch(name) is None:
+            raise CollectorInputError(f"inventory row {index} has an invalid container name")
+        refs.append(ContainerRef(uid=uid, container_id=container_id, name=name, source_index=index))
+        seen_ids.add(container_id)
+    return refs
+
+
+def _unit_valid(unit: str | None, suffix: str) -> bool:
+    return bool(unit and unit.endswith(suffix) and UNIT_RE.fullmatch(unit))
+
+
+def _service_unit(properties: Mapping[str, str], timer_unit: str) -> str | None:
+    value = properties.get("Unit", "").strip()
+    if _unit_valid(value, ".service"):
+        return value
+    triggers = properties.get("Triggers", "")
+    for candidate in triggers.split():
+        if _unit_valid(candidate, ".service"):
+            return candidate
+    # This fallback is only a unit relationship guess.  ExecStart validation
+    # below remains mandatory before a timer is attributed to a container.
+    if timer_unit.endswith(".timer"):
+        candidate = f"{timer_unit[:-6]}.service"
+        if _unit_valid(candidate, ".service"):
+            return candidate
+    return None
+
+
+def _timer_schedule(properties: Mapping[str, str], *, executing: bool = False) -> tuple[dict[str, Any], list[str]]:
+    errors: list[str] = []
+    interval_candidates: list[tuple[float, str]] = []
+    for names in (("OnUnitActiveUSec", "OnUnitActiveSec"), ("OnUnitInactiveUSec", "OnUnitInactiveSec")):
+        value, source = _duration_value(properties, names)
+        if value is not None and source is not None:
+            interval_candidates.append((value, source))
+
+    calendar = properties.get("OnCalendar", "").strip()
+    if len(interval_candidates) > 1:
+        # Both expressions can fire.  Expose the ambiguity rather than
+        # inventing one cadence for stale-result decisions.
+        values = {round(value, 9) for value, _ in interval_candidates}
+        if len(values) > 1:
+            errors.append("multiple-recurring-intervals")
+    if interval_candidates:
+        interval = interval_candidates[0][0] if len({round(v, 9) for v, _ in interval_candidates}) == 1 else None
+        interval_source = interval_candidates[0][1] if interval is not None else "multiple"
+    else:
+        interval = None
+        interval_source = "OnCalendar" if calendar else None
+        errors.append("missing-recurring-interval")
+
+    jitter, jitter_source = _duration_value(properties, ("RandomizedDelayUSec", "RandomizedDelaySec"))
+    if jitter is None:
+        # systemd's default is no random delay.  Preserve that fact as a
+        # value while making the source explicit; no configured value is made
+        # up for accuracy or interval.
+        jitter = 0.0
+        jitter_source = "systemd-default"
+
+    accuracy, accuracy_source = _duration_value(properties, ("AccuracyUSec", "AccuracySec"))
+    if accuracy is None:
+        errors.append("missing-accuracy")
+
+    next_realtime = properties.get("NextElapseUSecRealtime", "").strip()
+    next_monotonic = properties.get("NextElapseUSecMonotonic", "").strip()
+    valid_next_realtime = (
+        next_realtime if next_realtime.lower() not in {"", "-", "n/a", "na", "infinity", "inf", "0"} else None
+    )
+    valid_next_monotonic = (
+        next_monotonic if next_monotonic.lower() not in {"", "-", "n/a", "na", "infinity", "inf", "0"} else None
+    )
+    if valid_next_realtime is None and valid_next_monotonic is None and not (executing and interval is not None):
+        # An active unit with no next elapse can be a one-shot or already
+        # elapsed timer. Its configured interval is insufficient evidence of
+        # future health checks, so freshness must remain unavailable.
+        errors.append("missing-next-trigger")
+
+    schedule = {
+        "effective_interval_seconds": _number(interval),
+        "effective_interval_source": interval_source,
+        "interval_candidates": [
+            {"seconds": _number(value), "source": source} for value, source in interval_candidates
+        ],
+        "calendar": calendar or None,
+        "jitter_seconds": _number(jitter),
+        "jitter_source": jitter_source,
+        "accuracy_seconds": _number(accuracy),
+        "accuracy_source": accuracy_source,
+        "last_trigger": properties.get("LastTriggerUSecRealtime") or properties.get("LastTriggerUSec") or None,
+        "next_trigger": valid_next_realtime,
+        "next_trigger_monotonic": valid_next_monotonic,
+    }
+    return schedule, errors
+
+
+def _contains_token(text: str, token: str) -> bool:
+    if not token:
+        return False
+    # Unit arguments, shell-safe argv[] fragments and --name=value all use
+    # punctuation around the value.  Do not match a name or ID embedded in a
+    # different identifier.
+    pattern = rf"(?<![A-Za-z0-9_.-]){re.escape(token)}(?![A-Za-z0-9_.-])"
+    return re.search(pattern, text) is not None
+
+
+def _exec_start(properties: Mapping[str, str]) -> str:
+    return " ".join(value for key, value in properties.items() if key in {"ExecStart", "ExecStartEx"} and value)
+
+
+def _looks_like_health_command(exec_start: str) -> bool:
+    lowered = exec_start.lower()
+    return "healthcheck" in lowered and ("podman" in lowered or "healthcheck-run-safe" in lowered)
+
+
+def _looks_like_health_unit(timer_unit: str, service_unit: str | None) -> bool:
+    text = f"{timer_unit} {service_unit or ''}".lower()
+    return "healthcheck" in text or "podman-health" in text
+
+
+def _name_index(refs: Sequence[ContainerRef]) -> dict[str, list[ContainerRef]]:
+    index: dict[str, list[ContainerRef]] = {}
+    for ref in refs:
+        if ref.name is not None:
+            index.setdefault(ref.name, []).append(ref)
+    return index
+
+
+def _find_container(
+    refs: Sequence[ContainerRef],
+    names: Mapping[str, list[ContainerRef]],
+    service_unit: str,
+    exec_start: str,
+) -> tuple[ContainerRef | None, str | None]:
+    # Full IDs are authoritative.  A named service is only a fallback because
+    # names are labels and can collide in malformed or mixed inventories.
+    id_matches = [ref for ref in refs if _contains_token(exec_start, ref.container_id)]
+    if len(id_matches) == 1:
+        return id_matches[0], "full-id"
+    if len(id_matches) > 1:
+        return None, "ambiguous-full-id"
+
+    named_match: ContainerRef | None = None
+    named_matches: list[ContainerRef] = []
+    for name, candidates in names.items():
+        if _contains_token(exec_start, name):
+            named_matches.extend(candidates)
+    if len(named_matches) == 1:
+        named_match = named_matches[0]
+    elif len(named_matches) > 1:
+        return None, "ambiguous-container-name"
+    if named_match is not None:
+        return named_match, "container-name"
+
+    # The service instance itself is useful as a guard against a command that
+    # happens to contain an unrelated container name, but it cannot authorize
+    # attribution on its own.  Returning no match keeps stale/deleted IDs from
+    # being assigned to a newly created same-name container.
+    return None, None
+
+
+def _initial_record(coverage: ContainerCoverage) -> dict[str, Any]:
+    return {
+        "key": coverage.ref.key,
+        "uid": coverage.ref.uid,
+        "container_id": coverage.ref.container_id,
+        "name": coverage.ref.name,
+        "active_coverage_count": 0,
+        # Alias retained for clients that use the shorter noun while the
+        # explicit field above is the canonical schema field.
+        "coverage_count": 0,
+        "effective_interval_seconds": None,
+        "effective_interval_source": None,
+        "jitter_seconds": None,
+        "accuracy_seconds": None,
+        "schedules": [],
+        "coverage_status": "uncovered",
+        "coverage_reason": "no-active-matching-health-timer",
+        "collector_errors": list(coverage.errors),
+    }
+
+
+def _finalise_record(coverage: ContainerCoverage) -> dict[str, Any]:
+    record = _initial_record(coverage)
+    schedules = sorted(coverage.schedules, key=lambda item: (str(item.get("unit")), str(item.get("service_unit"))))
+    record["schedules"] = schedules
+    count = len(schedules)
+    record["active_coverage_count"] = count
+    record["coverage_count"] = count
+    if count:
+        record["coverage_status"] = "covered"
+        record["coverage_reason"] = "active-matching-health-timer"
+        for field_name in (
+            "effective_interval_seconds",
+            "effective_interval_source",
+            "jitter_seconds",
+            "accuracy_seconds",
+        ):
+            values = {json.dumps(item.get(field_name), sort_keys=True) for item in schedules}
+            if len(values) == 1:
+                record[field_name] = schedules[0].get(field_name)
+            else:
+                record[field_name] = None
+                record["collector_errors"].append(f"multiple-{field_name}")
+        if count > 1:
+            # One effective recurring schedule is required.  Keep every
+            # matching unit visible for diagnosis, but never present
+            # duplicate named/native coverage as settled coverage, even when
+            # both timers happen to use the same cadence.
+            record["collector_errors"].append("duplicate-active-health-timers")
+            record["coverage_status"] = "error"
+            record["coverage_reason"] = "duplicate-active-health-timers"
+    if record["collector_errors"]:
+        if count == 0:
+            record["coverage_status"] = "error"
+        elif count == 1:
+            record["coverage_status"] = "covered-with-errors"
+    # Preserve order and avoid repeating the same error from a timer and its
+    # service metadata path.
+    record["collector_errors"] = list(dict.fromkeys(record["collector_errors"]))
+    return record
+
+
+def collect_coverage(
+    refs: Sequence[ContainerRef],
+    *,
+    uid: int,
+    manager: str,
+    systemctl_bin: str = "/usr/bin/systemctl",
+    timeout: float = DEFAULT_TIMEOUT,
+    max_units: int = DEFAULT_MAX_UNITS,
+) -> dict[str, Any]:
+    """Collect one owner context without querying Podman or mutating systemd."""
+
+    if manager not in {"system", "user"}:
+        raise ValueError("manager must be system or user")
+    if uid == 0 and manager != "system":
+        raise ValueError("UID 0 must use the system systemd manager")
+    if uid != 0 and manager != "user":
+        raise ValueError("non-zero UIDs must use a user systemd manager")
+    if timeout <= 0 or timeout > 60:
+        raise ValueError("overall timeout must be greater than zero and at most 60 seconds")
+    if max_units <= 0 or max_units > 4096:
+        raise ValueError("max-units must be between 1 and 4096")
+
+    contexts = {ref.key: ContainerCoverage(ref) for ref in refs}
+    global_errors: list[str] = []
+    unattributed: list[dict[str, Any]] = []
+    prefix = [systemctl_bin] + ([] if manager == "system" else ["--user"])
+    deadline = time.monotonic() + timeout
+
+    def invoke(command: Sequence[str]) -> CommandResult:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return CommandResult(list(command), 124, "", "", timed_out=True)
+        return run_bounded(command, remaining)
+
+    listed = invoke(
+        [*prefix, "list-units", "--type=timer", "--state=active", "--all", "--no-legend", "--plain", "--no-pager"],
+    )
+    if listed.returncode != 0:
+        global_errors.append(_command_error("systemd timer inventory failed", listed))
+        for coverage in contexts.values():
+            coverage.errors.append("systemd-timer-inventory-unavailable")
+        return _result(refs, contexts, uid, manager, global_errors, unattributed, listed_units=0, unit_query_count=1)
+
+    timer_units = parse_unit_list(listed.stdout)
+    if len(timer_units) > max_units:
+        global_errors.append("systemd-timer-inventory-too-large")
+        for coverage in contexts.values():
+            coverage.errors.append("systemd-timer-inventory-too-large")
+        return _result(
+            refs,
+            contexts,
+            uid,
+            manager,
+            global_errors,
+            unattributed,
+            listed_units=len(timer_units),
+            unit_query_count=1,
+        )
+
+    if not timer_units:
+        return _result(refs, contexts, uid, manager, global_errors, unattributed, listed_units=0, unit_query_count=1)
+
+    timer_property_arg = "--property=" + ",".join(TIMER_PROPERTIES)
+    shown_timers = invoke([*prefix, "show", "--no-pager", timer_property_arg, *timer_units])
+    timer_sections = parse_show_sections(shown_timers.stdout) if shown_timers.returncode == 0 else {}
+    if shown_timers.returncode != 0:
+        global_errors.append(_command_error("systemd timer metadata failed", shown_timers))
+        for coverage in contexts.values():
+            coverage.errors.append("systemd-timer-metadata-unavailable")
+        return _result(
+            refs,
+            contexts,
+            uid,
+            manager,
+            global_errors,
+            unattributed,
+            listed_units=len(timer_units),
+            unit_query_count=2,
+        )
+
+    service_units: list[str] = []
+    for timer_unit in timer_units:
+        service_unit = _service_unit(timer_sections.get(timer_unit, {}), timer_unit)
+        if service_unit and service_unit not in service_units:
+            service_units.append(service_unit)
+    if len(service_units) > max_units:
+        global_errors.append("systemd-service-metadata-too-large")
+        for coverage in contexts.values():
+            coverage.errors.append("systemd-service-metadata-too-large")
+        return _result(
+            refs,
+            contexts,
+            uid,
+            manager,
+            global_errors,
+            unattributed,
+            listed_units=len(timer_units),
+            unit_query_count=2,
+        )
+
+    service_sections: dict[str, dict[str, str]] = {}
+    if service_units:
+        service_property_arg = "--property=" + ",".join(SERVICE_PROPERTIES)
+        shown_services = invoke([*prefix, "show", "--no-pager", service_property_arg, *service_units])
+        service_sections = parse_show_sections(shown_services.stdout) if shown_services.returncode == 0 else {}
+        if shown_services.returncode != 0:
+            global_errors.append(_command_error("systemd health service metadata failed", shown_services))
+            for coverage in contexts.values():
+                coverage.errors.append("systemd-health-service-metadata-unavailable")
+            return _result(
+                refs,
+                contexts,
+                uid,
+                manager,
+                global_errors,
+                unattributed,
+                listed_units=len(timer_units),
+                unit_query_count=3,
+            )
+
+    unit_query_count = 2 + bool(service_units)
+    # Timer and service metadata are read separately. A short one-shot may
+    # finish between those reads, leaving an old running timer beside a now
+    # inactive service. Re-read those timers once under the same overall
+    # deadline; only fresh waiting/executing evidence can establish coverage.
+    reconcile_units = [
+        unit
+        for unit in timer_units
+        if timer_sections.get(unit, {}).get("SubState") == "running"
+        and (
+            service_sections.get(_service_unit(timer_sections.get(unit, {}), unit) or "", {}).get("ActiveState"),
+            service_sections.get(_service_unit(timer_sections.get(unit, {}), unit) or "", {}).get("SubState"),
+        )
+        not in {("activating", "start"), ("active", "running")}
+    ]
+    if reconcile_units:
+        refreshed = invoke([*prefix, "show", "--no-pager", timer_property_arg, *reconcile_units])
+        unit_query_count += 1
+        refreshed_sections = parse_show_sections(refreshed.stdout) if refreshed.returncode == 0 else {}
+        for unit in reconcile_units:
+            # Missing/failed refreshed metadata must not retain an old timer.
+            timer_sections.pop(unit, None)
+            if unit in refreshed_sections:
+                timer_sections[unit] = refreshed_sections[unit]
+        if refreshed.returncode != 0:
+            global_errors.append(_command_error("systemd timer reconciliation failed", refreshed))
+
+    names = _name_index(refs)
+    for timer_unit in timer_units:
+        timer = timer_sections.get(timer_unit)
+        if timer is None:
+            unattributed.append({"unit": timer_unit, "reason": "timer-metadata-missing"})
+            continue
+        service_unit = _service_unit(timer, timer_unit)
+        service = service_sections.get(service_unit or "")
+        potential_health = _looks_like_health_unit(timer_unit, service_unit)
+        executing = timer.get("SubState") == "running" and (
+            ((service or {}).get("ActiveState"), (service or {}).get("SubState"))
+            in {("activating", "start"), ("active", "running")}
+        )
+        if timer.get("ActiveState") != "active" or (timer.get("SubState") != "waiting" and not executing):
+            # A recurring timer temporarily has no next elapse while its
+            # associated service executes. Elapsed/stopped timers still do
+            # not prove recurring coverage.
+            if potential_health:
+                unattributed.append({
+                    "unit": timer_unit,
+                    "service_unit": service_unit,
+                    "reason": "timer-not-waiting",
+                })
+            continue
+        exec_start = _exec_start(service or {})
+        if not service:
+            if potential_health:
+                unattributed.append({
+                    "unit": timer_unit,
+                    "service_unit": service_unit,
+                    "reason": "service-metadata-missing",
+                })
+            continue
+        if not _looks_like_health_command(exec_start):
+            if potential_health:
+                unattributed.append({
+                    "unit": timer_unit,
+                    "service_unit": service_unit,
+                    "reason": "service-is-not-podman-healthcheck",
+                })
+            continue
+
+        ref, match_method = _find_container(refs, names, service_unit or "", exec_start)
+        if ref is None:
+            unattributed.append({
+                "unit": timer_unit,
+                "service_unit": service_unit,
+                "reason": match_method or "no-container-match",
+            })
+            continue
+
+        schedule, schedule_errors = _timer_schedule(timer, executing=executing)
+        schedule.update({
+            "unit": timer_unit,
+            "service_unit": service_unit,
+            "active": True,
+            "match_method": match_method,
+            "schedule_source": "systemd",
+            "timer_active_state": timer.get("ActiveState"),
+            "timer_sub_state": timer.get("SubState"),
+        })
+        contexts[ref.key].schedules.append(schedule)
+        contexts[ref.key].errors.extend(schedule_errors)
+
+    return _result(
+        refs,
+        contexts,
+        uid,
+        manager,
+        global_errors,
+        unattributed,
+        listed_units=len(timer_units),
+        unit_query_count=unit_query_count,
+    )
+
+
+def _result(
+    refs: Sequence[ContainerRef],
+    contexts: Mapping[str, ContainerCoverage],
+    uid: int,
+    manager: str,
+    global_errors: Sequence[str],
+    unattributed: Sequence[Mapping[str, Any]],
+    *,
+    listed_units: int,
+    unit_query_count: int,
+) -> dict[str, Any]:
+    records = {ref.key: _finalise_record(contexts[ref.key]) for ref in refs}
+    return {
+        "schema": SCHEMA,
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "uid": uid,
+        "manager": manager,
+        "manager_scope": "rootful" if uid == 0 else "rootless",
+        "read_only": True,
+        "native_podman_health_is_authoritative": True,
+        "systemctl": {"unit_query_count": unit_query_count, "listed_active_timer_count": listed_units},
+        "collector_errors": list(dict.fromkeys(global_errors)),
+        "unattributed_health_timers": list(unattributed),
+        "containers": records,
+    }
+
+
+def _error_document(uid: int, manager: str, message: str) -> dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "uid": uid,
+        "manager": manager,
+        "manager_scope": "rootful" if uid == 0 else "rootless",
+        "read_only": True,
+        "native_podman_health_is_authoritative": True,
+        "systemctl": {"unit_query_count": 0, "listed_active_timer_count": 0},
+        "collector_errors": [message],
+        "unattributed_health_timers": [],
+        "containers": {},
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--uid", type=int, required=True, help="Podman owner UID (0 selects systemd system manager)")
+    parser.add_argument("--manager", choices=("system", "user"), help="Override the manager derived from --uid")
+    parser.add_argument("--systemctl-bin", default=os.environ.get("SYSTEMCTL_BIN", "/usr/bin/systemctl"))
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT, help="per-command timeout in seconds")
+    parser.add_argument("--max-units", type=int, default=DEFAULT_MAX_UNITS)
+    parser.add_argument("--inventory", help="JSON inventory path; stdin is used when omitted")
+    parser.add_argument("--indent", type=int, default=None, help="pretty-print JSON with this indentation")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    manager = args.manager or ("system" if args.uid == 0 else "user")
+    try:
+        if args.uid < 0:
+            raise CollectorInputError("UID must be non-negative")
+        if args.inventory:
+            with open(args.inventory, "r", encoding="utf-8") as stream:
+                payload = json.load(stream)
+        else:
+            payload = json.load(sys.stdin)
+        refs = parse_inventory(payload, args.uid)
+        result = collect_coverage(
+            refs,
+            uid=args.uid,
+            manager=manager,
+            systemctl_bin=args.systemctl_bin,
+            timeout=args.timeout,
+            max_units=args.max_units,
+        )
+        print(json.dumps(result, indent=args.indent, sort_keys=True))
+        return 0
+    except (CollectorInputError, OSError, ValueError, json.JSONDecodeError):
+        print(
+            json.dumps(
+                _error_document(args.uid, manager, "collector-input-invalid"), indent=args.indent, sort_keys=True
+            )
+        )
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/health.js
+++ b/src/health.js
@@ -1,0 +1,402 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+/*
+ * Keep health interpretation independent from React.  Apart from making the
+ * row renderer easier to audit, this gives the browser tests a deterministic
+ * contract for missing, stale, and collection-error states.
+ */
+
+export const healthStates = Object.freeze({
+    healthy: "healthy",
+    unhealthy: "unhealthy",
+    starting: "starting",
+    missing: "missing",
+    stale: "stale",
+    unknown: "unknown",
+    error: "error",
+    stopped: "stopped",
+    completed: "completed",
+});
+
+// Error details from Podman, systemd, and Cockpit can contain command lines,
+// URLs, or health output.  The display only needs an allowlisted reason; the
+// existing health-log detail view remains the place for an operator who has
+// deliberately opened the raw Podman log.
+const HEALTH_COLLECTION_ERROR = "health-collection-failed";
+const HEALTH_COLLECTION_TIMEOUT = "health-collection-timeout";
+const SCHEDULER_ERROR = "scheduler-metadata-unavailable";
+
+const durationToMilliseconds = duration => {
+    if (!Number.isFinite(duration) || duration <= 0)
+        return 0;
+
+    // Podman reports health timing fields as nanoseconds.
+    return duration / 1000000;
+};
+
+const timestampToMilliseconds = timestamp => {
+    if (timestamp instanceof Date)
+        return timestamp.getTime();
+    if (typeof timestamp === "number") {
+        // Accept milliseconds for fixtures while handling Unix seconds too.
+        return timestamp < 100000000000 ? timestamp * 1000 : timestamp;
+    }
+    if (typeof timestamp !== "string" || timestamp.length === 0)
+        return null;
+
+    const parsed = Date.parse(timestamp);
+    return Number.isNaN(parsed) ? null : parsed;
+};
+
+export const healthConfig = container => container?.Config?.Healthcheck ?? container?.Config?.Health ?? null;
+
+export const hasHealthCheck = container => {
+    const config = healthConfig(container);
+    if (!config || typeof config !== "object" || Object.keys(config).length === 0)
+        return false;
+
+    const test = config.Test;
+    // Podman's health configuration is only actionable when Test is a
+    // non-empty argv array.  Treat partial/malformed objects as missing so an
+    // interval-only response can never produce a configured or passing badge.
+    return Array.isArray(test) && test.length > 0 && test[0] !== "NONE" &&
+        test.every(item => typeof item === "string" && item.length > 0);
+};
+
+export const healthState = container => container?.State?.Health ?? container?.State?.Healthcheck ?? null;
+
+// An inspect response is the only source that can mark an inventory row's
+// health details as loaded.  Require the identity and the two top-level
+// inspect objects that the renderer consumes so a truthy but malformed API
+// reply cannot permanently turn a row into a false "loaded" state.
+export const isValidHealthDetails = (inventory, detail) => {
+    if (!inventory || typeof inventory.Id !== "string" || inventory.Id.length === 0 ||
+        !detail || typeof detail !== "object" || Array.isArray(detail) ||
+        detail.Id !== inventory.Id)
+        return false;
+
+    const state = detail.State;
+    if (!state || typeof state !== "object" || Array.isArray(state) ||
+        typeof state.Status !== "string" || state.Status.length === 0)
+        return false;
+
+    const config = detail.Config;
+    return Boolean(config && typeof config === "object" && !Array.isArray(config));
+};
+
+// Container inventory is intentionally cheaper than an inspect and is enough
+// to keep lifecycle rows current.  Once a full inspect has established that a
+// running container has no health check, repeating that inspect on every
+// refresh only adds load and can starve the configured checks before their
+// freshness window expires.  Keep full detail requests for pending rows and
+// rows with a configured check; stopped/completed rows are explained by their
+// lifecycle alone.
+export const shouldInspectHealth = (inventory, current = null) => {
+    const inventoryState = typeof inventory?.State === "string"
+        ? inventory.State
+        : inventory?.State?.Status;
+    const currentState = current?.State?.Status;
+    const lifecycle = String(inventoryState || currentState || "").toLowerCase();
+    if (lifecycle && lifecycle !== "running")
+        return false;
+
+    if (!current || current.healthDetailsLoaded !== true)
+        return true;
+    return hasHealthCheck(current);
+};
+
+export const healthLogTime = log => timestampToMilliseconds(log?.End) ?? timestampToMilliseconds(log?.Start);
+
+export const lastHealthCheck = state => {
+    const logs = Array.isArray(state?.Log) ? state.Log : [];
+    return logs.reduce((last, log) => {
+        const timestamp = healthLogTime(log);
+        return timestamp !== null && (last === null || timestamp > last) ? timestamp : last;
+    }, null);
+};
+
+// Podman may retain State.Health.Status as "healthy" while a later retry is
+// still represented by a failed log entry. Select the log by its timestamp,
+// rather than trusting the API's array order, so the row reflects the latest
+// observed health run.
+export const latestHealthLog = state => {
+    const logs = Array.isArray(state?.Log) ? state.Log : [];
+    return logs.reduce((latest, log) => {
+        const timestamp = healthLogTime(log);
+        if (timestamp === null)
+            return latest;
+        if (!latest || timestamp >= latest.timestamp)
+            return { log, timestamp };
+        return latest;
+    }, null)?.log || null;
+};
+
+const healthExitCode = value => {
+    if (typeof value === "number")
+        return Number.isInteger(value) ? value : null;
+    if (typeof value !== "string" || !/^[+-]?\d+$/.test(value.trim()))
+        return null;
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) ? parsed : null;
+};
+
+const isTrueMarker = value => value === true ||
+    (typeof value === "string" && ["1", "true", "yes"].includes(value.toLowerCase()));
+
+// Podman exposes the exit code for every exited container, but an exit code of
+// zero does not say that a workload was a one-shot job.  Only classify an
+// exited container as completed when the inspect payload carries explicit
+// one-shot metadata.  The direct fields also support normalized API fixtures;
+// the labels cover the common Compose and Kubernetes sources that persist this
+// distinction in Podman inspect output.
+export const isCompletedContainer = container => {
+    const state = container?.State;
+    const config = container?.Config;
+    const labels = config?.Labels || container?.Labels || {};
+    return isTrueMarker(container?.Completed) ||
+        isTrueMarker(container?.OneShot) ||
+        isTrueMarker(state?.Completed) ||
+        isTrueMarker(state?.OneShot) ||
+        isTrueMarker(config?.Completed) ||
+        isTrueMarker(config?.OneShot) ||
+        isTrueMarker(labels["com.docker.compose.oneoff"]);
+};
+
+export const observedHealthInterval = state => {
+    const logs = (Array.isArray(state?.Log) ? state.Log : [])
+            .map(healthLogTime)
+            .filter(timestamp => timestamp !== null)
+            .sort((a, b) => a - b);
+    if (logs.length < 2)
+        return null;
+
+    const intervals = [];
+    for (let index = 1; index < logs.length; index++) {
+        const interval = logs[index] - logs[index - 1];
+        if (interval > 0)
+            intervals.push(interval);
+    }
+    if (intervals.length === 0)
+        return null;
+
+    // Keep the observed cadence available for diagnostics. It never drives a
+    // stale decision: external schedules can be irregular or have no second
+    // run yet, so the scheduler collector is the freshness authority.
+    intervals.sort((a, b) => a - b);
+    return intervals[Math.floor(intervals.length / 2)];
+};
+
+const schedulerError = scheduler => {
+    if (!scheduler)
+        return null;
+
+    const errors = scheduler.collector_errors;
+    const coverageStatus = scheduler.coverage_status;
+    const coverageCount = scheduler.active_coverage_count;
+    const declaredCoverageCount = scheduler.coverage_count;
+    if (!["covered", "covered-with-errors", "uncovered", "error"].includes(coverageStatus))
+        return SCHEDULER_ERROR;
+    if (!Array.isArray(errors))
+        return SCHEDULER_ERROR;
+    if (!Number.isInteger(coverageCount) || coverageCount < 0)
+        return SCHEDULER_ERROR;
+    if (!Number.isInteger(declaredCoverageCount) || declaredCoverageCount !== coverageCount)
+        return SCHEDULER_ERROR;
+    if (scheduler.error)
+        return SCHEDULER_ERROR;
+    if (coverageStatus === "error" || coverageStatus === "covered-with-errors")
+        return SCHEDULER_ERROR;
+    if (coverageStatus === "covered" && coverageCount !== 1)
+        return SCHEDULER_ERROR;
+    if (coverageStatus === "uncovered" && coverageCount !== 0)
+        return SCHEDULER_ERROR;
+    if (coverageStatus === "covered") {
+        const interval = Number(scheduler.effective_interval_seconds);
+        const jitter = Number(scheduler.jitter_seconds);
+        const accuracy = Number(scheduler.accuracy_seconds);
+        const source = scheduler.schedule_source || scheduler.effective_interval_source;
+        if (!Number.isFinite(interval) || interval <= 0 ||
+            !Number.isFinite(jitter) || jitter < 0 ||
+            !Number.isFinite(accuracy) || accuracy < 0 ||
+            typeof source !== "string" || source.length === 0)
+            return SCHEDULER_ERROR;
+    }
+    if (errors.length > 0)
+        return SCHEDULER_ERROR;
+    return null;
+};
+
+const schedulerFreshness = (config, scheduler) => {
+    const effective = scheduler;
+    if (!effective)
+        return {
+            staleAfterMs: null,
+            cadenceSource: "scheduler-unavailable",
+            schedulerError: SCHEDULER_ERROR,
+            reason: "scheduler-unavailable",
+        };
+
+    const error = schedulerError(effective);
+    if (effective.coverage_status === "uncovered" || effective.active_coverage_count === 0)
+        return {
+            staleAfterMs: null,
+            cadenceSource: effective.effective_interval_source || "scheduler-coverage-missing",
+            schedulerError: error,
+            reason: "scheduler-coverage-missing",
+        };
+    const interval = Number(effective.effective_interval_seconds);
+    if (!Number.isFinite(interval) || interval <= 0)
+        return {
+            staleAfterMs: null,
+            cadenceSource: effective.effective_interval_source || "scheduler-unknown",
+            schedulerError: error || (effective.coverage_status === "covered" ? SCHEDULER_ERROR : null),
+            reason: effective.coverage_status === "uncovered" ? "scheduler-coverage-missing" : "scheduler-unknown",
+        };
+
+    const jitter = Number(effective.jitter_seconds);
+    const accuracy = Number(effective.accuracy_seconds);
+    const timeout = durationToMilliseconds(config?.Timeout);
+    const jitterMs = Number.isFinite(jitter) && jitter >= 0 ? jitter * 1000 : 0;
+    const accuracyMs = Number.isFinite(accuracy) && accuracy >= 0 ? accuracy * 1000 : 0;
+    const source = effective.schedule_source || effective.effective_interval_source || "systemd";
+    return {
+        staleAfterMs: error ? null : Math.max(1000, interval * 1000 + jitterMs + accuracyMs + timeout),
+        cadenceSource: source,
+        schedulerError: error,
+        reason: "schedule-known",
+    };
+};
+
+const collectionReason = error => typeof error === "string" &&
+    /\b(?:timed?\s*out|timeout)\b/i.test(error)
+    ? "collection-timeout"
+    : "collection-error";
+
+export const staleAfter = (config, _state, scheduler = null) => schedulerFreshness(config, scheduler).staleAfterMs;
+
+export const healthAssessment = (container, now = Date.now(), collectionError = null, scheduler = null) => {
+    const config = healthConfig(container);
+    const state = healthState(container);
+    const lastChecked = lastHealthCheck(state);
+    const latestLog = latestHealthLog(state);
+    const latestExitCode = latestLog === null ? null : healthExitCode(latestLog.ExitCode);
+    const ageMs = lastChecked === null ? null : Math.max(0, now - lastChecked);
+    const effectiveScheduler = scheduler;
+    const freshness = schedulerFreshness(config, effectiveScheduler);
+    const staleAfterMs = freshness.staleAfterMs;
+    const freshWindowMs = null;
+    const nativeStatus = state?.Status || null;
+
+    const base = extra => ({
+        rawStatus: nativeStatus,
+        latestExitCode,
+        configured: hasHealthCheck(container),
+        lastChecked,
+        ageMs,
+        staleAfterMs,
+        freshWindowMs,
+        cadenceSource: freshness.cadenceSource,
+        schedule: effectiveScheduler || null,
+        ...extra,
+    });
+
+    const lifecycle = String(container?.State?.Status || "").toLowerCase();
+    if (lifecycle && lifecycle !== "running") {
+        const exitCode = container?.State?.ExitCode;
+        const completed = lifecycle === "exited" && (exitCode === 0 || exitCode === "0") &&
+            isCompletedContainer(container);
+        return base({
+            status: completed ? healthStates.completed : healthStates.stopped,
+            reason: completed ? "completed" : "stopped",
+        });
+    }
+
+    // A stopped or completed container has no live health result to collect.
+    // Owner-wide refresh failures must not overwrite that lifecycle state.
+    if (collectionError) {
+        return base({
+            status: healthStates.error,
+            reason: collectionReason(collectionError),
+            error: collectionReason(collectionError) === "collection-timeout"
+                ? HEALTH_COLLECTION_TIMEOUT
+                : HEALTH_COLLECTION_ERROR,
+        });
+    }
+
+    // Inventory rows are rendered before their optional inspect payload. Do
+    // not infer a missing check from the absence of Config while that detail
+    // request is still pending.
+    if (container?.healthDetailsLoaded === false) {
+        return base({
+            status: healthStates.starting,
+            reason: "details-pending",
+        });
+    }
+
+    if (!hasHealthCheck(container)) {
+        return base({
+            status: healthStates.missing,
+            configured: false,
+            reason: "missing",
+        });
+    }
+
+    if (nativeStatus === "unhealthy") {
+        return base({
+            status: healthStates.unhealthy,
+            reason: "unhealthy",
+        });
+    }
+
+    if (nativeStatus === "starting") {
+        return base({
+            status: healthStates.starting,
+            reason: "starting",
+        });
+    }
+
+    // A transient failed run is still a confirmed failure even if Podman's
+    // aggregate status has not crossed its retry threshold yet. Keep
+    // rawStatus above so callers can distinguish the native aggregate state
+    // from this latest-run result.
+    if (latestExitCode !== null && latestExitCode !== 0) {
+        return base({
+            status: healthStates.unhealthy,
+            reason: "latest-check-failed",
+        });
+    }
+
+    if (latestLog !== null && latestExitCode === null) {
+        return base({
+            status: healthStates.unknown,
+            reason: "latest-check-unknown",
+        });
+    }
+
+    if (freshness.schedulerError) {
+        return base({
+            status: healthStates.error,
+            reason: "scheduler-error",
+            error: SCHEDULER_ERROR,
+        });
+    }
+
+    if (nativeStatus === "healthy" && lastChecked !== null && staleAfterMs !== null && ageMs > staleAfterMs) {
+        return base({
+            status: healthStates.stale,
+            reason: "stale",
+        });
+    }
+
+    if (nativeStatus === "healthy" && lastChecked !== null && staleAfterMs !== null) {
+        return base({
+            status: healthStates.healthy,
+            reason: "healthy",
+        });
+    }
+
+    return base({
+        status: healthStates.unknown,
+        reason: nativeStatus === "healthy" ? freshness.reason : "no-result",
+    });
+};

--- a/src/health.js
+++ b/src/health.js
@@ -16,7 +16,190 @@ export const healthStates = Object.freeze({
     error: "error",
     stopped: "stopped",
     completed: "completed",
+    retired: "retired",
+    infrastructure: "infrastructure",
 });
+
+// A lifecycle disposition is optional source metadata from the protected
+// bootstrap collector. Podman does not infer that an exited container was a
+// one-shot job, and the display must not turn names, exit codes, service names,
+// labels, or arbitrary inspect fields into that claim.
+export const lifecycleDispositionClasses = Object.freeze({
+    completed: "completed_one_shot",
+    retired: "retired",
+    infrastructure: "infrastructure_only",
+    stopped: "stopped",
+});
+
+const LIFECYCLE_CLASSES = new Set(Object.values(lifecycleDispositionClasses));
+const LIFECYCLE_TEXT_MAX_LENGTH = 240;
+const FULL_LIFECYCLE_ID = /^[0-9a-f]{64}$/;
+const FULL_CONTAINER_ID = /^[0-9a-f]{64}$/;
+const FULL_SHA256 = /^[0-9a-f]{64}$/;
+const LIFECYCLE_POLICY_SHA256 = "b58d2c2b95f46efc3cbd4fdf3b2c62a0024190c091d668e0a6f754d553ee4f81";
+const LIFECYCLE_POLICY_EVIDENCE_REF = "worktrees/misc-source/train.home.complete.tech/ops/fleet-recovery-20260907.md";
+
+const containsControlCharacter = value => {
+    for (const character of value) {
+        const code = character.codePointAt(0);
+        if (code <= 0x1f || code === 0x7f)
+            return true;
+    }
+    return false;
+};
+
+const lifecycleText = value => {
+    if (typeof value !== "string" || value.length === 0 || value.length > LIFECYCLE_TEXT_MAX_LENGTH ||
+        containsControlCharacter(value) || /https?:\/\//i.test(value))
+        return null;
+    return value.trim() || null;
+};
+
+// Keep operator-facing detail deliberately small and inert.  Collection
+// failures and lifecycle records can originate outside the browser process;
+// a command line, URL, control character, or unbounded payload must never be
+// copied into a badge, tooltip, or health summary.
+export const sanitizeHealthDetail = value => {
+    if (typeof value !== "string" || value.length === 0 || value.length > LIFECYCLE_TEXT_MAX_LENGTH ||
+        containsControlCharacter(value) || /https?:\/\//i.test(value))
+        return null;
+    return value.trim() || null;
+};
+
+// The route UID identifies the Cockpit connection (the session-user route is
+// represented by null), while ownerUid identifies the Podman namespace that
+// owns the container.  Keep both values so a same-named or same-short-ID row
+// can never inherit another context's health result.
+export const containerScope = container => {
+    const routeUid = container?.uid === null ||
+        (typeof container?.uid === "number" && Number.isInteger(container.uid) && container.uid >= 0)
+        ? container.uid
+        : null;
+    const ownerUid = typeof container?.ownerUid === "number" && Number.isInteger(container.ownerUid) && container.ownerUid >= 0
+        ? container.ownerUid
+        : routeUid;
+    const id = typeof container?.Id === "string" && container.Id.length > 0 ? container.Id : null;
+    const context = container?.context === "rootful" || container?.context === "rootless"
+        ? container.context
+        : ownerUid === 0 ? "rootful" : ownerUid === null ? "unknown" : "rootless";
+    return {
+        routeUid,
+        ownerUid,
+        context,
+        id,
+        fullId: id && FULL_CONTAINER_ID.test(id) ? id : null,
+    };
+};
+
+const SAFE_HEALTH_REASON_CODES = new Set([
+    "details-pending", "starting", "missing", "stale", "scheduler-coverage-missing",
+    "scheduler-unavailable", "scheduler-unknown", "latest-check-unknown", "freshness-unknown",
+    "no-result", "scheduler-error", "collection-timeout", "collection-error", "unhealthy",
+    "latest-check-failed", "timestamp-future", "stopped", "completed", "retired", "infrastructure", "error", "healthy",
+]);
+
+export const healthDetail = assessment => {
+    const reason = sanitizeHealthDetail(assessment?.disposition?.reason);
+    const code = SAFE_HEALTH_REASON_CODES.has(assessment?.reason) ? assessment.reason : "unknown";
+    switch (assessment?.status) {
+    case healthStates.healthy:
+        return { code: "healthy", reason: null };
+    case healthStates.unhealthy:
+        return {
+            code: assessment.reason === "latest-check-failed" ? "latest-check-failed" : "unhealthy",
+            reason: null,
+        };
+    case healthStates.starting:
+        return {
+            code: assessment.reason === "details-pending" ? "details-pending" : "starting",
+            reason: null,
+        };
+    case healthStates.missing:
+        return { code: "missing", reason: null };
+    case healthStates.stale:
+        return { code: "stale", reason: null };
+    case healthStates.unknown:
+        return { code, reason: null };
+    case healthStates.error:
+        return { code: code === "unknown" ? "error" : code, reason: null };
+    case healthStates.stopped:
+        return { code: "stopped", reason };
+    case healthStates.completed:
+        return { code: "completed", reason };
+    case healthStates.retired:
+        return { code: "retired", reason };
+    case healthStates.infrastructure:
+        return { code: "infrastructure", reason };
+    default:
+        return { code: "unknown", reason: null };
+    }
+};
+
+export const healthAge = assessment => {
+    const age = assessment?.ageMs;
+    return Number.isFinite(age) && age >= 0 ? age : null;
+};
+
+const lifecycleClass = value => {
+    return typeof value === "string" && LIFECYCLE_CLASSES.has(value) ? value : null;
+};
+
+const lifecycleMetadataObject = container => {
+    const value = container?.LifecycleDisposition;
+    return value && typeof value === "object" && !Array.isArray(value) &&
+        value.provenance && typeof value.provenance === "object" && !Array.isArray(value.provenance)
+        ? { value, source: "record" }
+        : null;
+};
+
+const lifecycleIdentityMatches = (container, metadata) => {
+    const metadataId = metadata.id;
+    if (metadataId !== container?.Id || !FULL_LIFECYCLE_ID.test(metadataId))
+        return false;
+    if (typeof metadata.uid !== "number" || !Number.isInteger(metadata.uid) || metadata.uid < 0 ||
+        typeof metadata.host !== "string" || metadata.host.length === 0 ||
+        typeof metadata.context !== "string" || !["rootful", "rootless"].includes(metadata.context))
+        return false;
+    const provenance = metadata.provenance;
+    const state = typeof container?.State === "string"
+        ? container.State
+        : container?.State?.Status || container?.Status || "";
+    if (typeof container?.ownerUid !== "number" || !Number.isInteger(container.ownerUid) || container.ownerUid < 0 ||
+        typeof state !== "string" || state.length === 0)
+        return false;
+    return container.ownerUid === metadata.uid && container?.host === metadata.host &&
+        container?.context === metadata.context && provenance.kind === "operator-policy" &&
+        provenance.source === "source-decisions.json" && provenance.source_ref === LIFECYCLE_POLICY_EVIDENCE_REF &&
+        provenance.policy_sha256 === LIFECYCLE_POLICY_SHA256 &&
+        typeof provenance.owner_verified === "boolean" &&
+        FULL_SHA256.test(provenance.manifest_sha256) && FULL_SHA256.test(provenance.decision_sha256) &&
+        state.toLowerCase() !== "running" && !/^up\b/i.test(state);
+};
+
+// Return only owner-authored lifecycle metadata.  A null result is deliberate
+// and keeps an ambiguous row on the ordinary stopped/no-health path.
+export const lifecycleDisposition = container => {
+    const candidate = lifecycleMetadataObject(container);
+    if (!candidate || !lifecycleIdentityMatches(container, candidate.value))
+        return null;
+
+    const dispositionClass = lifecycleClass(candidate.value.class);
+    if (!dispositionClass)
+        return null;
+    const reason = lifecycleText(candidate.value.reason);
+    const evidence = lifecycleText(candidate.value.provenance.source);
+    return {
+        class: dispositionClass,
+        reason,
+        evidence,
+        source: candidate.source,
+        id: candidate.value.id,
+        uid: candidate.value.uid,
+        host: candidate.value.host,
+        context: candidate.value.context,
+        provenance: candidate.value.provenance,
+    };
+};
 
 // Error details from Podman, systemd, and Cockpit can contain command lines,
 // URLs, or health output.  The display only needs an allowlisted reason; the
@@ -131,9 +314,12 @@ export const latestHealthLog = state => {
     }, null)?.log || null;
 };
 
-const healthExitCode = value => {
+// Podman can encode an exit code as either a JSON number or a decimal string.
+// Keep one parser for assessment and log rendering so a passing string "0"
+// cannot be shown as a failed run in the expanded view.
+export const normalizeExitCode = value => {
     if (typeof value === "number")
-        return Number.isInteger(value) ? value : null;
+        return Number.isSafeInteger(value) ? value : null;
     if (typeof value !== "string" || !/^[+-]?\d+$/.test(value.trim()))
         return null;
     const parsed = Number(value);
@@ -153,7 +339,9 @@ export const isCompletedContainer = container => {
     const state = container?.State;
     const config = container?.Config;
     const labels = config?.Labels || container?.Labels || {};
-    return isTrueMarker(container?.Completed) ||
+    const disposition = lifecycleDisposition(container);
+    return disposition?.class === lifecycleDispositionClasses.completed ||
+        isTrueMarker(container?.Completed) ||
         isTrueMarker(container?.OneShot) ||
         isTrueMarker(state?.Completed) ||
         isTrueMarker(state?.OneShot) ||
@@ -277,15 +465,20 @@ export const staleAfter = (config, _state, scheduler = null) => schedulerFreshne
 export const healthAssessment = (container, now = Date.now(), collectionError = null, scheduler = null) => {
     const config = healthConfig(container);
     const state = healthState(container);
-    const lastChecked = lastHealthCheck(state);
+    const observedLastChecked = lastHealthCheck(state);
+    const lastChecked = observedLastChecked !== null && observedLastChecked <= now ? observedLastChecked : null;
     const latestLog = latestHealthLog(state);
-    const latestExitCode = latestLog === null ? null : healthExitCode(latestLog.ExitCode);
+    const latestLogTime = latestLog === null ? null : healthLogTime(latestLog);
+    const futureTimestamp = latestLogTime !== null && latestLogTime > now;
+    const latestExitCode = latestLog === null ? null : normalizeExitCode(latestLog.ExitCode);
     const ageMs = lastChecked === null ? null : Math.max(0, now - lastChecked);
     const effectiveScheduler = scheduler;
     const freshness = schedulerFreshness(config, effectiveScheduler);
     const staleAfterMs = freshness.staleAfterMs;
     const freshWindowMs = null;
     const nativeStatus = state?.Status || null;
+    const disposition = lifecycleDisposition(container);
+    const lifecycle = String(container?.State?.Status || "").toLowerCase();
 
     const base = extra => ({
         rawStatus: nativeStatus,
@@ -297,17 +490,31 @@ export const healthAssessment = (container, now = Date.now(), collectionError = 
         freshWindowMs,
         cadenceSource: freshness.cadenceSource,
         schedule: effectiveScheduler || null,
+        disposition,
+        lifecycleStatus: lifecycle || null,
+        scope: containerScope(container),
         ...extra,
     });
 
-    const lifecycle = String(container?.State?.Status || "").toLowerCase();
+    const role = container?.IsInfra === true || disposition?.class === lifecycleDispositionClasses.infrastructure
+        ? "infrastructure"
+        : null;
+    if (role === "infrastructure") {
+        return base({
+            status: healthStates.infrastructure,
+            reason: "infrastructure",
+            role,
+        });
+    }
     if (lifecycle && lifecycle !== "running") {
         const exitCode = container?.State?.ExitCode;
         const completed = lifecycle === "exited" && (exitCode === 0 || exitCode === "0") &&
             isCompletedContainer(container);
+        const retired = disposition?.class === lifecycleDispositionClasses.retired;
         return base({
-            status: completed ? healthStates.completed : healthStates.stopped,
-            reason: completed ? "completed" : "stopped",
+            status: completed ? healthStates.completed : retired ? healthStates.retired : healthStates.stopped,
+            reason: completed ? "completed" : retired ? "retired" : "stopped",
+            role,
         });
     }
 
@@ -317,6 +524,7 @@ export const healthAssessment = (container, now = Date.now(), collectionError = 
         return base({
             status: healthStates.error,
             reason: collectionReason(collectionError),
+            role,
             error: collectionReason(collectionError) === "collection-timeout"
                 ? HEALTH_COLLECTION_TIMEOUT
                 : HEALTH_COLLECTION_ERROR,
@@ -330,6 +538,7 @@ export const healthAssessment = (container, now = Date.now(), collectionError = 
         return base({
             status: healthStates.starting,
             reason: "details-pending",
+            role,
         });
     }
 
@@ -338,6 +547,7 @@ export const healthAssessment = (container, now = Date.now(), collectionError = 
             status: healthStates.missing,
             configured: false,
             reason: "missing",
+            role,
         });
     }
 
@@ -345,6 +555,7 @@ export const healthAssessment = (container, now = Date.now(), collectionError = 
         return base({
             status: healthStates.unhealthy,
             reason: "unhealthy",
+            role,
         });
     }
 
@@ -352,6 +563,15 @@ export const healthAssessment = (container, now = Date.now(), collectionError = 
         return base({
             status: healthStates.starting,
             reason: "starting",
+            role,
+        });
+    }
+
+    if (futureTimestamp) {
+        return base({
+            status: healthStates.unknown,
+            reason: "timestamp-future",
+            role,
         });
     }
 
@@ -363,6 +583,7 @@ export const healthAssessment = (container, now = Date.now(), collectionError = 
         return base({
             status: healthStates.unhealthy,
             reason: "latest-check-failed",
+            role,
         });
     }
 
@@ -370,6 +591,7 @@ export const healthAssessment = (container, now = Date.now(), collectionError = 
         return base({
             status: healthStates.unknown,
             reason: "latest-check-unknown",
+            role,
         });
     }
 
@@ -378,6 +600,7 @@ export const healthAssessment = (container, now = Date.now(), collectionError = 
             status: healthStates.error,
             reason: "scheduler-error",
             error: SCHEDULER_ERROR,
+            role,
         });
     }
 
@@ -385,6 +608,7 @@ export const healthAssessment = (container, now = Date.now(), collectionError = 
         return base({
             status: healthStates.stale,
             reason: "stale",
+            role,
         });
     }
 
@@ -392,11 +616,13 @@ export const healthAssessment = (container, now = Date.now(), collectionError = 
         return base({
             status: healthStates.healthy,
             reason: "healthy",
+            role,
         });
     }
 
     return base({
         status: healthStates.unknown,
         reason: nativeStatus === "healthy" ? freshness.reason : "no-result",
+        role,
     });
 };

--- a/src/podman.scss
+++ b/src/podman.scss
@@ -56,14 +56,30 @@
     color: var(--pf-t--global--text--color--status--on-info--default);
 }
 
-.ct-badge-container-healthy {
+.ct-badge-container-healthy, .ct-badge-container-health-healthy {
     background-color: var(--pf-t--global--border--color--status--success--default);
     color: var(--pf-t--global--text--color--status--on-success--default);
 }
 
-.ct-badge-container-unhealthy {
+.ct-badge-container-unhealthy, .ct-badge-container-health-unhealthy, .ct-badge-container-health-error {
     background-color: var(--pf-t--global--border--color--status--danger--default);
     color: var(--pf-t--global--text--color--status--on-danger--default);
+}
+
+.ct-badge-container-health-starting {
+    background-color: var(--pf-t--global--color--status--info--default);
+    color: var(--pf-t--global--text--color--status--on-info--default);
+}
+
+.ct-badge-container-health-stale {
+    background-color: var(--pf-t--global--color--status--warning--default);
+    color: var(--pf-t--global--text--color--status--on-warning--default);
+}
+
+.ct-badge-container-health-missing, .ct-badge-container-health-unknown,
+.ct-badge-container-health-stopped, .ct-badge-container-health-completed {
+    background-color: var(--pf-t--global--border--color--default);
+    color: var(--pf-t--global--text--color--regular);
 }
 
 .ct-badge-toolbox {

--- a/src/podman.scss
+++ b/src/podman.scss
@@ -32,6 +32,15 @@
     color: var(--pf-t--global--text--color--subtle);
 }
 
+.container-scope, .container-health-detail, .health-last-checked {
+    color: var(--pf-t--global--text--color--subtle);
+    font-size: var(--pf-t--global--font--size--sm);
+}
+
+.container-id-full, .healthcheck-container-id {
+    overflow-wrap: anywhere;
+}
+
 .container-name {
     font-size: var(--pf-t--global--font--size--lg);
     font-weight: 400;

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -72,12 +72,30 @@ function isReturnRaw(return_raw: boolean, callback: MonitorCallback): callback i
     return return_raw;
 }
 
+// cockpit.http().request() returns a promise-like object with a close()
+// method. Keep that cancellation hook when adapting it to the normal Promise
+// interface so bounded callers can release a request that has timed out.
+export type CancellablePromise<T> = Promise<T> & {
+    close?: (problem?: string) => void;
+};
+
 export type Connection = {
     uid: Uid;
     monitor: (path: string, callback: MonitorCallback, return_raw?: boolean) => Promise<void>;
-    call: (options: JsonObject) => Promise<string>;
+    call: (options: JsonObject) => CancellablePromise<string>;
     close: () => void;
 };
+
+type CockpitHttpRequest = Promise<Uint8Array> & {
+    close?: (problem?: string) => void;
+};
+
+function forwardClose<T>(promise: Promise<T>, request: CockpitHttpRequest): CancellablePromise<T> {
+    const result = promise as CancellablePromise<T>;
+    if (typeof request.close === "function")
+        result.close = request.close.bind(request);
+    return result;
+}
 
 function connect(uid: Uid): Connection {
     const addr = getAddress(uid);
@@ -89,12 +107,18 @@ function connect(uid: Uid): Connection {
     const decoder = new TextDecoder();
     const user_str = (uid === null) ? "user" : (uid === 0) ? "root" : `uid ${uid}`;
 
-    function call(options: JsonObject): Promise<string> {
+    function call(options: JsonObject): CancellablePromise<string> {
         const id = call_id++;
         debug(user_str, `call ${id}:`, JSON.stringify(options));
-        return new Promise((resolve, reject) => {
-            options = options || {};
-            http.request(options)
+        options = options || {};
+        let request: CockpitHttpRequest;
+        try {
+            request = http.request(options) as CockpitHttpRequest;
+        } catch (error) {
+            return Promise.reject(error) as CancellablePromise<string>;
+        }
+        const promise = new Promise<string>((resolve, reject) => {
+            request
                     .then((result: Uint8Array) => {
                         const text = decoder.decode(result);
                         debug(user_str, `call ${id} result:`, text);
@@ -109,6 +133,7 @@ function connect(uid: Uid): Connection {
                         reject(format_error(error, content_text));
                     });
         });
+        return forwardClose(promise, request);
     }
 
     function monitor(path: string, callback: MonitorCallback, return_raw: boolean = false): Promise<void> {

--- a/src/scheduler-request.js
+++ b/src/scheduler-request.js
@@ -1,0 +1,379 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+// Cockpit refreshes can overlap when a Podman event arrives during an
+// inventory refresh.  Keep one monotonically increasing generation per owner
+// context so a late response cannot replace newer coverage.
+
+export const schedulerOwnerKey = uid => uid === null ? "user" : String(uid);
+
+export class SchedulerRequestGate {
+    constructor() {
+        this.generations = new Map();
+    }
+
+    begin(uid) {
+        const key = schedulerOwnerKey(uid);
+        const generation = (this.generations.get(key) || 0) + 1;
+        this.generations.set(key, generation);
+        return { key, generation };
+    }
+
+    isCurrent(uid, request) {
+        return Boolean(request) && request.key === schedulerOwnerKey(uid) &&
+            this.generations.get(request.key) === request.generation;
+    }
+}
+
+// A recurring owner refresh must not start a second Podman/API or scheduler
+// collection while the previous one is still in flight.  Invalidating an
+// owner advances its generation without cancelling the underlying promise;
+// callers can then discard the late result safely.
+export class OwnerRefreshGate extends SchedulerRequestGate {
+    constructor(maxConcurrentOwners = 2) {
+        super();
+        this.running = new Map();
+        this.pending = [];
+        this.queued = new Map();
+        this.maxConcurrentOwners = Number.isInteger(maxConcurrentOwners) && maxConcurrentOwners > 0
+            ? maxConcurrentOwners
+            : 1;
+    }
+
+    start(uid, operation) {
+        const key = schedulerOwnerKey(uid);
+        const running = this.running.get(key);
+        const queued = this.queued.get(key);
+        // Coalesce only the generation that is still current.  An invalidated
+        // operation remains in flight so its late result can be discarded, but
+        // a reconnect must still get a fresh operation queued behind it.
+        if (running && this.isCurrent(uid, running.request))
+            return running;
+        if (queued && this.isCurrent(uid, queued.request))
+            return queued;
+        if (queued)
+            this.queued.delete(key);
+
+        const request = this.begin(uid);
+        let resolveEntry;
+        let rejectEntry;
+        const promise = new Promise((resolve, reject) => {
+            resolveEntry = resolve;
+            rejectEntry = reject;
+        });
+        const entry = { key, request, operation, promise, resolve: resolveEntry, reject: rejectEntry };
+        this.pending.push(entry);
+        this.queued.set(key, entry);
+        this.drain();
+        return entry;
+    }
+
+    invalidate(uid) {
+        return this.begin(uid);
+    }
+
+    drain() {
+        while (this.running.size < this.maxConcurrentOwners && this.pending.length > 0) {
+            // A fresh generation for an invalidated owner must wait for the
+            // old generation to settle even when another global slot is free.
+            // Search past blocked owners so unrelated contexts can continue.
+            const index = this.pending.findIndex(entry => !this.running.has(entry.key));
+            if (index < 0)
+                break;
+            const [entry] = this.pending.splice(index, 1);
+            if (this.queued.get(entry.key) === entry)
+                this.queued.delete(entry.key);
+            // A connection can disappear while an owner is waiting for a
+            // global slot. Resolve the abandoned request without running its
+            // operation; the next connection for this UID gets a new
+            // generation and cannot be blocked by stale work.
+            if (!this.isCurrent(entry.key, entry.request)) {
+                entry.resolve(undefined);
+                continue;
+            }
+
+            this.running.set(entry.key, entry);
+            Promise.resolve()
+                    .then(() => entry.operation(entry.request))
+                    .then(entry.resolve, entry.reject)
+                    .finally(() => {
+                        if (this.running.get(entry.key)?.request === entry.request)
+                            this.running.delete(entry.key);
+                        this.drain();
+                    });
+        }
+    }
+}
+
+// Bound requests on a shared Podman HTTP connection.  Cockpit's HTTP helper
+// queues requests internally, so launching an inspect for every event can
+// leave timed-out work occupying the connection long after the caller has
+// moved on.  A queued entry is cancellable before it starts; an active entry
+// forwards cancellation to the close() hook preserved by rest.ts.
+export class RequestConcurrencyGate {
+    constructor(maxConcurrent = 8) {
+        this.maxConcurrent = Number.isInteger(maxConcurrent) && maxConcurrent > 0
+            ? maxConcurrent
+            : 1;
+        this.active = 0;
+        this.pending = [];
+    }
+
+    run(operation) {
+        let resolveEntry;
+        let rejectEntry;
+        let resolveStarted;
+        const promise = new Promise((resolve, reject) => {
+            resolveEntry = resolve;
+            rejectEntry = reject;
+        });
+        const started = new Promise(resolve => {
+            resolveStarted = resolve;
+        });
+        promise.started = started;
+        const entry = {
+            operation,
+            promise,
+            resolve: resolveEntry,
+            reject: rejectEntry,
+            request: null,
+            started: false,
+            settled: false,
+            resolveStarted,
+        };
+        promise.close = (problem = "cancelled") => {
+            if (entry.settled)
+                return;
+            if (!entry.started) {
+                const index = this.pending.indexOf(entry);
+                if (index !== -1)
+                    this.pending.splice(index, 1);
+                entry.settled = true;
+                entry.resolveStarted(false);
+                entry.reject(new Error(problem));
+                return;
+            }
+            entry.settled = true;
+            entry.request?.close?.(problem);
+            entry.reject(new Error(problem));
+        };
+        this.pending.push(entry);
+        this.drain();
+        return promise;
+    }
+
+    drain() {
+        while (this.active < this.maxConcurrent && this.pending.length > 0) {
+            const entry = this.pending.shift();
+            if (entry.settled)
+                continue;
+            entry.started = true;
+            this.active++;
+            let request;
+            try {
+                request = entry.operation();
+                entry.request = request;
+                entry.resolveStarted(true);
+            } catch (error) {
+                entry.settled = true;
+                entry.resolveStarted(false);
+                entry.reject(error);
+            }
+            if (request === undefined) {
+                entry.settled = true;
+                entry.resolve(undefined);
+                this.finish(entry);
+            } else
+                Promise.resolve(request)
+                        .then(value => {
+                            if (!entry.settled) {
+                                entry.settled = true;
+                                entry.resolve(value);
+                            }
+                        }, error => {
+                            if (!entry.settled) {
+                                entry.settled = true;
+                                entry.reject(error);
+                            }
+                        })
+                        .finally(() => this.finish(entry));
+        }
+    }
+
+    finish(entry) {
+        if (!entry.started)
+            return;
+        entry.started = false;
+        this.active--;
+        this.drain();
+    }
+}
+
+// Serialize requests for one container identity while allowing different
+// containers to use the global request budget.  A newer generation replaces
+// only an older queued request; an already running request is allowed to
+// settle before the latest request starts.
+export class KeyedRequestGate {
+    constructor(run) {
+        this.runRequest = run;
+        this.states = new Map();
+    }
+
+    request(key, metadata, operation, canReuse) {
+        let state = this.states.get(key);
+        if (!state) {
+            state = { active: null, queued: null };
+            this.states.set(key, state);
+        }
+        if (state.active && canReuse(state.active.metadata))
+            return state.active.promise;
+        if (state.queued && canReuse(state.queued.metadata))
+            return state.queued.promise;
+
+        if (state.queued)
+            state.queued.promise.close("superseded");
+
+        let resolveEntry;
+        let rejectEntry;
+        const promise = new Promise((resolve, reject) => {
+            resolveEntry = resolve;
+            rejectEntry = reject;
+        });
+        const entry = {
+            key,
+            metadata,
+            operation,
+            promise,
+            resolve: resolveEntry,
+            reject: rejectEntry,
+            request: null,
+            started: false,
+            settled: false,
+        };
+        const started = new Promise(resolve => {
+            entry.resolveStarted = resolve;
+        });
+        promise.started = started;
+        promise.close = (problem = "cancelled") => {
+            if (entry.settled)
+                return;
+            if (!entry.started) {
+                if (state.queued === entry)
+                    state.queued = null;
+                entry.settled = true;
+                entry.resolveStarted(false);
+                entry.reject(new Error(problem));
+                this.cleanup(key, state);
+                return;
+            }
+            entry.settled = true;
+            entry.request?.close?.(problem);
+            entry.reject(new Error(problem));
+        };
+
+        if (state.active)
+            state.queued = entry;
+        else
+            this.start(key, state, entry);
+        return promise;
+    }
+
+    start(key, state, entry) {
+        entry.started = true;
+        state.active = entry;
+        let request;
+        try {
+            request = this.runRequest(entry.operation);
+            entry.request = request;
+            if (request?.started)
+                request.started.then(entry.resolveStarted);
+            else
+                entry.resolveStarted(true);
+        } catch (error) {
+            entry.settled = true;
+            entry.resolveStarted(false);
+            entry.reject(error);
+        }
+        if (request === undefined) {
+            if (!entry.settled) {
+                entry.settled = true;
+                entry.resolve(undefined);
+            }
+            this.finish(key, state, entry);
+            return;
+        }
+        Promise.resolve(request)
+                .then(value => {
+                    if (!entry.settled) {
+                        entry.settled = true;
+                        entry.resolve(value);
+                    }
+                }, error => {
+                    if (!entry.settled) {
+                        entry.settled = true;
+                        entry.reject(error);
+                    }
+                })
+                .finally(() => this.finish(key, state, entry));
+    }
+
+    finish(key, state, entry) {
+        if (state.active !== entry)
+            return;
+        state.active = null;
+        const next = state.queued;
+        state.queued = null;
+        if (next)
+            this.start(key, state, next);
+        else
+            this.cleanup(key, state);
+    }
+
+    cleanup(key, state) {
+        if (!state.active && !state.queued && this.states.get(key) === state)
+            this.states.delete(key);
+    }
+
+    closeWhere(predicate, problem = "cancelled") {
+        for (const state of this.states.values()) {
+            if (state.active && predicate(state.active.metadata))
+                state.active.promise.close(problem);
+            if (state.queued && predicate(state.queued.metadata))
+                state.queued.promise.close(problem);
+        }
+    }
+}
+
+export const withTimeout = (promise, timeoutMs, message, onTimeout = null) => {
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0)
+        return Promise.reject(new Error(message));
+
+    let timer;
+    const timeout = new Promise((resolve, reject) => {
+        timer = setTimeout(() => {
+            try {
+                onTimeout?.();
+            } catch {
+                // Timeout cleanup is best effort; the timeout result remains
+                // deterministic even if a bridge channel is already closed.
+            }
+            reject(new Error(message));
+        }, timeoutMs);
+    });
+    return Promise.race([Promise.resolve(promise), timeout])
+            .finally(() => clearTimeout(timer));
+};
+
+export const mapWithConcurrency = async (items, worker, concurrency) => {
+    const results = new Array(items.length);
+    let nextIndex = 0;
+    const run = async () => {
+        while (nextIndex < items.length) {
+            const index = nextIndex++;
+            results[index] = await worker(items[index], index);
+        }
+    };
+    const requestedWorkers = Number.isFinite(concurrency) ? Math.floor(concurrency) : 1;
+    const workers = Math.min(Math.max(1, requestedWorkers), items.length);
+    await Promise.all(Array.from({ length: workers }, run));
+    return results;
+};

--- a/src/scheduler-request.js
+++ b/src/scheduler-request.js
@@ -148,13 +148,13 @@ export class RequestConcurrencyGate {
                 if (index !== -1)
                     this.pending.splice(index, 1);
                 entry.settled = true;
-                entry.resolveStarted(false);
-                entry.reject(new Error(problem));
+                entry.resolveStarted?.(false);
+                entry.reject?.(new Error(problem));
                 return;
             }
             entry.settled = true;
             entry.request?.close?.(problem);
-            entry.reject(new Error(problem));
+            entry.reject?.(new Error(problem));
         };
         this.pending.push(entry);
         this.drain();
@@ -260,14 +260,14 @@ export class KeyedRequestGate {
                 if (state.queued === entry)
                     state.queued = null;
                 entry.settled = true;
-                entry.resolveStarted(false);
-                entry.reject(new Error(problem));
+                entry.resolveStarted?.(false);
+                entry.reject?.(new Error(problem));
                 this.cleanup(key, state);
                 return;
             }
             entry.settled = true;
             entry.request?.close?.(problem);
-            entry.reject(new Error(problem));
+            entry.reject?.(new Error(problem));
         };
 
         if (state.active)

--- a/src/time-display.js
+++ b/src/time-display.js
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+// Intl formatter construction is relatively expensive and these functions
+// are called once for every visible row on every render. Keep a small LRU per
+// display format so changing the Cockpit language remains correct without
+// allowing repeated language switches to grow the cache indefinitely.
+const MAX_FORMATTER_CACHE = 8;
+const dateTimeSecondsFormatters = new Map();
+const relativeTimeFormatters = new Map();
+
+const relativeUnits = [
+    { name: "second", max: 60 },
+    { name: "minute", max: 3600 },
+    { name: "hour", max: 86400 },
+    { name: "day", max: 86400 * 7 },
+    { name: "week", max: 86400 * 30 },
+    { name: "month", max: 86400 * 365 },
+    { name: "year", max: Infinity },
+];
+
+const cachedFormatter = (cache, locale, create) => {
+    const existing = cache.get(locale);
+    if (existing) {
+        cache.delete(locale);
+        cache.set(locale, existing);
+        return existing;
+    }
+
+    const formatter = create();
+    cache.set(locale, formatter);
+    while (cache.size > MAX_FORMATTER_CACHE)
+        cache.delete(cache.keys().next().value);
+    return formatter;
+};
+
+const dateTimeSecondsFormatter = locale => cachedFormatter(
+    dateTimeSecondsFormatters,
+    locale,
+    () => new Intl.DateTimeFormat(locale, { dateStyle: "medium", timeStyle: "medium" }),
+);
+
+const relativeTimeFormatter = locale => cachedFormatter(
+    relativeTimeFormatters,
+    locale,
+    () => new Intl.RelativeTimeFormat(locale, { numeric: "auto" }),
+);
+
+export const cachedDateTimeSeconds = (timestamp, locale) =>
+    dateTimeSecondsFormatter(locale).format(timestamp);
+
+export const cachedDistanceToNow = (timestamp, locale, gettext) => {
+    const timestampValue = timestamp?.valueOf?.() ?? timestamp;
+    const secondsDiff = Math.round((timestampValue - Date.now()) / 1000);
+
+    // Keep the same precision and translated short strings as Cockpit's
+    // timeformat helper. Seconds are too precise for a display that does not
+    // constantly re-render.
+    if (secondsDiff <= 0 && secondsDiff > -60)
+        return gettext("less than a minute ago");
+    if (secondsDiff > 0 && secondsDiff < 60)
+        return gettext("in less than a minute");
+
+    const unitIndex = relativeUnits.findIndex(unit => unit.max > Math.abs(secondsDiff));
+    const divisor = unitIndex ? relativeUnits[unitIndex - 1].max : 1;
+    const unit = relativeUnits[unitIndex];
+    return relativeTimeFormatter(locale).format(Math.round(secondsDiff / divisor), unit.name);
+};

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -5,7 +5,8 @@ import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip";
 import { debounce } from 'throttle-debounce';
 
 import cockpit from 'cockpit';
-import * as timeformat from 'timeformat';
+
+import { cachedDateTimeSeconds, cachedDistanceToNow } from './time-display.js';
 
 const _ = cockpit.gettext;
 
@@ -66,8 +67,9 @@ export const RelativeTime = ({ time }: { time: Date | string }) => {
     if (!time)
         return null;
     const timestamp = typeof time === "string" ? Date.parse(time) : time;
-    const dateRel = timeformat.distanceToNow(timestamp);
-    const dateAbs = timeformat.dateTimeSeconds(timestamp);
+    const locale = cockpit.language.replace('_', '-');
+    const dateRel = cachedDistanceToNow(timestamp, locale, _);
+    const dateAbs = cachedDateTimeSeconds(timestamp, locale);
     return <Tooltip content={dateAbs}><span>{dateRel}</span></Tooltip>;
 };
 

--- a/test/browser-health-fixtures.json
+++ b/test/browser-health-fixtures.json
@@ -1,0 +1,91 @@
+{
+  "now": "2026-09-08T12:01:00Z",
+  "healthy": {
+    "expected": "healthy",
+    "container": {
+      "Id": "healthy-id",
+      "Config": { "Healthcheck": { "Test": ["CMD-SHELL", "true"], "Interval": 30000000000, "Timeout": 5000000000 } },
+      "State": { "Status": "running", "Health": { "Status": "healthy", "Log": [{ "Start": "2026-09-08T11:59:30Z", "End": "2026-09-08T11:59:31Z", "ExitCode": 0 }, { "Start": "2026-09-08T12:00:30Z", "End": "2026-09-08T12:00:31Z", "ExitCode": 0 }] } }
+    },
+    "scheduler": { "coverage_status": "covered", "active_coverage_count": 1, "coverage_count": 1, "effective_interval_seconds": 30, "jitter_seconds": 0, "accuracy_seconds": 1, "schedule_source": "systemd", "collector_errors": [] }
+  },
+  "unhealthy": {
+    "expected": "unhealthy",
+    "container": {
+      "Id": "unhealthy-id",
+      "Config": { "Healthcheck": { "Test": ["CMD-SHELL", "false"], "Interval": 30000000000, "Timeout": 5000000000 } },
+      "State": { "Status": "running", "Health": { "Status": "unhealthy", "Log": [{ "Start": "2026-09-08T12:00:30Z", "End": "2026-09-08T12:00:31Z", "ExitCode": 1 }] } }
+    },
+    "scheduler": { "coverage_status": "covered", "active_coverage_count": 1, "coverage_count": 1, "effective_interval_seconds": 30, "jitter_seconds": 0, "accuracy_seconds": 1, "schedule_source": "systemd", "collector_errors": [] }
+  },
+  "starting": {
+    "expected": "starting",
+    "container": {
+      "Id": "starting-id",
+      "Config": { "Healthcheck": { "Test": ["CMD-SHELL", "true"], "Interval": 30000000000, "Timeout": 5000000000 } },
+      "State": { "Status": "running", "Health": { "Status": "starting", "Log": [] } }
+    },
+    "scheduler": { "coverage_status": "covered", "active_coverage_count": 1, "coverage_count": 1, "effective_interval_seconds": 30, "jitter_seconds": 0, "accuracy_seconds": 1, "schedule_source": "systemd", "collector_errors": [] }
+  },
+  "missing": {
+    "expected": "missing",
+    "container": { "Id": "missing-id", "Config": {}, "State": { "Status": "running" } }
+  },
+  "stale": {
+    "expected": "stale",
+    "container": {
+      "Id": "stale-id",
+      "Config": { "Healthcheck": { "Test": ["CMD-SHELL", "true"], "Interval": 30000000000, "Timeout": 5000000000 } },
+      "State": { "Status": "running", "Health": { "Status": "healthy", "Log": [{ "Start": "2026-09-08T11:58:00Z", "End": "2026-09-08T11:58:01Z", "ExitCode": 0 }, { "Start": "2026-09-08T11:59:00Z", "End": "2026-09-08T11:59:01Z", "ExitCode": 0 }] } }
+    },
+    "scheduler": { "coverage_status": "covered", "active_coverage_count": 1, "coverage_count": 1, "effective_interval_seconds": 30, "jitter_seconds": 0, "accuracy_seconds": 1, "schedule_source": "systemd", "collector_errors": [] }
+  },
+  "freshness-unknown": {
+    "expected": "unknown",
+    "container": {
+      "Id": "unknown-freshness-id",
+      "Config": { "Healthcheck": { "Test": ["CMD-SHELL", "true"], "Interval": 5000000000, "Timeout": 1000000000 } },
+      "State": { "Status": "running", "Health": { "Status": "healthy", "Log": [{ "Start": "2026-09-08T11:59:00Z", "End": "2026-09-08T11:59:01Z", "ExitCode": 0 }] } }
+    },
+    "scheduler": { "coverage_status": "uncovered", "active_coverage_count": 0, "coverage_count": 0, "coverage_reason": "ambiguous-schedule", "effective_interval_seconds": null, "effective_interval_source": null, "collector_errors": [] }
+  },
+  "collector-error": {
+    "expected": "error",
+    "error": "permission denied\nfor /run/user/1000/podman/podman.sock",
+    "container": {
+      "Id": "error-id",
+      "Config": { "Healthcheck": { "Test": ["CMD-SHELL", "true"], "Interval": 30000000000, "Timeout": 5000000000 } },
+      "State": { "Status": "running", "Health": { "Status": "healthy", "Log": [{ "Start": "2026-09-08T12:00:30Z", "End": "2026-09-08T12:00:31Z", "ExitCode": 0 }] } }
+    },
+    "scheduler": { "coverage_status": "covered", "active_coverage_count": 1, "coverage_count": 1, "effective_interval_seconds": 30, "jitter_seconds": 0, "accuracy_seconds": 1, "schedule_source": "systemd", "collector_errors": [] }
+  },
+  "stopped": {
+    "expected": "stopped",
+    "container": {
+      "Id": "stopped-id",
+      "Config": { "Healthcheck": { "Test": ["CMD-SHELL", "true"], "Interval": 30000000000, "Timeout": 5000000000 } },
+      "State": { "Status": "exited", "ExitCode": 137, "Health": { "Status": "healthy", "Log": [{ "Start": "2026-09-08T12:00:30Z", "End": "2026-09-08T12:00:31Z", "ExitCode": 0 }] } }
+    },
+    "scheduler": { "coverage_status": "uncovered", "active_coverage_count": 0, "coverage_count": 0, "coverage_reason": "no-active-matching-health-timer", "collector_errors": [] }
+  },
+  "latest-failed": {
+    "expected": "unhealthy",
+    "container": {
+      "Id": "latest-failed-id",
+      "Config": { "Healthcheck": { "Test": ["CMD-SHELL", "curl -f http://service/health"], "Interval": 30000000000, "Timeout": 5000000000, "Retries": 30 } },
+      "State": { "Status": "running", "Health": { "Status": "healthy", "Log": [{ "Start": "2026-09-08T11:59:30Z", "End": "2026-09-08T11:59:31Z", "ExitCode": 0 }, { "Start": "2026-09-08T12:00:30Z", "End": "2026-09-08T12:00:31Z", "ExitCode": -1, "Output": "health check timed out" }] } }
+    },
+    "scheduler": { "coverage_status": "covered", "active_coverage_count": 1, "coverage_count": 1, "effective_interval_seconds": 30, "jitter_seconds": 0, "accuracy_seconds": 1, "schedule_source": "systemd", "collector_errors": [] }
+  },
+  "permission-context-collision": {
+    "expected": "owner-scoped",
+    "sameId": "same-id",
+    "healthyOwner": { "uid": 0, "error": null },
+    "errorOwner": { "uid": 1000, "error": "access denied" }
+  },
+  "recreated-id": {
+    "expected": "new-id-is-independent",
+    "old": { "uid": 1000, "id": "old-id", "error": "inspect 404" },
+    "new": { "uid": 1000, "id": "new-id", "error": null }
+  }
+}

--- a/test/check-application
+++ b/test/check-application
@@ -2484,9 +2484,9 @@ Yaml={name}.yaml
         if name:
             b.wait_text(sel + " .container-name", name)
         if image:
-            b.wait_in_text(sel + " td[data-label=Container] small:nth-child(2)", image)
+            b.wait_in_text(sel + " td[data-label=Container] .container-image", image)
         if cmd:
-            b.wait_text(sel + " td[data-label=Container] small:last-child", cmd)
+            b.wait_text(sel + " td[data-label=Container] .container-command", cmd)
         if owner:
             if owner == "system":
                 b.wait_text(sel + " td[data-label=Owner]", owner)
@@ -3452,7 +3452,7 @@ Yaml={name}.yaml
         self.performContainerAction("quak", "Stop", system=system)
         b.wait(lambda: self.getContainerAttr("quak", "State", "", system=system) == "Exited")
         # Shows Command when exited
-        b.wait_in_text(f"tr[data-row-id='{'0' if system else 'user'}-quak.service'] small:last-child",
+        b.wait_in_text(f"tr[data-row-id='{'0' if system else 'user'}-quak.service'] .container-command",
                        "sleep infinity")
         self.performContainerAction("quak", "Start", system=system)
         b.wait(lambda: self.getContainerAttr("quak", "State", "", system=system) == "Running")

--- a/test/check-application
+++ b/test/check-application
@@ -227,6 +227,14 @@ class TestApplication(testlib.MachineCase):
 
     def getContainerAttr(self, container: str, key: str, selector: str = "", *, system: bool = True) -> str:
         b = self.browser
+        if key == "State":
+            # The state cell also contains health and freshness badges. Keep
+            # lifecycle assertions scoped to the original Podman state badge;
+            # preserve the download-complete filter used by image tests.
+            downloading = ".downloading" in selector
+            selector = ".ct-badge-container-state"
+            if downloading:
+                selector += ":not(.downloading)"
         return b.text(f"{self.getContainerSelector(container, system=system)} > td[data-label={key}] {selector}")
 
     def getImageSelector(self, image: str, *, system: bool = True) -> str:
@@ -343,6 +351,52 @@ WantedBy=multi-user.target default.target
         if autostart:
             self.addCleanup(self.execute, f"{systemctl_cmd} stop {name}.service", system=auth)
             self.execute(f"{systemctl_cmd} start {name}.service", system=auth)
+
+    def createHealthScheduler(self, container_name: str, *, auth: bool = False) -> None:
+        """Install the supported external health schedule used by this browser fixture.
+
+        Podman still owns the native health result and log.  The timer only
+        gives Cockpit's read-only scheduler collector an actual effective
+        cadence to inspect; without it a native-only disposable container is
+        correctly reported as having unknown freshness.
+        """
+        systemctl_cmd = "systemctl" if auth else "systemctl --user"
+        unit_dir = "/etc/systemd/system" if auth else "/home/admin/.config/systemd/user"
+        owner = None if auth else "admin:admin"
+        unit_stem = f"cockpit-podman-healthcheck-{container_name}"
+        service_unit = f"{unit_stem}.service"
+        timer_unit = f"{unit_stem}.timer"
+        service_file = f"{unit_dir}/{service_unit}"
+        timer_file = f"{unit_dir}/{timer_unit}"
+
+        if not auth:
+            self.machine.execute(f"install -d -o admin -g admin {unit_dir}")
+
+        service = f"""
+[Unit]
+Description=Cockpit Podman healthcheck fixture for {container_name}
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/podman healthcheck run {container_name}
+"""
+        timer = f"""
+[Unit]
+Description=Cockpit Podman healthcheck timer fixture for {container_name}
+
+[Timer]
+OnUnitActiveSec=30s
+AccuracySec=1s
+Unit={service_unit}
+"""
+
+        self.write_file(service_file, service, owner=owner)
+        self.write_file(timer_file, timer, owner=owner)
+        self.addCleanup(self.execute,
+                        f"{systemctl_cmd} stop {timer_unit} {service_unit} || true; {systemctl_cmd} daemon-reload",
+                        system=auth)
+        self.execute(f"{systemctl_cmd} daemon-reload; {systemctl_cmd} start {timer_unit}; "
+                     f"{systemctl_cmd} is-active {timer_unit}", system=auth)
 
     def createQuadletPod(self, name: str, podName: str | None = None, *, auth: bool = False) -> None:
         podName = podName if podName else name
@@ -2441,7 +2495,7 @@ Yaml={name}.yaml
         if state is not None:
             if not isinstance(state, list):
                 state = [state]
-            b.wait(lambda: b.text(sel + " td[data-label=State]") in state)
+            b.wait(lambda: b.text(sel + " td[data-label=State] .ct-badge-container-state") in state)
 
     def filter_containers(self, value: str) -> None:
         """Use dropdown menu in the header to filter containers"""
@@ -2721,6 +2775,12 @@ Yaml={name}.yaml
 
         b.set_input_text("#run-image-dialog-name", "healthy")
 
+        # The health result remains native Podman state.  This matching timer
+        # supplies the real external cadence consumed by the display's
+        # scheduler collector, so the fixture does not rely on a green result
+        # while freshness is actually uncovered.
+        self.createHealthScheduler("healthy", auth=auth)
+
         b.click("#pf-tab-2-create-image-dialog-tab-healthcheck")
         b.set_input_text('#run-image-dialog-healthcheck-command', 'true')
         b.set_input_text('#run-image-healthcheck-interval input', '325')
@@ -2737,7 +2797,8 @@ Yaml={name}.yaml
         b.click("#containers-images .pf-v6-c-expandable-section__toggle button")
 
         healthy_sha = self.execute("podman inspect --format '{{.Id}}' healthy", system=auth).strip()
-        self.waitContainer(healthy_sha, auth=auth, state='RunningHealthy')
+        self.waitContainer(healthy_sha, auth=auth, state='Running')
+        b.wait_visible(f'{self.getContainerSelector("healthy", system=auth)} .ct-badge-container-health-healthy')
 
         self.toggleExpandedContainer("healthy", system=auth)
         b.click(".pf-m-expanded button:contains('Health check')")
@@ -2768,7 +2829,8 @@ Yaml={name}.yaml
         self.execute(f"podman run --name sick -dt --health-cmd false --health-interval 5s {IMG_BUSYBOX}", system=auth)
         self.waitContainerRow("sick")
         unhealthy_sha = self.execute("podman inspect --format '{{.Id}}' sick", system=auth).strip()
-        self.waitContainer(unhealthy_sha, auth=auth, state='RunningUnhealthy')
+        self.waitContainer(unhealthy_sha, auth=auth, state='Running')
+        b.wait_visible(f'{self.getContainerSelector("sick", system=auth)} .ct-badge-container-health-unhealthy')
         # Unhealthy should be first
         expected_ws = ""
         if auth and self.machine.ws_container:
@@ -2799,6 +2861,7 @@ Yaml={name}.yaml
         b.wait_text('div.pf-v6-c-modal-box header', 'Create container')
 
         containername = "healthaction"
+        self.createHealthScheduler(containername, auth=auth)
         b.set_input_text("#run-image-dialog-name", containername)
         b.set_input_text("#run-image-dialog-command", "/bin/sh -c 'echo 1 > /healthy && sleep infinity'")
 
@@ -2811,7 +2874,8 @@ Yaml={name}.yaml
 
         self.waitContainerRow(containername)
         self.toggleExpandedContainer(containername, system=auth)
-        b.wait(lambda: self.getContainerAttr(containername, "State", "", system=auth) == "RunningHealthy")
+        b.wait(lambda: self.getContainerAttr(containername, "State", "", system=auth) == "Running")
+        b.wait_visible(f'{self.getContainerSelector(containername, system=auth)} .ct-badge-container-health-healthy')
         b.click(".pf-m-expanded button:contains('Health check')")
         b.wait_in_text('.pf-m-expanded #container-details-healthcheck .healthcheck-when-unhealthy',
                        'Force stop')
@@ -2819,7 +2883,7 @@ Yaml={name}.yaml
         status = self.execute(f"podman exec {containername} rm -f /healthy", system=auth).strip()
         b.wait(lambda: self.getContainerAttr(containername,
                                              "State",
-                                             "span:not(.ct-badge-container-unhealthy)",
+                                             ".ct-badge-container-state",
                                              system=auth) in NOT_RUNNING)
         status = self.execute(f"podman inspect --format '{{{{.State.Health.Status}}}}' {containername}",
                               system=auth).strip()
@@ -3631,7 +3695,10 @@ Yaml={name}.yaml
             b.click(self.getContainerAction(cmd))
 
         def getContainerAttr(container: str, uid: str, key: str) -> str:
-            return b.text(f"#containers-containers tr[data-row-name='{uid}-{container}'] td[data-label={key}]")
+            return b.text(
+                f"#containers-containers tr[data-row-name='{uid}-{container}'] "
+                f"td[data-label={key}] .ct-badge-container-state"
+            )
 
         # container lifecycle actions
         uid = uids["guitar"]

--- a/test/health-scheduler.test.py
+++ b/test/health-scheduler.test.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Focused safety tests for the read-only scheduler collector."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "src" / "health-scheduler.py"
+SPEC = importlib.util.spec_from_file_location("health_scheduler", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def main() -> None:
+    overflow = MODULE.run_bounded(
+        [sys.executable, "-c", "import sys; sys.stdout.write('x' * (8 * 1024 * 1024 + 1))"],
+        5,
+    )
+    assert overflow.returncode == 75
+    assert overflow.stdout == ""
+    assert overflow.timed_out is False
+
+    aggregate_overflow = MODULE.run_bounded(
+        [
+            sys.executable,
+            "-c",
+            "import sys; sys.stdout.write('x' * (5 * 1024 * 1024)); sys.stderr.write('y' * (5 * 1024 * 1024))",
+        ],
+        5,
+    )
+    assert aggregate_overflow.returncode == 75
+    assert aggregate_overflow.stdout == ""
+    assert aggregate_overflow.stderr == "output exceeded collector limit"
+
+    timed_out = MODULE.run_bounded([sys.executable, "-c", "import time; time.sleep(5)"], 0.05)
+    assert timed_out.returncode == 124
+    assert timed_out.timed_out is True
+
+    valid_schedule, valid_errors = MODULE._timer_schedule({
+        "OnUnitActiveSec": "30s",
+        "AccuracySec": "1s",
+        "NextElapseUSecRealtime": "Mon 2026-09-08 12:01:30 EDT",
+    })
+    assert valid_schedule["effective_interval_seconds"] == 30
+    assert valid_schedule["next_trigger"]
+    assert "missing-next-trigger" not in valid_errors
+
+    missing_next, missing_errors = MODULE._timer_schedule({
+        "OnUnitActiveSec": "30s",
+        "AccuracySec": "1s",
+    })
+    assert missing_next["next_trigger"] is None
+    assert "missing-next-trigger" in missing_errors
+
+    # Keep the subprocess path explicit so descriptor cleanup is exercised even
+    # when the child exits nonzero.
+    failed = MODULE.run_bounded([sys.executable, "-c", "raise SystemExit(3)"], 5)
+    assert failed.returncode == 3
+
+    # An active timer that is elapsed rather than waiting cannot prove that a
+    # future health check is scheduled.
+    container_id = "a" * 64
+    ref = MODULE.ContainerRef(uid=0, container_id=container_id, name="fixture", source_index=0)
+    original_run_bounded = MODULE.run_bounded
+
+    def fake_systemctl(argv, _timeout):
+        if "list-units" in argv:
+            return MODULE.CommandResult(
+                list(argv), 0, "podman-healthcheck@fixture.timer loaded active waiting -\n", ""
+            )
+        if "podman-healthcheck@fixture.timer" in argv:
+            return MODULE.CommandResult(
+                list(argv),
+                0,
+                "Id=podman-healthcheck@fixture.timer\n"
+                "ActiveState=active\nSubState=elapsed\n"
+                "Unit=podman-healthcheck@fixture.service\n"
+                "OnUnitActiveSec=30s\nAccuracySec=1s\n"
+                "NextElapseUSecRealtime=Mon 2026-09-08 12:01:30 EDT\n\n",
+                "",
+            )
+        return MODULE.CommandResult(
+            list(argv),
+            0,
+            "Id=podman-healthcheck@fixture.service\n"
+            "ActiveState=active\nSubState=running\n"
+            "ExecStart=/usr/bin/podman healthcheck run fixture\n\n",
+            "",
+        )
+
+    MODULE.run_bounded = fake_systemctl
+    try:
+        coverage = MODULE.collect_coverage([ref], uid=0, manager="system", systemctl_bin="fixture-systemctl")
+    finally:
+        MODULE.run_bounded = original_run_bounded
+    record = coverage["containers"][ref.key]
+    assert record["active_coverage_count"] == 0
+    assert any(item["reason"] == "timer-not-waiting" for item in coverage["unattributed_health_timers"])
+
+    # Real one-shot health execution: timer running, service activating/start,
+    # recurring cadence retained, and no next elapse until completion.
+    for service_state, expected in [
+        ("ActiveState=activating\nSubState=start", "covered"),
+        ("ActiveState=active\nSubState=running", "covered"),
+        ("ActiveState=inactive\nSubState=dead", "uncovered"),
+    ]:
+
+        def executing_systemctl(argv, timeout, service_state=service_state):
+            result = fake_systemctl(argv, timeout)
+            if "podman-healthcheck@fixture.timer" in argv:
+                result.stdout = result.stdout.replace("SubState=elapsed", "SubState=running").replace(
+                    "NextElapseUSecRealtime=Mon 2026-09-08 12:01:30 EDT\n", ""
+                )
+            elif "list-units" not in argv:
+                result.stdout = result.stdout.replace("ActiveState=active\nSubState=running", service_state)
+            return result
+
+        MODULE.run_bounded = executing_systemctl
+        try:
+            result = MODULE.collect_coverage([ref], uid=0, manager="system", systemctl_bin="fixture-systemctl")
+        finally:
+            MODULE.run_bounded = original_run_bounded
+        assert result["containers"][ref.key]["coverage_status"] == expected
+    _, errors = MODULE._timer_schedule({"AccuracySec": "1s"}, executing=True)
+    assert "missing-recurring-interval" in errors and "missing-next-trigger" in errors
+
+    # A one-shot can complete between the timer and service snapshots. Only a
+    # fresh waiting timer with its next trigger resolves that inconsistent pair.
+    for refreshed_state, expected in [
+        ("waiting", "covered"),
+        ("elapsed", "uncovered"),
+        ("running", "uncovered"),
+        ("missing", "uncovered"),
+        ("timeout", "uncovered"),
+    ]:
+        timer_reads = 0
+
+        def raced_systemctl(argv, timeout, refreshed_state=refreshed_state):
+            nonlocal timer_reads
+            result = fake_systemctl(argv, timeout)
+            if "list-units" in argv:
+                return result
+            if "podman-healthcheck@fixture.timer" in argv:
+                timer_reads += 1
+                if timer_reads == 1:
+                    result.stdout = result.stdout.replace("SubState=elapsed", "SubState=running")
+                elif refreshed_state == "timeout":
+                    return MODULE.CommandResult(list(argv), 124, "", "", timed_out=True)
+                elif refreshed_state == "missing":
+                    result.stdout = ""
+                else:
+                    result.stdout = result.stdout.replace("SubState=elapsed", "SubState=" + refreshed_state)
+            else:
+                result.stdout = result.stdout.replace(
+                    "ActiveState=active\nSubState=running", "ActiveState=inactive\nSubState=dead"
+                )
+            return result
+
+        MODULE.run_bounded = raced_systemctl
+        try:
+            result = MODULE.collect_coverage([ref], uid=0, manager="system", systemctl_bin="fixture-systemctl")
+        finally:
+            MODULE.run_bounded = original_run_bounded
+        assert timer_reads == 2  # One reconciliation only, no retry loop.
+        assert result["containers"][ref.key]["coverage_status"] == expected
+
+    print("health-scheduler safety tests: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/health-state.test.mjs
+++ b/test/health-state.test.mjs
@@ -1,0 +1,240 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { healthAssessment, healthStates, isValidHealthDetails, shouldInspectHealth } from "../src/health.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixtures = JSON.parse(await readFile(resolve(here, "browser-health-fixtures.json"), "utf8"));
+const now = Date.parse(fixtures.now);
+
+assert.equal(shouldInspectHealth({ Id: "running-missing", State: "running" }, {
+    State: { Status: "running" },
+    healthDetailsLoaded: true,
+    Config: { Healthcheck: { Test: ["NONE"] } },
+}), false);
+assert.equal(shouldInspectHealth({ Id: "running-configured", State: "running" }, {
+    State: { Status: "running" },
+    healthDetailsLoaded: true,
+    Config: { Healthcheck: { Test: ["CMD-SHELL", "true"] } },
+}), true);
+assert.equal(shouldInspectHealth({ Id: "stopped-configured", State: "exited" }, {
+    State: { Status: "exited" },
+    healthDetailsLoaded: true,
+    Config: { Healthcheck: { Test: ["CMD-SHELL", "true"] } },
+}), false);
+assert.equal(shouldInspectHealth({ Id: "running-pending", State: "running" }, {
+    State: { Status: "running" },
+    healthDetailsLoaded: false,
+}), true);
+assert.equal(healthAssessment({
+    Id: "inventory-only",
+    State: { Status: "running" },
+    healthDetailsLoaded: false,
+}, now).status, healthStates.starting);
+assert.equal(healthAssessment({
+    Id: "inventory-only",
+    State: { Status: "running" },
+    healthDetailsLoaded: false,
+}, now).reason, "details-pending");
+
+// A detail response can be truthy while still being unusable. It must carry
+// the exact inventory identity and the objects consumed by the row renderer;
+// otherwise collection must remain failed and the next refresh must retry it.
+const inspectInventory = { Id: "inspect-owner-container" };
+const inspectDetail = {
+    Id: inspectInventory.Id,
+    State: { Status: "running" },
+    Config: {},
+};
+assert.equal(isValidHealthDetails(inspectInventory, inspectDetail), true);
+for (const [label, malformed] of [
+    ["null detail", null],
+    ["undefined detail", undefined],
+    ["truthy scalar", "inspect failed"],
+    ["mismatched id", { ...inspectDetail, Id: "different-container" }],
+    ["missing state", { ...inspectDetail, State: undefined }],
+    ["malformed state", { ...inspectDetail, State: "running" }],
+    ["missing state status", { ...inspectDetail, State: {} }],
+    ["missing config", { ...inspectDetail, Config: undefined }],
+    ["malformed config", { ...inspectDetail, Config: [] }],
+])
+    assert.equal(isValidHealthDetails(inspectInventory, malformed), false, label);
+
+const failedInspectRow = { ...inspectInventory, State: { Status: "running" }, healthDetailsLoaded: false };
+assert.equal(healthAssessment(failedInspectRow, now, "Container inspect response is invalid").status,
+             healthStates.error);
+const recoveredInspect = structuredClone(fixtures.healthy.container);
+recoveredInspect.Id = inspectInventory.Id;
+recoveredInspect.healthDetailsLoaded = true;
+assert.equal(isValidHealthDetails(inspectInventory, recoveredInspect), true);
+assert.equal(healthAssessment(recoveredInspect, now, null, fixtures.healthy.scheduler).status,
+             healthStates.healthy);
+
+assert.equal(healthAssessment({
+    Id: "partial-health-config",
+    Config: { Healthcheck: {} },
+    State: { Status: "running" },
+}, now, null, null).status, healthStates.missing);
+assert.equal(healthAssessment({
+    Id: "interval-only-health-config",
+    Config: { Healthcheck: { Interval: 30000000000 } },
+    State: { Status: "running" },
+}, now, null, null).status, healthStates.missing);
+assert.equal(healthAssessment({
+    Id: "disabled-health-config",
+    Config: { Healthcheck: { Test: ["NONE"], Interval: 30000000000 } },
+    State: { Status: "running" },
+}, now, null, null).status, healthStates.missing);
+assert.equal(healthAssessment({
+    Id: "malformed-health-config",
+    Config: { Healthcheck: { Test: ["CMD-SHELL", ""] } },
+    State: { Status: "running" },
+}, now, null, null).status, healthStates.missing);
+
+for (const name of ["healthy", "unhealthy", "starting", "missing", "stale", "freshness-unknown", "collector-error", "stopped", "latest-failed"]) {
+    const fixture = fixtures[name];
+    const assessment = healthAssessment(fixture.container, now, fixture.error, fixture.scheduler);
+    assert.equal(assessment.status, fixture.expected, name);
+}
+
+const latestFailed = healthAssessment(fixtures["latest-failed"].container, now, null, fixtures["latest-failed"].scheduler);
+assert.equal(latestFailed.status, healthStates.unhealthy);
+assert.equal(latestFailed.reason, "latest-check-failed");
+assert.equal(latestFailed.latestExitCode, -1);
+assert.equal(latestFailed.rawStatus, "healthy");
+assert.equal(healthAssessment(fixtures["latest-failed"].container, now, null, {
+    coverage_status: "error",
+    collector_errors: ["collector failed"],
+}).status, healthStates.unhealthy);
+
+for (const malformedExitCode of [null, "", false]) {
+    const malformed = structuredClone(fixtures["latest-failed"].container);
+    malformed.State.Health.Log.at(-1).ExitCode = malformedExitCode;
+    const assessment = healthAssessment(malformed, now, null, fixtures["latest-failed"].scheduler);
+    assert.equal(assessment.status, healthStates.unknown, `malformed exit code ${String(malformedExitCode)}`);
+    assert.equal(assessment.reason, "latest-check-unknown");
+    assert.equal(assessment.rawStatus, "healthy");
+    assert.equal(assessment.latestExitCode, null);
+}
+
+const sanitized = healthAssessment(fixtures["collector-error"].container, now, fixtures["collector-error"].error, fixtures["collector-error"].scheduler);
+assert.equal(sanitized.status, healthStates.error);
+assert.equal(sanitized.error, "health-collection-failed");
+assert.doesNotMatch(sanitized.error, /podman\.sock|secret|token|https?:\/\//i);
+const timedOut = healthAssessment(fixtures["collector-error"].container, now, "Container inspect timed out", fixtures["collector-error"].scheduler);
+assert.equal(timedOut.status, healthStates.error);
+assert.equal(timedOut.reason, "collection-timeout");
+assert.equal(timedOut.error, "health-collection-timeout");
+
+const schedulerSecret = healthAssessment(fixtures.healthy.container, now, null, {
+    coverage_status: "error",
+    collector_errors: ["systemd timer failed: https://user:password@example.invalid/?token=secret"],
+});
+assert.equal(schedulerSecret.status, healthStates.error);
+assert.equal(schedulerSecret.error, "scheduler-metadata-unavailable");
+assert.doesNotMatch(schedulerSecret.error, /https?:\/\/|password|token|secret/i);
+assert.equal(healthAssessment(fixtures.healthy.container, now, null, {
+    coverage_status: "covered",
+    active_coverage_count: 2,
+    effective_interval_seconds: 30,
+    collector_errors: [],
+}).status, healthStates.error);
+assert.equal(healthAssessment(fixtures.healthy.container, now, null, {
+    coverage_status: "unexpected",
+    effective_interval_seconds: 30,
+    collector_errors: [],
+}).status, healthStates.error);
+
+// A covered scheduler record must carry a complete, self-consistent count
+// and cadence. Missing or contradictory metadata must never produce green
+// health or a freshness window.
+const completeCovered = {
+    coverage_status: "covered",
+    active_coverage_count: 1,
+    coverage_count: 1,
+    effective_interval_seconds: 30,
+    jitter_seconds: 0,
+    accuracy_seconds: 1,
+    schedule_source: "systemd",
+    collector_errors: [],
+};
+assert.equal(healthAssessment(fixtures.healthy.container, now, null, completeCovered).status, healthStates.healthy);
+for (const [label, malformed] of [
+    ["missing active count", { ...completeCovered, active_coverage_count: undefined }],
+    ["zero covered count", { ...completeCovered, active_coverage_count: 0, coverage_count: 0 }],
+    ["mismatched counts", { ...completeCovered, coverage_count: 0 }],
+    ["missing collector errors", { ...completeCovered, collector_errors: undefined }],
+    ["missing cadence", { ...completeCovered, effective_interval_seconds: undefined }],
+    ["missing cadence source", { ...completeCovered, schedule_source: undefined }],
+])
+    assert.equal(healthAssessment(fixtures.healthy.container, now, null, malformed).status,
+                 healthStates.error, label);
+
+const collision = fixtures["permission-context-collision"];
+const healthyKey = `${collision.healthyOwner.uid}-${collision.sameId}`;
+const errorKey = `${collision.errorOwner.uid}-${collision.sameId}`;
+assert.notEqual(healthyKey, errorKey);
+assert.equal(healthAssessment(fixtures.healthy.container, now, collision.healthyOwner.error, fixtures.healthy.scheduler).status, healthStates.healthy);
+assert.equal(healthAssessment(fixtures.healthy.container, now, collision.errorOwner.error, fixtures.healthy.scheduler).status, healthStates.error);
+
+const recreated = fixtures["recreated-id"];
+assert.notEqual(`${recreated.old.uid}-${recreated.old.id}`, `${recreated.new.uid}-${recreated.new.id}`);
+assert.equal(healthAssessment(fixtures.healthy.container, now, recreated.old.error, fixtures.healthy.scheduler).status, healthStates.error);
+assert.equal(healthAssessment(fixtures.healthy.container, now, recreated.new.error, fixtures.healthy.scheduler).status, healthStates.healthy);
+
+assert.equal(healthAssessment(fixtures.stopped.container, now, null, fixtures.stopped.scheduler).status, healthStates.stopped);
+assert.equal(healthAssessment(fixtures.stopped.container, now, "inventory refresh timed out", fixtures.stopped.scheduler).status,
+             healthStates.stopped);
+
+// An exit code of zero is not sufficient to call an arbitrary workload a
+// completed one-shot job.  Without explicit metadata it remains stopped.
+const exitedSuccessfully = structuredClone(fixtures.stopped.container);
+exitedSuccessfully.State.ExitCode = 0;
+assert.equal(healthAssessment(exitedSuccessfully, now, null, fixtures.stopped.scheduler).status, healthStates.stopped);
+
+const completedOneShot = structuredClone(exitedSuccessfully);
+completedOneShot.Config.Labels = { "com.docker.compose.oneoff": "True" };
+assert.equal(healthAssessment(completedOneShot, now, null, fixtures.stopped.scheduler).status, healthStates.completed);
+assert.equal(healthAssessment(completedOneShot, now, "inventory refresh timed out", fixtures.stopped.scheduler).status,
+             healthStates.completed);
+
+const explicitStateOneShot = structuredClone(exitedSuccessfully);
+explicitStateOneShot.State.OneShot = true;
+assert.equal(healthAssessment(explicitStateOneShot, now, null, fixtures.stopped.scheduler).status, healthStates.completed);
+
+const restartPolicyOnly = structuredClone(exitedSuccessfully);
+restartPolicyOnly.Config.Labels = { "io.kubernetes.container.restartPolicy": "Never" };
+assert.equal(healthAssessment(restartPolicyOnly, now, null, fixtures.stopped.scheduler).status, healthStates.stopped);
+
+const slowSchedule = { ...fixtures.stale.scheduler, effective_interval_seconds: 180, jitter_seconds: 10, accuracy_seconds: 1 };
+assert.equal(healthAssessment(fixtures.stale.container, now, null, slowSchedule).status, healthStates.healthy);
+assert.equal(healthAssessment(fixtures.stale.container, now, null, fixtures.stale.scheduler).staleAfterMs, 36000);
+assert.equal(healthAssessment(fixtures.healthy.container, now, null, {
+    coverage_status: "uncovered",
+    active_coverage_count: 0,
+    coverage_count: 0,
+    coverage_reason: "no-active-matching-health-timer",
+    collector_errors: [],
+}).status, healthStates.unknown);
+
+// A repeated inspect is the source of the timestamp update.  Keep the native
+// status and scheduler cadence unchanged while asserting that a newer Podman
+// health log advances freshness instead of leaving a cached timestamp behind.
+const repeated = structuredClone(fixtures.healthy.container);
+const first = healthAssessment(repeated, now, null, fixtures.healthy.scheduler);
+repeated.State.Health.Log.push({
+    Start: "2026-09-08T12:01:00Z",
+    End: "2026-09-08T12:01:01Z",
+    ExitCode: 0,
+});
+const second = healthAssessment(repeated, Date.parse("2026-09-08T12:01:02Z"), null, fixtures.healthy.scheduler);
+assert.equal(first.status, healthStates.healthy);
+assert.equal(second.status, healthStates.healthy);
+assert.equal(second.lastChecked, Date.parse("2026-09-08T12:01:01Z"));
+assert.ok(second.lastChecked > first.lastChecked);
+
+console.log("health-state fixtures: PASS");

--- a/test/health-state.test.mjs
+++ b/test/health-state.test.mjs
@@ -5,11 +5,39 @@ import { readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { healthAssessment, healthStates, isValidHealthDetails, shouldInspectHealth } from "../src/health.js";
+import { containerScope, healthAge, healthAssessment, healthDetail, healthStates, isValidHealthDetails, lifecycleDisposition, normalizeExitCode, sanitizeHealthDetail, shouldInspectHealth } from "../src/health.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const fixtures = JSON.parse(await readFile(resolve(here, "browser-health-fixtures.json"), "utf8"));
 const now = Date.parse(fixtures.now);
+
+// The browser-facing projection keeps health and lifecycle independent and
+// carries the actual owner/full-ID scope used by the row key.
+const scopedContainer = {
+    ...fixtures.healthy.container,
+    Id: "a".repeat(64),
+    uid: null,
+    ownerUid: 1000,
+    context: "rootless",
+};
+const scopedAssessment = healthAssessment(scopedContainer, now, null, fixtures.healthy.scheduler);
+assert.equal(scopedAssessment.lifecycleStatus, "running");
+assert.deepEqual(scopedAssessment.scope, {
+    routeUid: null,
+    ownerUid: 1000,
+    context: "rootless",
+    id: scopedContainer.Id,
+    fullId: scopedContainer.Id,
+});
+assert.equal(healthAge(scopedAssessment), scopedAssessment.ageMs);
+assert.equal(healthDetail(scopedAssessment).code, "healthy");
+
+assert.equal(sanitizeHealthDetail("short operator reason"), "short operator reason");
+for (const unsafe of ["see https://example.invalid/token", "line\nwith control", " ", "x".repeat(241)])
+    assert.equal(sanitizeHealthDetail(unsafe), null);
+
+for (const [value, expected] of [[0, 0], ["0", 0], [" +0 ", 0], [-1, -1], ["-1", -1], ["1", 1], [null, null], ["", null], [false, null], [1.5, null], ["1.5", null], ["9007199254740992", null]])
+    assert.equal(normalizeExitCode(value), expected, `exit code ${String(value)}`);
 
 assert.equal(shouldInspectHealth({ Id: "running-missing", State: "running" }, {
     State: { Status: "running" },
@@ -101,6 +129,38 @@ for (const name of ["healthy", "unhealthy", "starting", "missing", "stale", "fre
     assert.equal(assessment.status, fixture.expected, name);
 }
 
+assert.equal(healthDetail(healthAssessment(fixtures.missing.container, now)).code, "missing");
+assert.equal(healthDetail(healthAssessment(fixtures.stale.container, now, null, fixtures.stale.scheduler)).code, "stale");
+assert.equal(healthDetail(healthAssessment(fixtures["collector-error"].container, now,
+                                           fixtures["collector-error"].error, fixtures["collector-error"].scheduler)).code,
+             "collection-error");
+assert.equal(healthDetail(healthAssessment(fixtures["latest-failed"].container, now, null,
+                                           fixtures["latest-failed"].scheduler)).code,
+             "latest-check-failed");
+assert.equal(healthDetail({ status: "error", reason: "https://secret.invalid" }).code, "error");
+
+for (const [label, value] of [
+    ["invalid age", { ageMs: Infinity }],
+    ["negative age", { ageMs: -1 }],
+    ["missing age", {}],
+])
+    assert.equal(healthAge(value), null, label);
+
+assert.deepEqual(containerScope({ Id: "b".repeat(64), uid: 0 }), {
+    routeUid: 0,
+    ownerUid: 0,
+    context: "rootful",
+    id: "b".repeat(64),
+    fullId: "b".repeat(64),
+});
+assert.deepEqual(containerScope({ Id: "short-id", uid: null, ownerUid: 1000, context: "rootless" }), {
+    routeUid: null,
+    ownerUid: 1000,
+    context: "rootless",
+    id: "short-id",
+    fullId: null,
+});
+
 const latestFailed = healthAssessment(fixtures["latest-failed"].container, now, null, fixtures["latest-failed"].scheduler);
 assert.equal(latestFailed.status, healthStates.unhealthy);
 assert.equal(latestFailed.reason, "latest-check-failed");
@@ -110,6 +170,13 @@ assert.equal(healthAssessment(fixtures["latest-failed"].container, now, null, {
     coverage_status: "error",
     collector_errors: ["collector failed"],
 }).status, healthStates.unhealthy);
+
+const futureHealth = structuredClone(fixtures.healthy.container);
+futureHealth.State.Health.Log.at(-1).End = "2026-09-08T12:05:01Z";
+assert.equal(healthAssessment(futureHealth, now, null, fixtures.healthy.scheduler).status, healthStates.unknown);
+assert.equal(healthAssessment(futureHealth, now, null, fixtures.healthy.scheduler).reason, "timestamp-future");
+assert.equal(healthAssessment(futureHealth, now, null, fixtures.healthy.scheduler).lastChecked, null);
+assert.equal(healthAssessment(futureHealth, now, null, fixtures.healthy.scheduler).ageMs, null);
 
 for (const malformedExitCode of [null, "", false]) {
     const malformed = structuredClone(fixtures["latest-failed"].container);
@@ -209,6 +276,194 @@ assert.equal(healthAssessment(explicitStateOneShot, now, null, fixtures.stopped.
 const restartPolicyOnly = structuredClone(exitedSuccessfully);
 restartPolicyOnly.Config.Labels = { "io.kubernetes.container.restartPolicy": "Never" };
 assert.equal(healthAssessment(restartPolicyOnly, now, null, fixtures.stopped.scheduler).status, healthStates.stopped);
+
+// A disposition supplied by the owner is accepted only when it is bound to
+// the current full container identity. It is lifecycle metadata, not a health
+// result, and it never overrides a running container.
+const dispositionIdentity = {
+    id: "b".repeat(64),
+    uid: 0,
+    host: "train.home.complete.tech",
+    context: "rootful",
+};
+const sourceProvenance = {
+    kind: "operator-policy",
+    source: "source-decisions.json",
+    source_ref: "worktrees/misc-source/train.home.complete.tech/ops/fleet-recovery-20260907.md",
+    policy_sha256: "b58d2c2b95f46efc3cbd4fdf3b2c62a0024190c091d668e0a6f754d553ee4f81",
+    owner_verified: true,
+    manifest_sha256: "c".repeat(64),
+    decision_sha256: "d".repeat(64),
+};
+const completedFromMetadata = structuredClone(exitedSuccessfully);
+completedFromMetadata.Id = dispositionIdentity.id;
+completedFromMetadata.uid = 0;
+completedFromMetadata.ownerUid = 0;
+completedFromMetadata.host = "train.home.complete.tech";
+completedFromMetadata.context = "rootful";
+completedFromMetadata.LifecycleDisposition = {
+    ...dispositionIdentity,
+    class: "completed_one_shot",
+    reason: "bootstrap job completed and is not a live workload",
+    provenance: sourceProvenance,
+};
+assert.equal(lifecycleDisposition(completedFromMetadata)?.class, "completed_one_shot");
+assert.equal(healthAssessment(completedFromMetadata, now, null, fixtures.stopped.scheduler).status, healthStates.completed);
+assert.equal(healthAssessment(completedFromMetadata, now, null, fixtures.stopped.scheduler).disposition.reason,
+             "bootstrap job completed and is not a live workload");
+
+// A session-user connection keeps uid null for UI routing while the Podman
+// backend owner is resolved separately as numeric UID 1000. Lifecycle
+// identity must use that verified owner context rather than the route key.
+const nullRoutedRootless = structuredClone(completedFromMetadata);
+nullRoutedRootless.uid = null;
+nullRoutedRootless.ownerUid = 1000;
+nullRoutedRootless.host = "train.home.complete.tech";
+nullRoutedRootless.context = "rootless";
+nullRoutedRootless.LifecycleDisposition = {
+    ...nullRoutedRootless.LifecycleDisposition,
+    uid: 1000,
+    host: "train.home.complete.tech",
+    context: "rootless",
+};
+assert.equal(nullRoutedRootless.uid, null);
+assert.equal(nullRoutedRootless.ownerUid, 1000);
+assert.equal(lifecycleDisposition(nullRoutedRootless)?.class, "completed_one_shot");
+assert.equal(healthAssessment(nullRoutedRootless, now, null, fixtures.stopped.scheduler).status,
+             healthStates.completed);
+
+const missingProvenanceReference = structuredClone(completedFromMetadata);
+delete missingProvenanceReference.LifecycleDisposition.provenance.source_ref;
+assert.equal(lifecycleDisposition(missingProvenanceReference), null);
+
+const missingCurrentState = structuredClone(completedFromMetadata);
+missingCurrentState.State = {};
+assert.equal(lifecycleDisposition(missingCurrentState), null);
+
+for (const [label, mismatch] of [
+    ["full ID", { ...dispositionIdentity, id: "different-id" }],
+    ["owner UID", { ...dispositionIdentity, uid: 1000 }],
+    ["host", { ...dispositionIdentity, host: "other-host" }],
+    ["context", { ...dispositionIdentity, context: "rootless" }],
+]) {
+    const mismatched = structuredClone(completedFromMetadata);
+    mismatched.LifecycleDisposition = { ...mismatch, class: "completed_one_shot" };
+    assert.equal(lifecycleDisposition(mismatched), null, label);
+    assert.equal(healthAssessment(mismatched, now, null, fixtures.stopped.scheduler).status,
+                 healthStates.stopped, label);
+}
+
+const retiredFromMetadata = structuredClone(completedFromMetadata);
+retiredFromMetadata.State.ExitCode = 143;
+retiredFromMetadata.LifecycleDisposition = {
+    ...dispositionIdentity,
+    class: "retired",
+    reason: "replaced by an active rootless service",
+    provenance: sourceProvenance,
+};
+assert.equal(healthAssessment(retiredFromMetadata, now, "inventory refresh timed out", fixtures.stopped.scheduler).status,
+             healthStates.retired);
+assert.equal(healthAssessment(retiredFromMetadata, now, null, fixtures.stopped.scheduler).disposition.reason,
+             "replaced by an active rootless service");
+
+const staleRetirement = structuredClone(retiredFromMetadata);
+staleRetirement.State.Status = "running";
+staleRetirement.State.ExitCode = undefined;
+staleRetirement.Config.Healthcheck = {
+    Test: ["CMD-SHELL", "true"],
+    Interval: 30000000000,
+    Timeout: 5000000000,
+};
+staleRetirement.State.Health = {
+    Status: "healthy",
+    Log: [{ Start: "2026-09-08T12:00:30Z", End: "2026-09-08T12:00:31Z", ExitCode: 0 }],
+};
+assert.equal(lifecycleDisposition(staleRetirement), null);
+assert.equal(healthAssessment(staleRetirement, now, null, fixtures.healthy.scheduler).status, healthStates.healthy);
+
+const infrastructure = structuredClone(staleRetirement);
+infrastructure.IsInfra = true;
+infrastructure.LifecycleDisposition = {
+    ...dispositionIdentity,
+    class: "infrastructure_only",
+    reason: "Podman infrastructure container",
+    provenance: sourceProvenance,
+};
+assert.equal(healthAssessment(infrastructure, now, null, fixtures.healthy.scheduler).status,
+             healthStates.infrastructure);
+assert.equal(healthAssessment(infrastructure, now, null, fixtures.healthy.scheduler).role,
+             "infrastructure");
+const runtimeInfrastructure = structuredClone(staleRetirement);
+runtimeInfrastructure.IsInfra = true;
+delete runtimeInfrastructure.LifecycleDisposition;
+assert.equal(healthAssessment(runtimeInfrastructure, now, null, fixtures.healthy.scheduler).status,
+             healthStates.infrastructure);
+assert.equal(healthAssessment(runtimeInfrastructure, now, null, fixtures.healthy.scheduler).role,
+             "infrastructure");
+
+const stoppedInfrastructure = structuredClone(exitedSuccessfully);
+stoppedInfrastructure.IsInfra = true;
+assert.equal(healthAssessment(stoppedInfrastructure, now, null, fixtures.stopped.scheduler).status,
+             healthStates.infrastructure);
+assert.equal(healthAssessment(stoppedInfrastructure, now, null, fixtures.stopped.scheduler).lifecycleStatus,
+             "exited");
+
+const pausedInfrastructure = structuredClone(staleRetirement);
+pausedInfrastructure.IsInfra = true;
+pausedInfrastructure.State.Status = "paused";
+assert.equal(healthAssessment(pausedInfrastructure, now, null, fixtures.healthy.scheduler).status,
+             healthStates.infrastructure);
+assert.equal(healthAssessment(pausedInfrastructure, now, null, fixtures.healthy.scheduler).lifecycleStatus,
+             "paused");
+
+const labelCompleted = structuredClone(exitedSuccessfully);
+labelCompleted.Config.Labels = {
+    "com.complete.tech.lifecycle.disposition": "completed_one_shot",
+    "com.complete.tech.lifecycle.reason": "owner-declared one-shot",
+};
+assert.equal(healthAssessment(labelCompleted, now, null, fixtures.stopped.scheduler).status, healthStates.stopped);
+
+const labelShortName = structuredClone(exitedSuccessfully);
+labelShortName.Config.Labels = { "com.complete.tech.lifecycle.disposition": "completed" };
+assert.equal(healthAssessment(labelShortName, now, null, fixtures.stopped.scheduler).status, healthStates.stopped);
+
+const retainedFixture = structuredClone(exitedSuccessfully);
+retainedFixture.Config.Labels = {
+    "com.complete.tech.lifecycle.disposition": "retired",
+    "com.complete.tech.lifecycle.reason": "retained fixture; no live service",
+};
+assert.equal(healthAssessment(retainedFixture, now, null, fixtures.stopped.scheduler).status, healthStates.stopped);
+
+const sourceRecordId = "a".repeat(64);
+const sourceStopped = structuredClone(exitedSuccessfully);
+sourceStopped.Id = sourceRecordId;
+sourceStopped.LifecycleDisposition = {
+    class: "stopped",
+    id: sourceRecordId,
+    uid: 0,
+    host: "train.home.complete.tech",
+    context: "rootful",
+    reason: "owner evidence is insufficient to call this retired",
+    provenance: sourceProvenance,
+};
+sourceStopped.uid = 0;
+sourceStopped.ownerUid = 0;
+sourceStopped.host = "train.home.complete.tech";
+sourceStopped.context = "rootful";
+assert.equal(lifecycleDisposition(sourceStopped)?.class, "stopped");
+assert.equal(healthAssessment(sourceStopped, now, null, fixtures.stopped.scheduler).status, healthStates.stopped);
+assert.equal(healthAssessment(sourceStopped, now, null, fixtures.stopped.scheduler).disposition.reason,
+             "owner evidence is insufficient to call this retired");
+
+const sourceRecordMissingContext = structuredClone(sourceStopped);
+delete sourceRecordMissingContext.context;
+delete sourceRecordMissingContext.LifecycleDisposition.context;
+assert.equal(lifecycleDisposition(sourceRecordMissingContext), null);
+
+const unsafeReason = structuredClone(completedFromMetadata);
+unsafeReason.LifecycleDisposition.reason = "see https://example.invalid/secret";
+assert.equal(healthAssessment(unsafeReason, now, null, fixtures.stopped.scheduler).status, healthStates.completed);
+assert.equal(healthAssessment(unsafeReason, now, null, fixtures.stopped.scheduler).disposition.reason, null);
 
 const slowSchedule = { ...fixtures.stale.scheduler, effective_interval_seconds: 180, jitter_seconds: 10, accuracy_seconds: 1 };
 assert.equal(healthAssessment(fixtures.stale.container, now, null, slowSchedule).status, healthStates.healthy);

--- a/test/scheduler-refresh-fixture.json
+++ b/test/scheduler-refresh-fixture.json
@@ -1,0 +1,8 @@
+{
+  "owner_uid": 1000,
+  "responses": [
+    { "label": "newer", "generation": 2, "delay_ms": 1 },
+    { "label": "older", "generation": 1, "delay_ms": 10 }
+  ],
+  "expected_applied": ["newer"]
+}

--- a/test/scheduler-refresh.test.mjs
+++ b/test/scheduler-refresh.test.mjs
@@ -15,6 +15,28 @@ const fixture = JSON.parse(await readFile(resolve(here, "scheduler-refresh-fixtu
 // same-UID reconnect. The production guard must run before that stale frame
 // can replace the new connection's pending batch or cancel its timer.
 const applicationSource = await readFile(resolve(here, "../src/app.jsx"), "utf8");
+// cockpit.spawn().input(message) closes the stream by default. The scheduler
+// collector must keep its identity write open and send one explicit EOF with
+// the following null input; otherwise the bridge receives duplicate `done`
+// controls when the transport is already closing.
+assert.equal((applicationSource.match(/process\.input\(JSON\.stringify\(identity\), true\);/g) || []).length, 1);
+assert.equal((applicationSource.match(/process\.input\(JSON\.stringify\(identity\)\);/g) || []).length, 0);
+const bridgeControls = [];
+const schedulerProcess = {
+    input(message, stream) {
+        if (!stream)
+            bridgeControls.push({ control: "done" });
+        else
+            bridgeControls.push({ data: message });
+    },
+};
+const schedulerIdentity = { containers: [] };
+schedulerProcess.input(JSON.stringify(schedulerIdentity), true);
+schedulerProcess.input(null);
+assert.deepEqual(bridgeControls, [
+    { data: JSON.stringify(schedulerIdentity) },
+    { control: "done" },
+]);
 // Exercise the production inventory mapping with a real list-shaped one-shot.
 const inventoryMapperStart = applicationSource.indexOf("const containerFromInventory =");
 const inventoryMapperEnd = applicationSource.indexOf("\n// sort order", inventoryMapperStart);

--- a/test/scheduler-refresh.test.mjs
+++ b/test/scheduler-refresh.test.mjs
@@ -1,0 +1,443 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { healthAssessment, isValidHealthDetails } from "../src/health.js";
+import { KeyedRequestGate, mapWithConcurrency, OwnerRefreshGate, RequestConcurrencyGate, SchedulerRequestGate, withTimeout } from "../src/scheduler-request.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixture = JSON.parse(await readFile(resolve(here, "scheduler-refresh-fixture.json"), "utf8"));
+
+// A closed connection can still deliver one final stats frame after a
+// same-UID reconnect. The production guard must run before that stale frame
+// can replace the new connection's pending batch or cancel its timer.
+const applicationSource = await readFile(resolve(here, "../src/app.jsx"), "utf8");
+// Exercise the production inventory mapping with a real list-shaped one-shot.
+const inventoryMapperStart = applicationSource.indexOf("const containerFromInventory =");
+const inventoryMapperEnd = applicationSource.indexOf("\n// sort order", inventoryMapperStart);
+const mapInventory = new Function(applicationSource.slice(inventoryMapperStart, inventoryMapperEnd) + "\nreturn containerFromInventory;")();
+for (const [exitCode, expected] of [[0, "completed"], ["0", "completed"], [1, "stopped"], [null, "stopped"], [undefined, "stopped"]]) {
+    const row = mapInventory({ Id: "one-shot", Names: ["one-shot"], State: "exited", ExitCode: exitCode,
+        Labels: { "com.docker.compose.oneoff": "True" } }, 0, "0-one-shot");
+    assert.equal(healthAssessment(row).status, expected);
+}
+
+const statsQueueStart = applicationSource.indexOf("    queueContainerStats(con, stats) {");
+const statsQueueEnd = applicationSource.indexOf("\n    clearContainerStats", statsQueueStart);
+assert.ok(statsQueueStart >= 0 && statsQueueEnd > statsQueueStart);
+const statsQueueBody = applicationSource.slice(statsQueueStart, statsQueueEnd);
+assert.ok(statsQueueBody.startsWith("    queueContainerStats(con, stats) {\n        if (!this.isCurrentConnection(con))\n            return;"));
+
+// Scheduler metadata must start from the validated inventory snapshot in the
+// periodic owner pass. The explicit request arguments keep scheduler and
+// health results tied to the same generations.
+const ownerHealthStart = applicationSource.indexOf("    async collectOwnerHealth(con, request) {");
+const ownerHealthEnd = applicationSource.indexOf("\n    schedulerErrorRecord", ownerHealthStart);
+const ownerHealthBody = applicationSource.slice(ownerHealthStart, ownerHealthEnd);
+const ownerSchedulerStart = ownerHealthBody.indexOf("schedulerPromise = this.updateSchedulerCoverage");
+const ownerInspectStart = ownerHealthBody.indexOf("const results = await mapWithConcurrency");
+assert.ok(ownerSchedulerStart >= 0 && ownerSchedulerStart < ownerInspectStart);
+assert.match(ownerHealthBody.slice(ownerSchedulerStart, ownerInspectStart),
+             /schedulerRequest, request,[\s\S]*HEALTH_SCHEDULER_TIMEOUT_MS/);
+assert.match(ownerHealthBody, /result && !isValidHealthDetails\(inventory, result\.detail\)/);
+assert.match(ownerHealthBody, /errors\[key\] = CONTAINER_INSPECT_INVALID/);
+assert.match(ownerHealthBody, /failed\.healthDetailsLoaded = false/);
+assert.match(applicationSource, /if \(!isValidHealthDetails\(\{ Id: id \}, details\)\)/);
+
+// The owner refresh must classify null/undefined and malformed truthy detail
+// replies as collection failures, while a later exact inspect clears that
+// failure and is eligible to mark details loaded.
+const ownerInventory = { Id: "owner-refresh-container" };
+const validOwnerDetail = { Id: ownerInventory.Id, State: { Status: "running" }, Config: {} };
+for (const malformed of [null, undefined, { ...validOwnerDetail, Id: "other" },
+    { ...validOwnerDetail, State: {} }, { ...validOwnerDetail, Config: [] }])
+    assert.equal(isValidHealthDetails(ownerInventory, malformed), false);
+assert.equal(isValidHealthDetails(ownerInventory, validOwnerDetail), true);
+
+const initialHealthStart = applicationSource.indexOf("    async collectInitialContainers(con, refreshRequest) {");
+const initialHealthEnd = applicationSource.indexOf("\n    updateImages", initialHealthStart);
+const initialHealthBody = applicationSource.slice(initialHealthStart, initialHealthEnd);
+const initialSchedulerStart = initialHealthBody.indexOf("schedulerPromise = this.updateSchedulerCoverage");
+const initialInspectStart = initialHealthBody.indexOf("const results = await mapWithConcurrency");
+assert.equal(initialSchedulerStart, -1);
+assert.equal(initialInspectStart, -1);
+assert.match(applicationSource,
+             /this\.healthRefreshFollowups = new Map\(\)/);
+assert.match(applicationSource,
+             /healthRefreshFollowups\.set\(ownerKey, con\)[\s\S]*setTimeout\(\(\) =>/);
+const gate = new SchedulerRequestGate();
+const applied = [];
+
+const older = gate.begin(fixture.owner_uid);
+const newer = gate.begin(fixture.owner_uid);
+assert.equal(older.generation, fixture.responses.find(response => response.label === "older").generation);
+assert.equal(newer.generation, fixture.responses.find(response => response.label === "newer").generation);
+
+const responses = fixture.responses.map(response => new Promise(resolveResponse => {
+    setTimeout(() => {
+        const request = response.label === "older" ? older : newer;
+        if (gate.isCurrent(fixture.owner_uid, request))
+            applied.push(response.label);
+        resolveResponse();
+    }, response.delay_ms);
+}));
+await Promise.all(responses);
+
+assert.deepEqual(applied, fixture.expected_applied);
+assert.equal(gate.isCurrent(fixture.owner_uid, older), false);
+assert.equal(gate.isCurrent(fixture.owner_uid, newer), true);
+
+const refreshGate = new OwnerRefreshGate();
+const active = new Map();
+const maxActive = new Map();
+const run = (uid, delay) => refreshGate.start(uid, async request => {
+    const count = (active.get(request.key) || 0) + 1;
+    active.set(request.key, count);
+    maxActive.set(request.key, Math.max(maxActive.get(request.key) || 0, count));
+    await new Promise(resolveResponse => setTimeout(resolveResponse, delay));
+    active.set(request.key, active.get(request.key) - 1);
+    return request;
+});
+const ownerA = run(1000, 10);
+const ownerARepeat = run(1000, 1);
+const ownerB = run(2000, 1);
+assert.equal(ownerA, ownerARepeat);
+assert.notEqual(ownerA, ownerB);
+refreshGate.invalidate(1000);
+await Promise.all([ownerA.promise, ownerB.promise]);
+assert.equal(maxActive.get("1000"), 1);
+assert.equal(maxActive.get("2000"), 1);
+assert.equal(refreshGate.isCurrent(1000, ownerA.request), false);
+assert.equal(refreshGate.isCurrent(2000, ownerB.request), true);
+
+// Invalidating an in-flight owner must not make a reconnect reuse the old
+// promise.  The fresh generation waits for the old operation to settle even
+// when a global owner slot is available.
+const reconnectGate = new OwnerRefreshGate(2);
+const reconnectEvents = [];
+const staleReconnect = reconnectGate.start("reconnect-owner", async () => {
+    reconnectEvents.push("old-start");
+    await new Promise(resolveResponse => setTimeout(resolveResponse, 10));
+    reconnectEvents.push("old-done");
+    return "old-result";
+});
+reconnectGate.invalidate("reconnect-owner");
+const freshReconnect = reconnectGate.start("reconnect-owner", async () => {
+    reconnectEvents.push("fresh-start");
+    return "fresh-result";
+});
+assert.notEqual(staleReconnect, freshReconnect);
+assert.equal(await staleReconnect.promise, "old-result");
+assert.equal(await freshReconnect.promise, "fresh-result");
+assert.deepEqual(reconnectEvents, ["old-start", "old-done", "fresh-start"]);
+assert.equal(reconnectGate.isCurrent("reconnect-owner", staleReconnect.request), false);
+assert.equal(reconnectGate.isCurrent("reconnect-owner", freshReconnect.request), true);
+
+// Model the initial-load lifecycle: an invalidated generation may resolve
+// without committing `containersLoaded`, so the caller must start the queued
+// fresh generation and eventually settle loaded state.
+const initialLifecycleGate = new OwnerRefreshGate(2);
+let initialLoaded = false;
+let initialRuns = 0;
+const runInitialLoad = () => {
+    initialLifecycleGate.invalidate("initial-owner");
+    const entry = initialLifecycleGate.start("initial-owner", async request => {
+        initialRuns++;
+        await new Promise(resolveResponse => setTimeout(resolveResponse, 2));
+        if (!initialLifecycleGate.isCurrent("initial-owner", request))
+            return;
+        initialLoaded = true;
+    });
+    return entry.promise.then(() => {
+        if (!initialLoaded)
+            return runInitialLoad();
+    });
+};
+const initialLoad = runInitialLoad();
+initialLifecycleGate.invalidate("initial-owner");
+await initialLoad;
+assert.equal(initialLoaded, true);
+assert.equal(initialRuns, 2);
+
+// Event detail requests are keyed by full owner/container identity. A newer
+// event for B must discard only B's older inspect while an in-flight A inspect
+// remains applicable. The production path uses a separate owner gate for
+// scheduler coverage, so scheduler invalidation cannot drop container detail.
+const eventDetailGate = new SchedulerRequestGate();
+const detailAKey = "event-guard-owner-a";
+const detailBKey = "event-guard-owner-b";
+const detailA = eventDetailGate.begin(detailAKey);
+const detailBOld = eventDetailGate.begin(detailBKey);
+const detailBNew = eventDetailGate.begin(detailBKey);
+assert.equal(eventDetailGate.isCurrent(detailAKey, detailA), true);
+assert.equal(eventDetailGate.isCurrent(detailBKey, detailBOld), false);
+assert.equal(eventDetailGate.isCurrent(detailBKey, detailBNew), true);
+
+// Health and exec events do not launch scheduler collection, so they must not
+// invalidate an in-flight owner scheduler result with no replacement. A
+// topology event does request a new owner-scoped scheduler generation.
+const schedulerCoverageGate = new SchedulerRequestGate();
+const schedulerOwner = "event-guard-scheduler-owner";
+const schedulerInFlight = schedulerCoverageGate.begin(schedulerOwner);
+assert.equal(schedulerCoverageGate.isCurrent(schedulerOwner, schedulerInFlight), true);
+const topologyRefresh = schedulerCoverageGate.begin(schedulerOwner);
+assert.equal(schedulerCoverageGate.isCurrent(schedulerOwner, schedulerInFlight), false);
+assert.equal(schedulerCoverageGate.isCurrent(schedulerOwner, topologyRefresh), true);
+
+// Health events can arrive continuously while both owner inventories are
+// inspected. Model the actual event path: each event starts a per-container
+// inspect, records its generation/action, and commits only when that event is
+// still current. The initial inventory captures generations before listing,
+// preserves event-updated rows at commit, and merges event-created rows that
+// were absent from the listing. Exercise the observed 84/72-row scopes.
+const sleep = delay => new Promise(resolveResponse => setTimeout(resolveResponse, delay));
+const eventFloodGate = new OwnerRefreshGate(2);
+const runEventFloodInitialLoad = async (rowCount, ownerIndex) => {
+    const uid = `event-flood-${ownerIndex}`;
+    const ids = Array.from({ length: rowCount }, (_, index) =>
+        `${index.toString(16).padStart(2, "0")}${"0".repeat(62)}`);
+    const eventGate = new SchedulerRequestGate();
+    const eventGenerations = new Map();
+    const eventActions = new Map();
+    const pendingEvents = new Map();
+    const state = new Map();
+    const schedulerGate = new SchedulerRequestGate();
+    const initialEventGenerations = new Map(eventGenerations);
+    let eventCount = 0;
+    let loaded = false;
+
+    const emitContainerEvent = (id, action = "health_status") => {
+        const key = `${uid}-${id}`;
+        const request = eventGate.begin(key);
+        eventGenerations.set(key, request.generation);
+        eventActions.set(key, action);
+        const wait = pendingEvents.get(key) || Promise.resolve();
+        const operation = wait.then(async () => {
+            await sleep(1);
+            if (eventGate.isCurrent(key, request))
+                state.set(key, { Id: id, source: "event", generation: request.generation });
+        });
+        pendingEvents.set(key, operation);
+        operation.finally(() => {
+            if (pendingEvents.get(key) === operation)
+                pendingEvents.delete(key);
+        });
+        return operation;
+    };
+
+    const entry = eventFloodGate.start(uid, async request => {
+        // getContainers() resolves before the bounded 8-worker inspect fanout.
+        await sleep(2);
+        const inventory = ids.map(id => ({ Id: id }));
+        const inspected = await mapWithConcurrency(inventory, async row => {
+            await sleep(1);
+            return { ...row, source: "inventory" };
+        }, 8);
+        assert.equal(eventFloodGate.isCurrent(uid, request), true);
+
+        const listedKeys = new Set(inspected.map(row => `${uid}-${row.Id}`));
+        const committed = new Map();
+        for (const [key, row] of state) {
+            if (key.startsWith(`${uid}-`) && !listedKeys.has(key)) {
+                const snapshotGeneration = initialEventGenerations.get(key) || 0;
+                const currentGeneration = eventGenerations.get(key) || 0;
+                if (currentGeneration !== snapshotGeneration && eventActions.get(key) !== "remove")
+                    committed.set(key, row);
+            }
+        }
+        for (const row of inspected) {
+            const key = `${uid}-${row.Id}`;
+            const snapshotGeneration = initialEventGenerations.get(key) || 0;
+            const currentGeneration = eventGenerations.get(key) || 0;
+            if (currentGeneration !== snapshotGeneration) {
+                if (eventActions.get(key) === "remove")
+                    continue;
+                const current = state.get(key);
+                if (current) {
+                    committed.set(key, current);
+                    continue;
+                }
+            }
+            committed.set(key, row);
+        }
+        state.clear();
+        for (const [key, row] of committed)
+            state.set(key, row);
+        loaded = true;
+
+        // The scheduler collector runs after the inventory commit. Health
+        // events must not invalidate this owner-scoped result while they
+        // continue through independent per-container detail requests.
+        const schedulerRequest = schedulerGate.begin(uid);
+        await sleep(2);
+        assert.equal(schedulerGate.isCurrent(uid, schedulerRequest), true);
+    });
+
+    // This is the health_status stream that previously invalidated the owner
+    // generation on every event. It deliberately never invalidates the owner
+    // gate; only the per-container inspect generation changes.
+    const events = setInterval(() => {
+        const id = ids[eventCount % ids.length];
+        eventCount++;
+        void emitContainerEvent(id);
+    }, 1);
+    await entry.promise;
+    clearInterval(events);
+    await Promise.all([...pendingEvents.values()]);
+    assert.equal(loaded, true);
+    assert.equal(state.size, rowCount);
+    assert.ok(eventCount > 0);
+    return { state, eventCount };
+};
+
+const eventFloodLoads = await Promise.all([84, 72].map(runEventFloodInitialLoad));
+assert.deepEqual(eventFloodLoads.map(result => result.state.size), [84, 72]);
+assert.ok(eventFloodLoads.every(result => result.eventCount > 0));
+
+// A remove tombstone must win over the stale inventory row, while an event
+// created row absent from that inventory must survive the initial rebuild.
+const mergeGate = new SchedulerRequestGate();
+const mergeOwner = "event-merge-owner";
+const removedId = "a".repeat(64);
+const createdId = "b".repeat(64);
+const removedKey = `${mergeOwner}-${removedId}`;
+const createdKey = `${mergeOwner}-${createdId}`;
+const mergeGenerations = new Map();
+const mergeActions = new Map();
+const mergeState = new Map([[removedKey, { Id: removedId, source: "old" }],
+    [createdKey, { Id: createdId, source: "event" }]]);
+const mergeSnapshot = new Map(mergeGenerations);
+const removedRequest = mergeGate.begin(removedKey);
+mergeGenerations.set(removedKey, removedRequest.generation);
+mergeActions.set(removedKey, "remove");
+const createdRequest = mergeGate.begin(createdKey);
+mergeGenerations.set(createdKey, createdRequest.generation);
+mergeActions.set(createdKey, "create");
+const mergeInventory = [{ Id: removedId }];
+const mergedState = new Map();
+for (const [key, row] of mergeState) {
+    if (mergeInventory.some(container => `${mergeOwner}-${container.Id}` === key))
+        continue;
+    if ((mergeGenerations.get(key) || 0) !== (mergeSnapshot.get(key) || 0) &&
+        mergeActions.get(key) !== "remove")
+        mergedState.set(key, row);
+}
+for (const container of mergeInventory) {
+    const key = `${mergeOwner}-${container.Id}`;
+    if (mergeActions.get(key) === "remove")
+        continue;
+    mergedState.set(key, mergeState.get(key) || container);
+}
+assert.equal(mergeGate.isCurrent(removedKey, removedRequest), true);
+assert.equal(mergeGate.isCurrent(createdKey, createdRequest), true);
+assert.equal(mergedState.has(removedKey), false);
+assert.equal(mergedState.get(createdKey)?.source, "event");
+
+// The timer may enumerate many owner sockets. A per-owner gate alone would
+// still start one inventory and scheduler collector per owner at once; the
+// global cap keeps the next timer fire bounded while retaining owner
+// isolation.
+const globalGate = new OwnerRefreshGate(2);
+let globalActive = 0;
+let globalMaxActive = 0;
+const globalRuns = [1, 2, 3, 4].map(uid => globalGate.start(uid, async () => {
+    globalActive++;
+    globalMaxActive = Math.max(globalMaxActive, globalActive);
+    await new Promise(resolveResponse => setTimeout(resolveResponse, 4));
+    globalActive--;
+}));
+await Promise.all(globalRuns.map(entry => entry.promise));
+assert.equal(globalMaxActive, 2);
+
+const queuedGate = new OwnerRefreshGate(1);
+const queuedOwner = queuedGate.start("queued-owner", async () => {
+    await new Promise(resolveResponse => setTimeout(resolveResponse, 4));
+});
+const waitingOwner = queuedGate.start("waiting-owner", async () => undefined);
+assert.equal(queuedGate.start("waiting-owner", async () => undefined), waitingOwner);
+await Promise.all([queuedOwner.promise, waitingOwner.promise]);
+
+// Shared Podman HTTP calls have a global cap, and a timeout must remove a
+// queued call before it can start later and re-saturate the connection.
+const requestGate = new RequestConcurrencyGate(1);
+let requestStarts = 0;
+const heldRequest = requestGate.run(async () => {
+    requestStarts++;
+    await new Promise(resolveResponse => setTimeout(resolveResponse, 4));
+});
+const canceledRequest = requestGate.run(async () => {
+    requestStarts++;
+});
+canceledRequest.close("timeout");
+await assert.rejects(canceledRequest, /timeout/);
+await heldRequest;
+assert.equal(requestStarts, 1);
+
+const activeRequestGate = new RequestConcurrencyGate(1);
+let activeClosed = false;
+const activeCancellable = activeRequestGate.run(() => {
+    const request = new Promise(() => {});
+    request.close = () => { activeClosed = true; };
+    return request;
+});
+activeCancellable.close("timeout");
+await assert.rejects(activeCancellable, /timeout/);
+assert.equal(activeClosed, true);
+
+// A container event must not reuse an inspect that began before that event,
+// and a reconnect with the same UID must not reuse the old connection's
+// promise. Newer requests wait behind a running request for that ID.
+const keyedRuns = [];
+const keyedGate = new KeyedRequestGate(operation => operation());
+const firstConnection = {};
+const secondConnection = {};
+const keyedRequest = (con, generation, value) => keyedGate.request(
+    "owner-container",
+    { con, generation },
+    async () => {
+        keyedRuns.push(value);
+        await new Promise(resolveResponse => setTimeout(resolveResponse, 2));
+        return value;
+    },
+    metadata => metadata.con === con && metadata.generation === generation,
+);
+const preEvent = keyedRequest(firstConnection, 0, "pre-event");
+const eventRefresh = keyedRequest(firstConnection, 1, "event");
+assert.notEqual(preEvent, eventRefresh);
+assert.equal(await preEvent, "pre-event");
+assert.equal(await eventRefresh, "event");
+const reconnectRefresh = keyedRequest(secondConnection, 0, "reconnect");
+assert.notEqual(reconnectRefresh, eventRefresh);
+assert.equal(await reconnectRefresh, "reconnect");
+assert.deepEqual(keyedRuns, ["pre-event", "event", "reconnect"]);
+
+const capacityGate = new RequestConcurrencyGate(8);
+let activeRequests = 0;
+let maxActiveRequests = 0;
+const capacityRuns = Array.from({ length: 156 }, (_, index) => capacityGate.run(async () => {
+    activeRequests++;
+    maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+    await new Promise(resolveResponse => setTimeout(resolveResponse, index % 3));
+    activeRequests--;
+    return index;
+}));
+assert.deepEqual(await Promise.all(capacityRuns), Array.from({ length: 156 }, (_, index) => index));
+assert.ok(maxActiveRequests <= 8);
+
+let activeWorkers = 0;
+let maxWorkers = 0;
+const bounded = await mapWithConcurrency([1, 2, 3, 4, 5], async value => {
+    activeWorkers++;
+    maxWorkers = Math.max(maxWorkers, activeWorkers);
+    await new Promise(resolveResponse => setTimeout(resolveResponse, 2));
+    activeWorkers--;
+    return value * 2;
+}, 2);
+assert.deepEqual(bounded, [2, 4, 6, 8, 10]);
+assert.equal(maxWorkers, 2);
+await assert.rejects(withTimeout(new Promise(() => {}), 2, "fixture-timeout"), /fixture-timeout/);
+
+console.log("scheduler-refresh fixture: PASS");

--- a/test/time-display.test.mjs
+++ b/test/time-display.test.mjs
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+import assert from "node:assert/strict";
+
+const OriginalDateTimeFormat = Intl.DateTimeFormat;
+const OriginalRelativeTimeFormat = Intl.RelativeTimeFormat;
+let dateFormatterCount = 0;
+let relativeFormatterCount = 0;
+
+Intl.DateTimeFormat = function(...args) {
+    dateFormatterCount++;
+    return new OriginalDateTimeFormat(...args);
+};
+Intl.DateTimeFormat.prototype = OriginalDateTimeFormat.prototype;
+Intl.RelativeTimeFormat = function(...args) {
+    relativeFormatterCount++;
+    return new OriginalRelativeTimeFormat(...args);
+};
+Intl.RelativeTimeFormat.prototype = OriginalRelativeTimeFormat.prototype;
+
+try {
+    const { cachedDateTimeSeconds, cachedDistanceToNow } = await import("../src/time-display.js?test=cache");
+    const timestamp = Date.UTC(2026, 0, 2, 3, 4, 5);
+    const locales = ["en-US", "de-DE", "fr-FR", "es-ES", "it-IT", "ja-JP", "ko-KR", "pt-BR"];
+
+    assert.equal(cachedDateTimeSeconds(timestamp, "de-DE"),
+                 new OriginalDateTimeFormat("de-DE", { dateStyle: "medium", timeStyle: "medium" }).format(timestamp));
+    assert.equal(cachedDateTimeSeconds(timestamp, "de-DE"),
+                 new OriginalDateTimeFormat("de-DE", { dateStyle: "medium", timeStyle: "medium" }).format(timestamp));
+    assert.equal(dateFormatterCount, 1);
+
+    assert.equal(cachedDistanceToNow(Date.now() - 2 * 60 * 60 * 1000, "en-US", text => text),
+                 new OriginalRelativeTimeFormat("en-US", { numeric: "auto" }).format(-2, "hour"));
+    assert.equal(cachedDistanceToNow(Date.now() - 2 * 60 * 60 * 1000, "en-US", text => text),
+                 new OriginalRelativeTimeFormat("en-US", { numeric: "auto" }).format(-2, "hour"));
+    assert.equal(relativeFormatterCount, 1);
+
+    // The cache is bounded to eight locales and uses LRU order. Touch the
+    // first locale, add a ninth, then confirm the least recently used entry
+    // is reconstructed when it is requested again.
+    for (const locale of locales)
+        cachedDateTimeSeconds(timestamp, locale);
+    assert.equal(dateFormatterCount, 8);
+    cachedDateTimeSeconds(timestamp, locales[0]);
+    assert.equal(dateFormatterCount, 8);
+    cachedDateTimeSeconds(timestamp, "zh-CN");
+    assert.equal(dateFormatterCount, 9);
+    cachedDateTimeSeconds(timestamp, locales[1]);
+    assert.equal(dateFormatterCount, 10);
+
+    console.log("time-display fixtures: PASS");
+} finally {
+    Intl.DateTimeFormat = OriginalDateTimeFormat;
+    Intl.RelativeTimeFormat = OriginalRelativeTimeFormat;
+}


### PR DESCRIPTION
Makes container health rows preserve their real Podman owner context and render lifecycle-only dispositions explicitly. A session-user rootless row now carries its verified owner UID/context through inventory, inspect, event, and Quadlet paths; retired and infrastructure rows show their own labels instead of “Health unknown.”

Validation:
- `node --test test/health-state.test.mjs`
- `node --test test/scheduler-refresh.test.mjs`
- `git diff --check`

Source review independently cleared the scope and disposition fixes. This is source-only; live Cockpit/browser validation remains pending.
